### PR TITLE
Fix resolution of absolute pkg-config dependencies

### DIFF
--- a/Sources/TSCUtility/PkgConfig.swift
+++ b/Sources/TSCUtility/PkgConfig.swift
@@ -80,7 +80,13 @@ public struct PCFileFinder {
         // search paths, which is likely to be substantially more efficient if
         // we end up searching for a reasonably sized number of packages.
         for path in OrderedSet(customSearchPaths + PCFileFinder.pkgConfigPaths! + PCFileFinder.searchPaths) {
-            let pcFile = path.appending(component: name + ".pc")
+            let pcFile: AbsolutePath
+            // If a name has ".pc" suffix, it is interpreted as an absolute path to the package file
+            if name.hasSuffix(".pc") {
+                pcFile = AbsolutePath(name)
+            } else {
+                pcFile = path.appending(component: name + ".pc")
+            }
             if fileSystem.isFile(pcFile) {
                 return pcFile
             }


### PR DESCRIPTION
According to pkg-config [specification](https://dev.gentoo.org/~mgorny/pkg-config-spec.html) and [implementation](https://cgit.freedesktop.org/pkg-config/tree/pkg.c#n239), if a dependency name ends in `.pc`, the name should be treated as an absolute file path.

The issue can be reproduced by trying to wrap Gtk+3 into a system library package. `gobject-2.0.pc` in the pkg-config dependency chain has a private dependency as a file path:

```pc
prefix=/usr/local/Cellar/glib/2.64.3
libdir=${prefix}/lib
includedir=${prefix}/include

Name: GObject
Description: GLib Type, Object, Parameter and Signal Library
Version: 2.64.3
Requires: glib-2.0
Requires.private: /usr/local/opt/libffi/lib/pkgconfig/libffi.pc >=  3.0.0
Libs: -L${libdir} -lgobject-2.0
Libs.private: -lintl
Cflags:-I${includedir}
```

The issue started appearing in Swift 5.2 when SPM started parsing `Requires.private`. 

This PR aligns implementation in `PkgConfig.swift` with the official pkg-config implementation.