### PR TITLE
Reduce Swift Tools Version to 4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:4.2
 
 /*
  This source file is part of the Swift.org open source project

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -687,8 +687,9 @@ public class InMemoryFileSystem: FileSystem {
     public func removeFileTree(_ path: AbsolutePath) throws {
         // Ignore root and get the parent node's content if its a directory.
         guard !path.isRoot,
-              let parent = try? getNode(path.parentDirectory),
-            case .directory(let contents) = parent.contents else {
+              let parentOpt = try? getNode(path.parentDirectory),
+              let parent = parentOpt,
+              case .directory(let contents) = parent.contents else {
             return
         }
         // Set it to nil to release the contents.


### PR DESCRIPTION
Reduce the minimum required Swift tools version for TSC to 4.2.