### PR TITLE
build: add windows link workaround for CMake<3.16

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -6,6 +6,12 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+if(CMAKE_VERSION VERSION_LESS 3.16)
+  if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    link_directories(${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+  endif()
+endif()
+
 add_library(TSCBasic
   Await.swift
   ByteString.swift


### PR DESCRIPTION
The import libraries were emitted into the wrong directory in CMake
3.15.  This has been fixed since in CMake 3.16.  Provide a workaround
for the earlier releases.