### PR TITLE
Add support for replacing files atomically

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -380,17 +380,9 @@ private class LocalFileSystem: FileSystem {
         if !atomically {
             return try writeFileContents(path, bytes: bytes)
         }
-        try withTemporaryFile(dir: path.parentDirectory, deleteOnClose: false) { temp in
-            do {
-                try writeFileContents(temp.path, bytes: bytes)
-                try FileManager.default.moveItem(atPath: temp.path.pathString, toPath: path.pathString)
-            } catch {
-                // Write or rename failed, delete the temporary file.
-                // Rethrow the original error, however, as that's the
-                // root cause of the failure.
-                _ = try? self.removeFileTree(temp.path)
-                throw error
-            }
+
+        try bytes.withData {
+            try $0.write(to: URL(fileURLWithPath: path.pathString), options: .atomic)
         }
     }
 

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -161,10 +161,16 @@ class FileSystemTests: XCTestCase {
             let read1 = try fs.readFileContents(filePath1)
             XCTAssertEqual(read1, byteString)
 
+            // Test overwriting file non-atomically
+            XCTAssertNoThrow(try fs.writeFileContents(filePath1, bytes: byteString, atomically: false))
+
             let filePath2 = tmpDirPath.appending(components: "test-data-2.txt")
             XCTAssertNoThrow(try fs.writeFileContents(filePath2, bytes: byteString, atomically: true))
             let read2 = try fs.readFileContents(filePath2)
             XCTAssertEqual(read2, byteString)
+
+            // Test overwriting file atomically
+            XCTAssertNoThrow(try fs.writeFileContents(filePath2, bytes: byteString, atomically: true))
 
             // Check overwrite of a file.
             try! fs.writeFileContents(filePath, bytes: "Hello, new world!")


### PR DESCRIPTION
Previously if you tried to write a file to a destination atomically it
would error because moveItem doesn't support overwriting.