### PR TITLE
Process: avoid including the executable URL twice on Windows

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -290,7 +290,7 @@ public final class Process: ObjectIdentifierProtocol {
 
     #if os(Windows)
         _process = Foundation.Process()
-        _process?.arguments = arguments
+        _process?.arguments = Array(arguments.dropFirst()) // Avoid including the executable URL twice.
         _process?.executableURL = URL(fileURLWithPath: arguments[0])
 
         if outputRedirection.redirectsOutput {


### PR DESCRIPTION
Without this change, the executable URL/path appears twice in the launched program's `argv`/`CommandLine.arguments`.