### PR TITLE
Add support for posix_spawn_file_actions_addchdir_np on available Linux platforms

### DIFF
--- a/Sources/TSCclibc/CMakeLists.txt
+++ b/Sources/TSCclibc/CMakeLists.txt
@@ -7,7 +7,7 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(TSCclibc STATIC
-  libc.c)
+  libc.c process.c)
 target_include_directories(TSCclibc PUBLIC
   include)
 

--- a/Sources/TSCclibc/include/module.modulemap
+++ b/Sources/TSCclibc/include/module.modulemap
@@ -1,5 +1,6 @@
 module TSCclibc {
     header "TSCclibc.h"
     header "indexstore_functions.h"
+    header "process.h"
     export *
 }

--- a/Sources/TSCclibc/include/process.h
+++ b/Sources/TSCclibc/include/process.h
@@ -1,0 +1,12 @@
+#if defined(__linux__)
+
+#include <spawn.h>
+#include <stdbool.h>
+
+// Wrapper method for posix_spawn_file_actions_addchdir_np that fails on Linux versions that do not have this method available.
+int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restrict file_actions, const char *restrict path);
+
+// Runtime check for the availability of posix_spawn_file_actions_addchdir_np. Returns 0 if the method is available, -1 if not.
+bool SPM_posix_spawn_file_actions_addchdir_np_supported();
+
+#endif

--- a/Sources/TSCclibc/process.c
+++ b/Sources/TSCclibc/process.c
@@ -1,0 +1,23 @@
+#if defined(__linux__)
+
+#include <errno.h>
+
+#include "process.h"
+
+int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restrict file_actions, const char *restrict path) {
+#if __GLIBC_PREREQ(2, 29)
+    return posix_spawn_file_actions_addchdir_np(file_actions, path);
+#else
+    return ENOSYS;
+#endif
+}
+
+bool SPM_posix_spawn_file_actions_addchdir_np_supported() {
+#if __GLIBC_PREREQ(2, 29)
+    return true;
+#else
+    return false;
+#endif
+}
+
+#endif


### PR DESCRIPTION
This adds support for workingDirectory APIs for TSCBasic.Process on Linux if the system where the library is compiled with has libc6 >= 2.29. Uses the `__GLIBC_PREREQ(2, 29)` check as per @jakepetroules 's suggestion on #69 

Because there are no compile time checks for this version on Swift, I had to add runtime support for the failure mode where the `posix_spawn_file_actions_addchdir_np` function is not available.