### PR TITLE
build: account for `FoundationNetworking`

### DIFF
--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -34,6 +34,10 @@ add_library(TSCUtility
   misc.swift)
 target_link_libraries(TSCUtility PUBLIC
   TSCBasic)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  target_link_libraries(TSCUtility PUBLIC
+    FoundationNetworking)
+endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCUtility PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})


### PR DESCRIPTION
When building TSC with a development build of Foundation and using
`-D Foundation_DIR=`, FoundationNetworking would not be found as it
would not be in the library search path.  Explicitly mark the dependency
which also enables better tracking.