### PR TITLE
Import for SwiftPM #2523

### DIFF
--- a/Sources/TSCBasic/CollectionAlgorithms.swift
+++ b/Sources/TSCBasic/CollectionAlgorithms.swift
@@ -8,15 +8,16 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-extension Sequence where Iterator.Element: Hashable {
+extension Sequence where Element: Hashable {
 
     /// Finds duplicates in given sequence of Hashables.
     /// - Returns: duplicated elements in the invoking sequence.
-    public func spm_findDuplicates() -> [Iterator.Element] {
-        var unique: Set<Iterator.Element> = []
-        return filter {
-            !unique.insert($0).inserted
+    public func spm_findDuplicates() -> [Element] {
+        var counts: [Element: Int] = [:]
+        for element in self {
+            counts[element, default: 0] += 1
         }
+        return Array(counts.lazy.filter({ $0.value > 1 }).map({ $0.key }))
     }
 }
 

--- a/Sources/TSCBasic/DiagnosticsEngine.swift
+++ b/Sources/TSCBasic/DiagnosticsEngine.swift
@@ -101,23 +101,27 @@ public final class DiagnosticsEngine: CustomStringConvertible {
     /// The handler will be called on an unknown queue.
     private let handlers: [DiagnosticsHandler]
 
+    /// The default location to apply to location-less diagnostics.
+    public let defaultLocation: DiagnosticLocation
+
     /// Returns true if there is an error diagnostics in the engine.
     public var hasErrors: Bool {
         return diagnostics.contains(where: { $0.message.behavior == .error })
     }
 
-    public init(handlers: [DiagnosticsHandler] = []) {
+    public init(handlers: [DiagnosticsHandler] = [], defaultLocation: DiagnosticLocation = UnknownLocation.location) {
         self.handlers = handlers
+        self.defaultLocation = defaultLocation
     }
 
     public func emit(
         _ message: Diagnostic.Message,
-        location: DiagnosticLocation = UnknownLocation.location
+        location: DiagnosticLocation? = nil
     ) {
-        emit(Diagnostic(message: message, location: location))
+        emit(Diagnostic(message: message, location: location ?? defaultLocation))
     }
 
-    private func emit(_ diagnostic: Diagnostic) {
+    public func emit(_ diagnostic: Diagnostic) {
         queue.sync {
             _diagnostics.append(diagnostic)
         }

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -148,6 +148,11 @@ public protocol FileSystem: class {
     /// This follows the POSIX `getcwd(3)` semantics.
     var currentWorkingDirectory: AbsolutePath? { get }
 
+    /// Change the current working directory.
+    /// - Parameters:
+    ///   - path: The path to the directory to change the current working directory to.
+    func changeCurrentWorkingDirectory(to path: AbsolutePath) throws
+
     /// Get the home directory of current user
     var homeDirectory: AbsolutePath { get }
 
@@ -277,6 +282,16 @@ private class LocalFileSystem: FileSystem {
     var currentWorkingDirectory: AbsolutePath? {
         let cwdStr = FileManager.default.currentDirectoryPath
         return try? AbsolutePath(validating: cwdStr)
+    }
+
+    func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
+        guard isDirectory(path) else {
+            throw FileSystemError.notDirectory
+        }
+
+        guard FileManager.default.changeCurrentDirectoryPath(path.pathString) else {
+            throw FileSystemError.unknownOSError
+        }
     }
 
     var homeDirectory: AbsolutePath {
@@ -570,6 +585,10 @@ public class InMemoryFileSystem: FileSystem {
         return AbsolutePath("/")
     }
 
+    public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
+        fatalError("Unsupported")
+    }
+
     public var homeDirectory: AbsolutePath {
         // FIXME: Maybe we should allow setting this when creating the fs.
         return AbsolutePath("/home/user")
@@ -798,6 +817,10 @@ public class RerootedFileSystemView: FileSystem {
     /// Virtualized current working directory.
     public var currentWorkingDirectory: AbsolutePath? {
         return AbsolutePath("/")
+    }
+
+    public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
+        fatalError("Unsupported")
     }
 
     public var homeDirectory: AbsolutePath {

--- a/Sources/TSCTestSupport/DiagnosticsEngine.swift
+++ b/Sources/TSCTestSupport/DiagnosticsEngine.swift
@@ -13,36 +13,6 @@ import TSCUtility
 
 import XCTest
 
-public enum StringCheck: ExpressibleByStringLiteral {
-    case equal(String)
-    case contains(String)
-
-    func check(
-        input: String,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) {
-        switch self {
-        case .equal(let str):
-            XCTAssertEqual(str, input, file: file, line: line)
-        case .contains(let str):
-            XCTAssert(input.contains(str), "\(input) does not contain \(str)", file: file, line: line)
-        }
-    }
-
-    public init(stringLiteral value: String) {
-        self = .equal(value)
-    }
-
-    public init(extendedGraphemeClusterLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-
-    public init(unicodeScalarLiteral value: String) {
-        self.init(stringLiteral: value)
-    }
-}
-
 public func DiagnosticsEngineTester(
     _ engine: DiagnosticsEngine,
     ignoreNotes: Bool = false,
@@ -73,7 +43,7 @@ final public class DiagnosticsEngineResult {
     }
 
     public func check(
-        diagnostic: StringCheck,
+        diagnostic: StringPattern,
         checkContains: Bool = false,
         behavior: Diagnostic.Behavior,
         location: String? = nil,
@@ -87,7 +57,7 @@ final public class DiagnosticsEngineResult {
         let location = location ?? UnknownLocation.location.description
         let theDiagnostic = uncheckedDiagnostics.removeFirst()
 
-        diagnostic.check(input: theDiagnostic.description, file: file, line: line)
+        XCTAssertMatch(theDiagnostic.description, diagnostic, file: file, line: line)
         XCTAssertEqual(theDiagnostic.message.behavior, behavior, file: file, line: line)
         XCTAssertEqual(theDiagnostic.location.description, location, file: file, line: line)
     }

--- a/Tests/TSCBasicTests/CollectionAlgorithmsTests.swift
+++ b/Tests/TSCBasicTests/CollectionAlgorithmsTests.swift
@@ -14,7 +14,8 @@ import TSCBasic
 
 class CollectionAlgorithmsTests: XCTestCase {
     func testFindDuplicates() {
-        XCTAssertEqual([1, 2, 3, 2, 1].spm_findDuplicates(), [2, 1])
+        XCTAssertEqual(Set([1, 2, 3, 2, 1].spm_findDuplicates()), [1, 2])
+        XCTAssertEqual(Set([1, 2, 3, 2, 1, 2].spm_findDuplicates()), [1, 2])
         XCTAssertEqual(["foo", "bar"].spm_findDuplicates(), [])
         XCTAssertEqual(["foo", "Foo"].spm_findDuplicates(), [])
     }

--- a/Tests/TSCUtilityTests/DownloaderTests.swift
+++ b/Tests/TSCUtilityTests/DownloaderTests.swift
@@ -320,6 +320,10 @@ class FailingFileSystem: FileSystem {
         fatalError("unexpected call")
     }
 
+    func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
+        fatalError("unexpected call")
+    }
+
     func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool {
         fatalError("unexpected call")
     }


### PR DESCRIPTION
Contains:

* Fixed bug in `Sequence.spm_findDuplicates`,
* Added `FileSystem.changeCurrentWorkingDirectory`,
* Removed `TSCTestSupport.StringCheck` and use `TSCTestSupport.StringPattern` instead,
* Added `DiagnosticLocation.defaultLocation` to be able to configure the location used when non is provided,
* Added helper function to generate a new `DiagnosticsEngine` with a specific default location that emits back to a parent DiagnosticsEngine.