### PR TITLE
Improve FileSystemError by adding associated path

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -11,74 +11,87 @@
 import TSCLibc
 import Foundation
 
-public enum FileSystemError: Swift.Error {
-    /// Access to the path is denied.
-    ///
-    /// This is used when an operation cannot be completed because a component of
-    /// the path cannot be accessed.
-    ///
-    /// Used in situations that correspond to the POSIX EACCES error code.
-    case invalidAccess
+public struct FileSystemError: Swift.Error, Equatable {
+    public enum Kind: Equatable {
+        /// Access to the path is denied.
+        ///
+        /// This is used when an operation cannot be completed because a component of
+        /// the path cannot be accessed.
+        ///
+        /// Used in situations that correspond to the POSIX EACCES error code.
+        case invalidAccess
 
-    /// IO Error encoding
-    ///
-    /// This is used when an operation cannot be completed due to an otherwise
-    /// unspecified IO error.
-    case ioError
+        /// IO Error encoding
+        ///
+        /// This is used when an operation cannot be completed due to an otherwise
+        /// unspecified IO error.
+        case ioError(code: Int32)
 
-    /// Is a directory
-    ///
-    /// This is used when an operation cannot be completed because a component
-    /// of the path which was expected to be a file was not.
-    ///
-    /// Used in situations that correspond to the POSIX EISDIR error code.
-    case isDirectory
+        /// Is a directory
+        ///
+        /// This is used when an operation cannot be completed because a component
+        /// of the path which was expected to be a file was not.
+        ///
+        /// Used in situations that correspond to the POSIX EISDIR error code.
+        case isDirectory
 
-    /// No such path exists.
-    ///
-    /// This is used when a path specified does not exist, but it was expected
-    /// to.
-    ///
-    /// Used in situations that correspond to the POSIX ENOENT error code.
-    case noEntry
+        /// No such path exists.
+        ///
+        /// This is used when a path specified does not exist, but it was expected
+        /// to.
+        ///
+        /// Used in situations that correspond to the POSIX ENOENT error code.
+        case noEntry
 
-    /// Not a directory
-    ///
-    /// This is used when an operation cannot be completed because a component
-    /// of the path which was expected to be a directory was not.
-    ///
-    /// Used in situations that correspond to the POSIX ENOTDIR error code.
-    case notDirectory
+        /// Not a directory
+        ///
+        /// This is used when an operation cannot be completed because a component
+        /// of the path which was expected to be a directory was not.
+        ///
+        /// Used in situations that correspond to the POSIX ENOTDIR error code.
+        case notDirectory
 
-    /// Unsupported operation
-    ///
-    /// This is used when an operation is not supported by the concrete file
-    /// system implementation.
-    case unsupported
+        /// Unsupported operation
+        ///
+        /// This is used when an operation is not supported by the concrete file
+        /// system implementation.
+        case unsupported
 
-    /// An unspecific operating system error.
-    case unknownOSError
+        /// An unspecific operating system error at a given path.
+        case unknownOSError
 
-    /// File or folder already exists at destination.
-    ///
-    /// This is thrown when copying or moving a file or directory but the destination
-    /// path already contains a file or folder.
-    case alreadyExistsAtDestination
+        /// File or folder already exists at destination.
+        ///
+        /// This is thrown when copying or moving a file or directory but the destination
+        /// path already contains a file or folder.
+        case alreadyExistsAtDestination
+    }
+
+    /// The kind of the error being raised.
+    public let kind: Kind
+
+    /// The absolute path to the file associated with the error, if available.
+    public let path: AbsolutePath?
+
+    public init(_ kind: Kind, _ path: AbsolutePath? = nil) {
+        self.kind = kind
+        self.path = path
+    }
 }
 
 extension FileSystemError {
-    init(errno: Int32) {
+    init(errno: Int32, _ path: AbsolutePath) {
         switch errno {
         case TSCLibc.EACCES:
-            self = .invalidAccess
+            self.init(.invalidAccess, path)
         case TSCLibc.EISDIR:
-            self = .isDirectory
+            self.init(.isDirectory, path)
         case TSCLibc.ENOENT:
-            self = .noEntry
+            self.init(.noEntry, path)
         case TSCLibc.ENOTDIR:
-            self = .notDirectory
+            self.init(.notDirectory, path)
         default:
-            self = .unknownOSError
+            self.init(.unknownOSError, path)
         }
     }
 }
@@ -224,7 +237,7 @@ public extension FileSystem {
     // if `atomically` is `true`, otherwise fall back to whatever implementation already exists.
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString, atomically: Bool) throws {
         guard !atomically else {
-            throw FileSystemError.unsupported
+            throw FileSystemError(.unsupported, path)
         }
         try writeFileContents(path, bytes: bytes)
     }
@@ -238,7 +251,7 @@ public extension FileSystem {
     }
 
     func getFileInfo(_ path: AbsolutePath) throws -> FileInfo {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 }
 
@@ -286,11 +299,11 @@ private class LocalFileSystem: FileSystem {
 
     func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
         guard isDirectory(path) else {
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, path)
         }
 
         guard FileManager.default.changeCurrentDirectoryPath(path.pathString) else {
-            throw FileSystemError.unknownOSError
+            throw FileSystemError(.unknownOSError, path)
         }
     }
 
@@ -327,7 +340,7 @@ private class LocalFileSystem: FileSystem {
         // Open the file.
         let fp = fopen(path.pathString, "rb")
         if fp == nil {
-            throw FileSystemError(errno: errno)
+            throw FileSystemError(errno: errno, path)
         }
         defer { fclose(fp) }
 
@@ -338,11 +351,12 @@ private class LocalFileSystem: FileSystem {
             let n = fread(&tmpBuffer, 1, tmpBuffer.count, fp)
             if n < 0 {
                 if errno == EINTR { continue }
-                throw FileSystemError.ioError
+                throw FileSystemError(.ioError(code: errno), path)
             }
             if n == 0 {
-                if ferror(fp) != 0 {
-                    throw FileSystemError.ioError
+                let errno = ferror(fp)
+                if errno != 0 {
+                    throw FileSystemError(.ioError(code: errno), path)
                 }
                 break
             }
@@ -356,7 +370,7 @@ private class LocalFileSystem: FileSystem {
         // Open the file.
         let fp = fopen(path.pathString, "wb")
         if fp == nil {
-            throw FileSystemError(errno: errno)
+            throw FileSystemError(errno: errno, path)
         }
         defer { fclose(fp) }
 
@@ -366,10 +380,10 @@ private class LocalFileSystem: FileSystem {
             let n = fwrite(&contents, 1, contents.count, fp)
             if n < 0 {
                 if errno == EINTR { continue }
-                throw FileSystemError.ioError
+                throw FileSystemError(.ioError(code: errno), path)
             }
             if n != contents.count {
-                throw FileSystemError.ioError
+                throw FileSystemError(.unknownOSError, path)
             }
             break
         }
@@ -415,7 +429,7 @@ private class LocalFileSystem: FileSystem {
         guard let traverse = FileManager.default.enumerator(
                 at: URL(fileURLWithPath: path.pathString),
                 includingPropertiesForKeys: nil) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, path)
         }
 
         if !options.contains(.recursive) {
@@ -428,14 +442,16 @@ private class LocalFileSystem: FileSystem {
     }
 
     func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
-        guard exists(sourcePath) else { throw FileSystemError.noEntry }
-        guard !exists(destinationPath) else { throw FileSystemError.alreadyExistsAtDestination }
+        guard exists(sourcePath) else { throw FileSystemError(.noEntry, sourcePath) }
+        guard !exists(destinationPath)
+        else { throw FileSystemError(.alreadyExistsAtDestination, destinationPath) }
         try FileManager.default.copyItem(at: sourcePath.asURL, to: destinationPath.asURL)
     }
 
     func move(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
-        guard exists(sourcePath) else { throw FileSystemError.noEntry }
-        guard !exists(destinationPath) else { throw FileSystemError.alreadyExistsAtDestination }
+        guard exists(sourcePath) else { throw FileSystemError(.noEntry, sourcePath) }
+        guard !exists(destinationPath)
+        else { throw FileSystemError(.alreadyExistsAtDestination, destinationPath) }
         try FileManager.default.moveItem(at: sourcePath.asURL, to: destinationPath.asURL)
     }
 }
@@ -517,7 +533,7 @@ public class InMemoryFileSystem: FileSystem {
 
             // If we didn't find a directory, this is an error.
             guard case .directory(let contents) = parent.contents else {
-                throw FileSystemError.notDirectory
+                throw FileSystemError(.notDirectory, path.parentDirectory)
             }
 
             // Return the directory entry.
@@ -578,7 +594,7 @@ public class InMemoryFileSystem: FileSystem {
     }
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     public var homeDirectory: AbsolutePath {
@@ -588,10 +604,10 @@ public class InMemoryFileSystem: FileSystem {
 
     public func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {
         guard let node = try getNode(path) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, path)
         }
         guard case .directory(let contents) = node.contents else {
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, path)
         }
 
         // FIXME: Perhaps we should change the protocol to allow lazy behavior.
@@ -616,14 +632,14 @@ public class InMemoryFileSystem: FileSystem {
                 return try createDirectory(path, recursive: false)
             } else {
                 // Otherwise, we failed.
-                throw FileSystemError.noEntry
+                throw FileSystemError(.noEntry, parentPath)
             }
         }
 
         // Check that the parent is a directory.
         guard case .directory(let contents) = parent.contents else {
             // The parent isn't a directory, this is an error.
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, parentPath)
         }
 
         // Check if the node already exists.
@@ -631,7 +647,7 @@ public class InMemoryFileSystem: FileSystem {
             // Verify it is a directory.
             guard case .directory = node.contents else {
                 // The path itself isn't a directory, this is an error.
-                throw FileSystemError.notDirectory
+                throw FileSystemError(.notDirectory, path)
             }
 
             // We are done.
@@ -645,13 +661,13 @@ public class InMemoryFileSystem: FileSystem {
     public func readFileContents(_ path: AbsolutePath) throws -> ByteString {
         // Get the node.
         guard let node = try getNode(path) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, path)
         }
 
         // Check that the node is a file.
         guard case .file(let contents) = node.contents else {
             // The path is a directory, this is an error.
-            throw FileSystemError.isDirectory
+            throw FileSystemError(.isDirectory, path)
         }
 
         // Return the file contents.
@@ -662,18 +678,18 @@ public class InMemoryFileSystem: FileSystem {
         // It is an error if this is the root node.
         let parentPath = path.parentDirectory
         guard path != parentPath else {
-            throw FileSystemError.isDirectory
+            throw FileSystemError(.isDirectory, path)
         }
 
         // Get the parent node.
         guard let parent = try getNode(parentPath) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, parentPath)
         }
 
         // Check that the parent is a directory.
         guard case .directory(let contents) = parent.contents else {
             // The parent isn't a directory, this is an error.
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, parentPath)
         }
 
         // Check if the node exists.
@@ -681,7 +697,7 @@ public class InMemoryFileSystem: FileSystem {
             // Verify it is a file.
             guard case .file = node.contents else {
                 // The path is a directory, this is an error.
-                throw FileSystemError.isDirectory
+                throw FileSystemError(.isDirectory, path)
             }
         }
 
@@ -713,21 +729,21 @@ public class InMemoryFileSystem: FileSystem {
     public func copy(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
         // Get the source node.
         guard let source = try getNode(sourcePath) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, sourcePath)
         }
 
         // Create directory to destination parent.
         guard let destinationParent = try getNode(destinationPath.parentDirectory) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, destinationPath.parentDirectory)
         }
 
         // Check that the parent is a directory.
         guard case .directory(let contents) = destinationParent.contents else {
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, destinationPath.parentDirectory)
         }
 
         guard contents.entries[destinationPath.basename] == nil else {
-            throw FileSystemError.alreadyExistsAtDestination
+            throw FileSystemError(.alreadyExistsAtDestination, destinationPath)
         }
 
         contents.entries[destinationPath.basename] = source
