### PR TITLE
Update StringConversions for Windows shell escaping

### DIFF
--- a/Sources/TSCBasic/StringConversions.swift
+++ b/Sources/TSCBasic/StringConversions.swift
@@ -43,7 +43,7 @@ private func inShellWhitelist(_ codeUnit: UInt8) -> Bool {
 extension String {
 
     /// Creates a shell escaped string. If the string does not need escaping, returns the original string.
-    /// Otherwise escapes using single quotes. For example:
+    /// Otherwise escapes using single quotes on Unix and double quotes on Windows. For example:
     /// hello -> hello, hello$world -> 'hello$world', input A -> 'input A'
     ///
     /// - Returns: Shell escaped string.

--- a/Sources/TSCBasic/StringConversions.swift
+++ b/Sources/TSCBasic/StringConversions.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -15,6 +15,11 @@
 ///
 /// - Returns: True if shell escaping is not needed.
 private func inShellWhitelist(_ codeUnit: UInt8) -> Bool {
+  #if os(Windows)
+    if codeUnit == UInt8(ascii: "\\") {
+        return true
+    }
+  #endif
     switch codeUnit {
         case UInt8(ascii: "a")...UInt8(ascii: "z"),
              UInt8(ascii: "A")...UInt8(ascii: "Z"),
@@ -49,23 +54,30 @@ extension String {
             return self
         }
 
-        // If there are no single quotes then we can just wrap the string around single quotes.
-        guard let singleQuotePos = utf8[pos...].firstIndex(of: UInt8(ascii: "'")) else {
-            return "'" + self + "'"
+      #if os(Windows)
+        let quoteCharacter: Character = "\""
+        let escapedQuoteCharacter = "\"\""
+      #else
+        let quoteCharacter: Character = "'"
+        let escapedQuoteCharacter = "'\\''"
+      #endif
+        // If there are no quote characters then we can just wrap the string within the quotes.
+        guard let quotePos = utf8[pos...].firstIndex(of: quoteCharacter.asciiValue!) else {
+            return String(quoteCharacter) + self + String(quoteCharacter)
         }
 
         // Otherwise iterate and escape all the single quotes.
-        var newString = "'" + String(self[..<singleQuotePos])
+        var newString = String(quoteCharacter) + String(self[..<quotePos])
 
-        for char in self[singleQuotePos...] {
-            if char == "'" {
-                newString += "'\\''"
+        for char in self[quotePos...] {
+            if char == quoteCharacter {
+                newString += escapedQuoteCharacter
             } else {
                 newString += String(char)
             }
         }
 
-        newString += "'"
+        newString += String(quoteCharacter)
 
         return newString
     }


### PR DESCRIPTION
We don't need to escape backslashes on Windows, and multiple double-quotes seem to be standard (https://stackoverflow.com/a/15262019) for escaping other characters. Note that single-quote escaping does not work on Windows shells.