### PR TITLE
Fix search for the Swift compiler on Windows

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -397,6 +397,12 @@ private struct UNIXPath: Path {
         return name != "" && name != "." && name != ".." && !name.contains("/")
     }
 
+#if os(Windows)
+    static func isAbsolutePath(_ path: String) -> Bool {
+        return !path.withCString(encodedAs: UTF16.self, PathIsRelativeW)
+    }
+#endif
+
     var dirname: String {
 #if os(Windows)
         let dir = string.deletingLastPathComponent
@@ -421,7 +427,11 @@ private struct UNIXPath: Path {
     }
 
     var isAbsolute: Bool {
-        string.hasPrefix("/")
+#if os(Windows)
+        return UNIXPath.isAbsolutePath(string)
+#else
+        return string.hasPrefix("/")
+#endif
     }
 
     var basename: String {
@@ -608,7 +618,7 @@ private struct UNIXPath: Path {
         defer { fsr.deallocate() }
 
         let realpath = String(cString: fsr)
-        if realpath.withCString(encodedAs: UTF16.self, PathIsRelativeW) {
+        if !UNIXPath.isAbsolutePath(realpath) {
             throw PathValidationError.invalidAbsolutePath(path)
         }
         self.init(normalizingAbsolutePath: path)
@@ -630,7 +640,7 @@ private struct UNIXPath: Path {
         defer { fsr.deallocate() }
 
         let realpath: String = String(cString: fsr)
-        if !realpath.withCString(encodedAs: UTF16.self, PathIsRelativeW) {
+        if UNIXPath.isAbsolutePath(realpath) {
             throw PathValidationError.invalidRelativePath(path)
         }
         self.init(normalizingRelativePath: path)

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -48,16 +48,16 @@ public func getEnvSearchPaths(
     currentWorkingDirectory: AbsolutePath?
 ) -> [AbsolutePath] {
     // Compute search paths from PATH variable.
-    return (pathString ?? "").split(separator: ":").map(String.init).compactMap({ pathString in
-        // If this is an absolute path, we're done.
-        if pathString.first == "/" {
-            return AbsolutePath(pathString)
+#if os(Windows)
+    let pathSeparator: Character = ";"
+#else
+    let pathSeparator: Character = ":"
+#endif
+    return (pathString ?? "").split(separator: pathSeparator).map(String.init).compactMap({ pathString in
+        if let cwd = currentWorkingDirectory {
+            return AbsolutePath(pathString, relativeTo: cwd)
         }
-        // Otherwise convert it into absolute path relative to the working directory.
-        guard let cwd = currentWorkingDirectory else {
-            return nil
-        }
-        return AbsolutePath(pathString, relativeTo: cwd)
+        return try? AbsolutePath(validating: pathString)
     })
 }
 


### PR DESCRIPTION
Since the `Path.isAbsolute` implementation isn't valid for Windows paths, SwiftPM tries to find the Swift compiler in paths like this:
```
C:/Users/User/Documents/C:/Library/Developer/Toolchains/custom-development.xctoolchain/usr/bin/swiftc.exe
```
while the actual path is:
```
C:/Library/Developer/Toolchains/custom-development.xctoolchain/usr/bin/swiftc.exe
```

After this change SwiftPM can successfully find `swiftc.exe` on Windows, create a temporary directory for the artifacts and run the compiler (which currently results in an unrelated error).