### PR TITLE
build: workaround CMake 3.15 link failures on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SWIFT_VERSION 5)
 set(CMAKE_Swift_LANGUAGE_VERSION ${SWIFT_VERSION})
 if(CMAKE_VERSION VERSION_LESS 3.16)
     add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-swift-version$<SEMICOLON>${SWIFT_VERSION}>)
+    # Workaround for CMake 3.15 which doesn't link libraries properly on Windows
+    set(CMAKE_LINK_LIBRARY_FLAG "-l")
 endif()
 
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)


### PR DESCRIPTION
The libraries would be linked without the `-l` prefix on Windows which
works when using absolute paths and C/C++ but not Swift as the driver
will try to read the import library locally.