### PR TITLE
Add support for redirecting stderr to stdout.

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -129,10 +129,20 @@ public final class Process: ObjectIdentifierProtocol {
     public enum OutputRedirection {
         /// Do not redirect the output
         case none
-        /// Collect stdout and stderr output and provide it back via ProcessResult object
-        case collect
-        /// Stream stdout and stderr via the corresponding closures
-        case stream(stdout: OutputClosure, stderr: OutputClosure)
+        /// Collect stdout and stderr output and provide it back via ProcessResult object. If redirectStderr is true,
+        /// stderr be redirected to stdout.
+        case collect(redirectStderr: Bool)
+        /// Stream stdout and stderr via the corresponding closures. If redirectStderr is true, stderr be redirected to
+        /// stdout.
+        case stream(stdout: OutputClosure, stderr: OutputClosure, redirectStderr: Bool)
+
+        /// Default collect OutputRedirection that defaults to not redirect stderr. Provided for API compatibility.
+        public static let collect: OutputRedirection = .collect(redirectStderr: false)
+
+        /// Default stream OutputRedirection that defaults to not redirect stderr. Provided for API compatibility.
+        public static func stream(stdout: @escaping OutputClosure, stderr: @escaping OutputClosure) -> Self {
+            return .stream(stdout: stdout, stderr: stderr, redirectStderr: false)
+        }
 
         public var redirectsOutput: Bool {
             switch self {
@@ -145,10 +155,21 @@ public final class Process: ObjectIdentifierProtocol {
 
         public var outputClosures: (stdoutClosure: OutputClosure, stderrClosure: OutputClosure)? {
             switch self {
-            case .stream(let stdoutClosure, let stderrClosure):
+            case let .stream(stdoutClosure, stderrClosure, _):
                 return (stdoutClosure: stdoutClosure, stderrClosure: stderrClosure)
             case .collect, .none:
                 return nil
+            }
+        }
+
+        public var redirectStderr: Bool {
+            switch self {
+            case let .collect(redirectStderr):
+                return redirectStderr
+            case let .stream(_, _, redirectStderr):
+                return redirectStderr
+            default:
+                return false
             }
         }
     }
@@ -433,19 +454,30 @@ public final class Process: ObjectIdentifierProtocol {
         // Open /dev/null as stdin.
         posix_spawn_file_actions_addopen(&fileActions, 0, devNull, O_RDONLY, 0)
 
-        var outputPipe: [Int32] = [0, 0]
-        var stderrPipe: [Int32] = [0, 0]
+        var outputPipe: [Int32] = [-1, -1]
+        var stderrPipe: [Int32] = [-1, -1]
         if outputRedirection.redirectsOutput {
-            // Open the pipes.
+            // Open the pipe.
             try open(pipe: &outputPipe)
-            try open(pipe: &stderrPipe)
-            // Open the write end of the pipe as stdout and stderr, if desired.
+
+            // Open the write end of the pipe.
             posix_spawn_file_actions_adddup2(&fileActions, outputPipe[1], 1)
-            posix_spawn_file_actions_adddup2(&fileActions, stderrPipe[1], 2)
+
             // Close the other ends of the pipe.
-            for pipe in [outputPipe, stderrPipe] {
-                posix_spawn_file_actions_addclose(&fileActions, pipe[0])
-                posix_spawn_file_actions_addclose(&fileActions, pipe[1])
+            posix_spawn_file_actions_addclose(&fileActions, outputPipe[0])
+            posix_spawn_file_actions_addclose(&fileActions, outputPipe[1])
+
+            if outputRedirection.redirectStderr {
+                // If merged was requested, send stderr to stdout.
+                posix_spawn_file_actions_adddup2(&fileActions, 1, 2)
+            } else {
+                // If no redirect was requested, open the pipe for stderr.
+                try open(pipe: &stderrPipe)
+                posix_spawn_file_actions_adddup2(&fileActions, stderrPipe[1], 2)
+
+                // Close the other ends of the pipe.
+                posix_spawn_file_actions_addclose(&fileActions, stderrPipe[0])
+                posix_spawn_file_actions_addclose(&fileActions, stderrPipe[1])
             }
         } else {
             posix_spawn_file_actions_adddup2(&fileActions, 1, 1)
@@ -475,17 +507,20 @@ public final class Process: ObjectIdentifierProtocol {
             thread.start()
             self.stdout.thread = thread
 
-            // Close the write end of the stderr pipe.
-            try close(fd: &stderrPipe[1])
+            // Only schedule a thread for stderr if no redirect was requested.
+            if !outputRedirection.redirectStderr {
+                // Close the write end of the stderr pipe.
+                try close(fd: &stderrPipe[1])
 
-            // Create a thread and start reading the stderr output on it.
-            thread = Thread { [weak self] in
-                if let readResult = self?.readOutput(onFD: stderrPipe[0], outputClosure: outputClosures?.stderrClosure) {
-                    self?.stderr.result = readResult
+                // Create a thread and start reading the stderr output on it.
+                thread = Thread { [weak self] in
+                    if let readResult = self?.readOutput(onFD: stderrPipe[0], outputClosure: outputClosures?.stderrClosure) {
+                        self?.stderr.result = readResult
+                    }
                 }
+                thread.start()
+                self.stderr.thread = thread
             }
-            thread.start()
-            self.stderr.thread = thread
         }
       #endif // POSIX implementation
     }

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -191,7 +191,7 @@ class ProcessTests: XCTestCase {
         do {
             let result = try Process.popen(args: script("simple-stdout-stderr"))
             XCTAssertEqual(try result.utf8Output(), "simple output\n")
-            XCTAssertEqual(try result.utf8stderrOutput(), "simple error")
+            XCTAssertEqual(try result.utf8stderrOutput(), "simple error\n")
         }
 
         // A long stdout and stderr output.
@@ -209,6 +209,60 @@ class ProcessTests: XCTestCase {
             XCTAssertEqual(try result.utf8Output(), String(repeating: "1", count: count))
             XCTAssertEqual(try result.utf8stderrOutput(), String(repeating: "2", count: count))
         }
+    }
+
+    func testStdoutStdErrRedirected() throws {
+        // A simple script to check that stdout and stderr are captured in the same location.
+        do {
+            let process = Process(args: script("simple-stdout-stderr"), outputRedirection: .collect(redirectStderr: true))
+            try process.launch()
+            let result = try process.waitUntilExit()
+            XCTAssertEqual(try result.utf8Output(), "simple error\nsimple output\n")
+            XCTAssertEqual(try result.utf8stderrOutput(), "")
+        }
+
+        // A long stdout and stderr output.
+        do {
+            let process = Process(args: script("long-stdout-stderr"), outputRedirection: .collect(redirectStderr: true))
+            try process.launch()
+            let result = try process.waitUntilExit()
+
+            let count = 16 * 1024
+            XCTAssertEqual(try result.utf8Output(), String(repeating: "12", count: count))
+            XCTAssertEqual(try result.utf8stderrOutput(), "")
+        }
+    }
+
+    func testStdoutStdErrStreaming() throws {
+        var stdout = [UInt8]()
+        var stderr = [UInt8]()
+        let process = Process(args: script("long-stdout-stderr"), outputRedirection: .stream(stdout: { stdoutBytes in
+            stdout += stdoutBytes
+        }, stderr: { stderrBytes in
+            stderr += stderrBytes
+        }))
+        try process.launch()
+        try process.waitUntilExit()
+
+        let count = 16 * 1024
+        XCTAssertEqual(String(bytes: stdout, encoding: .utf8), String(repeating: "1", count: count))
+        XCTAssertEqual(String(bytes: stderr, encoding: .utf8), String(repeating: "2", count: count))
+    }
+
+    func testStdoutStdErrStreamingRedirected() throws {
+        var stdout = [UInt8]()
+        var stderr = [UInt8]()
+        let process = Process(args: script("long-stdout-stderr"), outputRedirection: .stream(stdout: { stdoutBytes in
+            stdout += stdoutBytes
+        }, stderr: { stderrBytes in
+            stderr += stderrBytes
+        }, redirectStderr: true))
+        try process.launch()
+        try process.waitUntilExit()
+
+        let count = 16 * 1024
+        XCTAssertEqual(String(bytes: stdout, encoding: .utf8), String(repeating: "12", count: count))
+        XCTAssertEqual(stderr, [])
     }
 
     func testWorkingDirectory() throws {

--- a/Tests/TSCBasicTests/processInputs/simple-stdout-stderr
+++ b/Tests/TSCBasicTests/processInputs/simple-stdout-stderr
@@ -2,7 +2,7 @@
 
 import sys
 
-sys.stderr.write("simple error")
+sys.stderr.write("simple error\n")
 sys.stderr.flush()
 sys.stdout.write("simple output\n")
 sys.stdout.flush()


### PR DESCRIPTION
This is done by expanding the OutputRedirection enum to support a boolean. 

This does mean that the stream enum case will have a required closure that won't be used in the case redirectStderr is set, but shouldn't be much of an eye sore. Also adds some source compatibility methods to avoid breaking current users of the API.