### PR TITLE
Basic: handle root checking on Windows more properly

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -164,9 +164,21 @@ public struct AbsolutePath: Hashable {
         return isRoot ? self : AbsolutePath(_impl.dirname)
     }
 
+#if os(Windows)
+    internal var isDriveName: Bool {
+        return _impl.string.count == 2 &&
+            _impl.string.first!.isLetter && _impl.string.last! == ":"
+    }
+#endif
+
     /// True if the path is the root directory.
     public var isRoot: Bool {
+#if os(Windows)
+        return isDriveName ||
+            _impl.string.withCString(encodedAs: UTF16.self, PathCchIsRoot)
+#else
         return _impl.string.spm_only == "/"
+#endif
     }
 
     /// Returns the absolute path with the relative path applied.


### PR DESCRIPTION
Roots on Windows are more complicated.  The drive name is not considered
a root, but is a root for the Path API as you can not go any further.
It is however a name and not a path, therefore it is not a root path.
Use that alongwith `PathCchIsRootW` to classify the paths on Windows as
being a root or not.