### PR TITLE
Basic: make `dirname` work better on Windows

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -55,6 +55,10 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(TSCBasic PUBLIC
     Foundation)
 endif()
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  target_link_libraries(TSCBasic PRIVATE
+    Pathcch)
+endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCBasic PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})


### PR DESCRIPTION
Use the Path APIs to compute the parent directory path on Windows.