### PR TITLE
Basic: replace `resolvingSymlinks` with Foundation

### DIFF
--- a/Sources/TSCLibc/libc.swift
+++ b/Sources/TSCLibc/libc.swift
@@ -20,14 +20,6 @@
 @_exported import TSCclibc
 
 #if os(Windows)
-// char *realpath(const char *path, char *resolved_path);
-public func realpath(
-    _ path: String,
-    _ resolvedPath: UnsafeMutablePointer<CChar>?
-) -> UnsafeMutablePointer<CChar>? {
-  fatalError("realpath is unimplemented")
-}
-
 // char *mkdtemp(char *template);
 public func mkdtemp(
     _ template: UnsafeMutablePointer<CChar>?


### PR DESCRIPTION
```
realpath() expands all symbolic links and resolves references to
/./, /../ and extra '/' characters in the null-terminated string
named by path to produce a canonicalized absolute pathname.
```

This is effectively the standardized path and resolution of symlinks
along it.