@@ -736,12 +752,12 @@ public class InMemoryFileSystem: FileSystem {
     public func move(from sourcePath: AbsolutePath, to destinationPath: AbsolutePath) throws {
         // Get the source parent node.
         guard let sourceParent = try getNode(sourcePath.parentDirectory) else {
-            throw FileSystemError.noEntry
+            throw FileSystemError(.noEntry, sourcePath)
         }
 
         // Check that the parent is a directory.
         guard case .directory(let contents) = sourceParent.contents else {
-            throw FileSystemError.notDirectory
+            throw FileSystemError(.notDirectory, sourcePath.parentDirectory)
         }
 
         try copy(from: sourcePath, to: destinationPath)
@@ -812,7 +828,7 @@ public class RerootedFileSystemView: FileSystem {
     }
 
     public func changeCurrentWorkingDirectory(to path: AbsolutePath) throws {
-        throw FileSystemError.unsupported
+        throw FileSystemError(.unsupported, path)
     }
 
     public var homeDirectory: AbsolutePath {

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -88,7 +88,7 @@ public final class FileLock {
         if fileDescriptor == nil {
             let fd = TSCLibc.open(lockFile.pathString, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
             if fd == -1 {
-                throw FileSystemError(errno: errno)
+                throw FileSystemError(errno: errno, lockFile)
             }
             self.fileDescriptor = fd
         }

--- a/Sources/TSCUtility/Archiver.swift
+++ b/Sources/TSCUtility/Archiver.swift
@@ -51,12 +51,12 @@ public struct ZipArchiver: Archiver {
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         guard fileSystem.exists(archivePath) else {
-            completion(.failure(FileSystemError.noEntry))
+            completion(.failure(FileSystemError(.noEntry, archivePath)))
             return
         }
 
         guard fileSystem.isDirectory(destinationPath) else {
-            completion(.failure(FileSystemError.notDirectory))
+            completion(.failure(FileSystemError(.notDirectory, destinationPath)))
             return
         }
 

--- a/Tests/TSCUtilityTests/ArchiverTests.swift
+++ b/Tests/TSCUtilityTests/ArchiverTests.swift
@@ -40,8 +40,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem()
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.noEntry)
+        let archive = AbsolutePath("/archive.zip")
+        archiver.extract(from: archive, to: AbsolutePath("/"), completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.noEntry, archive))
             expectation.fulfill()
         })
 
@@ -53,8 +54,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
+        let destination = AbsolutePath("/destination")
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
 
@@ -66,8 +68,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip", "/destination")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
+        let destination = AbsolutePath("/destination")
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
 


### PR DESCRIPTION
I've recently stumbled upon this error when running `swift build`:

```
error: noEntry
```

This is the exact and only output of this `swift build` invocation. Unfortunately, I think it's impossible to diagnose without an attached debugger. It's also hard to pinpoint where exactly the error comes from in the source code, since `FileSystemError.noEntry` is thrown from multiple places.

In my opinion, for an error value to be helpful it should have associated information attached to it. In this case, it would make sense for almost all cases of `FileSystemError` to have an associated `AbsolutePath` value.

`FileSystemError` now also has to be explicitly declared `Equatable` to make the tests compile, but previously it was `Equatable` anyway, although implicitly by virtue of being an enum with no associated values.