### PR TITLE
build: add some workarounds for Windows, explicitly link dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15.1)
 
 project(SwiftTSC LANGUAGES C Swift)
- 
+
 set(SWIFT_VERSION 5)
 set(CMAKE_Swift_LANGUAGE_VERSION ${SWIFT_VERSION})
 if(CMAKE_VERSION VERSION_LESS 3.16)
@@ -9,12 +9,19 @@ if(CMAKE_VERSION VERSION_LESS 3.16)
 endif()
 
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
- 
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+if(CMAKE_VERSION VERSION_LESS 3.16 AND CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+else()
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+endif()
 
 option(BUILD_SHARED_LIBS "Build shared libraryes by default" YES)
+
+find_package(dispatch QUIET)
+find_package(Foundation QUIET)
 
 add_subdirectory(Sources)
 add_subdirectory(cmake/modules)

--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -6,6 +6,11 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+if(CMAKE_VERSION VERSION_LESS 3.16 AND CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(CMAKE_LINK_LIBRARY_FLAG "-l")
+  set(CMAKE_LINK_LIBRARY_SUFFIX "")
+endif()
+
 add_library(TSCBasic
   Await.swift
   ByteString.swift
@@ -51,6 +56,10 @@ add_library(TSCBasic
   Tuple.swift)
 target_link_libraries(TSCBasic PUBLIC
   TSCLibc)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(TSCBasic PUBLIC
+    Foundation)
+endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCBasic PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -6,6 +6,11 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
+if(CMAKE_VERSION VERSION_LESS 3.16 AND CMAKE_SYSTEM_NAME STREQUAL Windows)
+  set(CMAKE_LINK_LIBRARY_FLAG "-l")
+  set(CMAKE_LINK_LIBRARY_SUFFIX "")
+endif()
+
 add_library(TSCUtility
   ArgumentParser.swift
   ArgumentParserShellCompletion.swift


### PR DESCRIPTION
CMake prior to 3.16 did not correctly emit the import library into the requested
location.  Adjust the library emission path instead to workaround missing import
libraries.  Explicitly link against Foundation in TSCBasic which is needed on
non-Darwin targets.  Add the ability to build against an explicit build of
Foundation or the toolchain provided one.