### PR TITLE
Revert "Improve FileSystemError by adding associated path"

### DIFF
--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -88,7 +88,7 @@ public final class FileLock {
         if fileDescriptor == nil {
             let fd = TSCLibc.open(lockFile.pathString, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
             if fd == -1 {
-                throw FileSystemError(errno: errno, lockFile)
+                throw FileSystemError(errno: errno)
             }
             self.fileDescriptor = fd
         }

--- a/Sources/TSCUtility/Archiver.swift
+++ b/Sources/TSCUtility/Archiver.swift
@@ -51,12 +51,12 @@ public struct ZipArchiver: Archiver {
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         guard fileSystem.exists(archivePath) else {
-            completion(.failure(FileSystemError(.noEntry, archivePath)))
+            completion(.failure(FileSystemError.noEntry))
             return
         }
 
         guard fileSystem.isDirectory(destinationPath) else {
-            completion(.failure(FileSystemError(.notDirectory, destinationPath)))
+            completion(.failure(FileSystemError.notDirectory))
             return
         }
 

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -177,45 +177,42 @@ class FileSystemTests: XCTestCase {
             XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
             // Check read/write of a directory.
-            XCTAssertThrows(FileSystemError(.ioError(code: TSCLibc.EPERM), filePath.parentDirectory)) {
+            XCTAssertThrows(FileSystemError.ioError) {
                 _ = try fs.readFileContents(filePath.parentDirectory)
             }
-            XCTAssertThrows(FileSystemError(.isDirectory, filePath.parentDirectory)) {
+            XCTAssertThrows(FileSystemError.isDirectory) {
                 try fs.writeFileContents(filePath.parentDirectory, bytes: [])
             }
             XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
             // Check read/write against root.
-            #if os(Android)
-            let root = AbsolutePath("/system/")
-            #else
-            let root = AbsolutePath("/")
-            #endif
-            XCTAssertThrows(FileSystemError(.ioError(code: TSCLibc.EPERM), root)) {
-                _ = try fs.readFileContents(root)
-
+            XCTAssertThrows(FileSystemError.ioError) {
+              #if os(Android)
+                _ = try fs.readFileContents(AbsolutePath("/system/"))
+              #else
+                _ = try fs.readFileContents(AbsolutePath("/"))
+              #endif
             }
-            XCTAssertThrows(FileSystemError(.isDirectory, root)) {
-                try fs.writeFileContents(root, bytes: [])
+            XCTAssertThrows(FileSystemError.isDirectory) {
+                try fs.writeFileContents(AbsolutePath("/"), bytes: [])
             }
             XCTAssert(fs.exists(filePath))
 
             // Check read/write into a non-directory.
-            let notDirectoryPath = filePath.appending(component: "not-possible")
-            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath)) {
-                _ = try fs.readFileContents(notDirectoryPath)
+            XCTAssertThrows(FileSystemError.notDirectory) {
+                _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
             }
-            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath)) {
+            XCTAssertThrows(FileSystemError.notDirectory) {
                 try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
             }
             XCTAssert(fs.exists(filePath))
 
             // Check read/write into a missing directory.
             let missingDir = tmpDirPath.appending(components: "does", "not", "exist")
-            XCTAssertThrows(FileSystemError(.noEntry, missingDir)) {
+            XCTAssertThrows(FileSystemError.noEntry) {
                 _ = try fs.readFileContents(missingDir)
             }
-            XCTAssertThrows(FileSystemError(.noEntry, missingDir)) {
+            XCTAssertThrows(FileSystemError.noEntry) {
                 try fs.writeFileContents(missingDir, bytes: [])
             }
             XCTAssert(!fs.exists(missingDir))
@@ -237,10 +234,10 @@ class FileSystemTests: XCTestCase {
 
             // Copy with no source
 
-            XCTAssertThrows(FileSystemError(.noEntry, source)) {
+            XCTAssertThrows(FileSystemError.noEntry) {
                 try fs.copy(from: source, to: destination)
             }
-            XCTAssertThrows(FileSystemError(.noEntry, source)) {
+            XCTAssertThrows(FileSystemError.noEntry) {
                 try fs.move(from: source, to: destination)
             }
 
@@ -249,10 +246,10 @@ class FileSystemTests: XCTestCase {
             try fs.writeFileContents(source, bytes: "source1")
             try fs.writeFileContents(destination, bytes: "destination")
 
-            XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
+            XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
                 try fs.copy(from: source, to: destination)
             }
-            XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
+            XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
                 try fs.move(from: source, to: destination)
             }
 
@@ -308,23 +305,22 @@ class FileSystemTests: XCTestCase {
 
     func testInMemoryBasics() throws {
         let fs = InMemoryFileSystem()
-        let doesNotExist = AbsolutePath("/does-not-exist")
 
         // exists()
-        XCTAssert(!fs.exists(doesNotExist))
+        XCTAssert(!fs.exists(AbsolutePath("/does-not-exist")))
 
         // isDirectory()
-        XCTAssert(!fs.isDirectory(doesNotExist))
+        XCTAssert(!fs.isDirectory(AbsolutePath("/does-not-exist")))
 
         // isFile()
-        XCTAssert(!fs.isFile(doesNotExist))
+        XCTAssert(!fs.isFile(AbsolutePath("/does-not-exist")))
 
         // isSymlink()
-        XCTAssert(!fs.isSymlink(doesNotExist))
+        XCTAssert(!fs.isSymlink(AbsolutePath("/does-not-exist")))
 
         // getDirectoryContents()
-        XCTAssertThrows(FileSystemError(.noEntry, doesNotExist)) {
-            _ = try fs.getDirectoryContents(doesNotExist)
+        XCTAssertThrows(FileSystemError.noEntry) {
+            _ = try fs.getDirectoryContents(AbsolutePath("/does-not-exist"))
         }
 
         // createDirectory()
@@ -358,10 +354,9 @@ class FileSystemTests: XCTestCase {
         XCTAssert(fs.isDirectory(subsubdir))
 
         // Check non-recursive failing subdir case.
-        let veryNewDir = AbsolutePath("/very-new-dir")
-        let newsubdir = veryNewDir.appending(component: "subdir")
+        let newsubdir = AbsolutePath("/very-new-dir/subdir")
         XCTAssert(!fs.isDirectory(newsubdir))
-        XCTAssertThrows(FileSystemError(.noEntry, veryNewDir)) {
+        XCTAssertThrows(FileSystemError.noEntry) {
             try fs.createDirectory(newsubdir, recursive: false)
         }
         XCTAssert(!fs.isDirectory(newsubdir))
@@ -370,10 +365,10 @@ class FileSystemTests: XCTestCase {
         let filePath = AbsolutePath("/mach_kernel")
         try! fs.writeFileContents(filePath, bytes: [0xCD, 0x0D])
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
-        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
+        XCTAssertThrows(FileSystemError.notDirectory) {
             try fs.createDirectory(filePath, recursive: true)
         }
-        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
+        XCTAssertThrows(FileSystemError.notDirectory) {
             try fs.createDirectory(filePath.appending(component: "not-possible"), recursive: true)
         }
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
@@ -399,45 +394,42 @@ class FileSystemTests: XCTestCase {
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
         // Check read/write of a directory.
-        XCTAssertThrows(FileSystemError(.isDirectory, filePath.parentDirectory)) {
+        XCTAssertThrows(FileSystemError.isDirectory) {
             _ = try fs.readFileContents(filePath.parentDirectory)
         }
-        XCTAssertThrows(FileSystemError(.isDirectory, filePath.parentDirectory)) {
+        XCTAssertThrows(FileSystemError.isDirectory) {
             try fs.writeFileContents(filePath.parentDirectory, bytes: [])
         }
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
         // Check read/write against root.
-        let root = AbsolutePath("/")
-        XCTAssertThrows(FileSystemError(.isDirectory, root)) {
-            _ = try fs.readFileContents(root)
+        XCTAssertThrows(FileSystemError.isDirectory) {
+            _ = try fs.readFileContents(AbsolutePath("/"))
         }
-        XCTAssertThrows(FileSystemError(.isDirectory, root)) {
-            try fs.writeFileContents(root, bytes: [])
+        XCTAssertThrows(FileSystemError.isDirectory) {
+            try fs.writeFileContents(AbsolutePath("/"), bytes: [])
         }
         XCTAssert(fs.exists(filePath))
         XCTAssertTrue(fs.isFile(filePath))
 
         // Check read/write into a non-directory.
-        let notDirectory = filePath.appending(component: "not-possible")
-        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
-            _ = try fs.readFileContents(notDirectory)
+        XCTAssertThrows(FileSystemError.notDirectory) {
+            _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
         }
-        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
-            try fs.writeFileContents(notDirectory, bytes: [])
+        XCTAssertThrows(FileSystemError.notDirectory) {
+            try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
         }
         XCTAssert(fs.exists(filePath))
 
         // Check read/write into a missing directory.
-        let missingParent = AbsolutePath("/does/not")
-        let missingFile = missingParent.appending(component: "exist")
-        XCTAssertThrows(FileSystemError(.noEntry, missingFile)) {
-            _ = try fs.readFileContents(missingFile)
+        let missingDir = AbsolutePath("/does/not/exist")
+        XCTAssertThrows(FileSystemError.noEntry) {
+            _ = try fs.readFileContents(missingDir)
         }
-        XCTAssertThrows(FileSystemError(.noEntry, missingParent)) {
-            try fs.writeFileContents(missingFile, bytes: [])
+        XCTAssertThrows(FileSystemError.noEntry) {
+            try fs.writeFileContents(missingDir, bytes: [])
         }
-        XCTAssert(!fs.exists(missingFile))
+        XCTAssert(!fs.exists(missingDir))
     }
 
     func testInMemoryFsCopy() throws {
@@ -469,10 +461,10 @@ class FileSystemTests: XCTestCase {
 
         // Copy with no source
 
-        XCTAssertThrows(FileSystemError(.noEntry, source)) {
+        XCTAssertThrows(FileSystemError.noEntry) {
             try fs.copy(from: source, to: destination)
         }
-        XCTAssertThrows(FileSystemError(.noEntry, source)) {
+        XCTAssertThrows(FileSystemError.noEntry) {
             try fs.move(from: source, to: destination)
         }
 
@@ -481,10 +473,10 @@ class FileSystemTests: XCTestCase {
         try fs.writeFileContents(source, bytes: "source1")
         try fs.writeFileContents(destination, bytes: "destination")
 
-        XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
+        XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
             try fs.copy(from: source, to: destination)
         }
-        XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
+        XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
             try fs.move(from: source, to: destination)
         }
 
@@ -575,13 +567,13 @@ class FileSystemTests: XCTestCase {
 
             // Set foo to unwritable.
             try fs.chmod(.userUnWritable, path: foo)
-            XCTAssertThrows(FileSystemError(.invalidAccess, foo)) {
+            XCTAssertThrows(FileSystemError.invalidAccess) {
                 try fs.writeFileContents(foo, bytes: "test")
             }
 
             // Set the directory as unwritable.
             try fs.chmod(.userUnWritable, path: dir, options: [.recursive, .onlyFiles])
-            XCTAssertThrows(FileSystemError(.invalidAccess, bar)) {
+            XCTAssertThrows(FileSystemError.invalidAccess) {
                 try fs.writeFileContents(bar, bytes: "test")
             }
 
@@ -593,9 +585,8 @@ class FileSystemTests: XCTestCase {
 
             // But not anymore.
             try fs.chmod(.userUnWritable, path: dir, options: [.recursive])
-            let newFile = dir.appending(component: "new2")
-            XCTAssertThrows(FileSystemError(.invalidAccess, newFile)) {
-                try fs.writeFileContents(newFile, bytes: "")
+            XCTAssertThrows(FileSystemError.invalidAccess) {
+                try fs.writeFileContents(dir.appending(component: "new2"), bytes: "")
             }
 
             try? fs.removeFileTree(bar)

--- a/Tests/TSCUtilityTests/ArchiverTests.swift
+++ b/Tests/TSCUtilityTests/ArchiverTests.swift
@@ -40,9 +40,8 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem()
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let archive = AbsolutePath("/archive.zip")
-        archiver.extract(from: archive, to: AbsolutePath("/"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError(.noEntry, archive))
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/"), completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError.noEntry)
             expectation.fulfill()
         })
 
@@ -54,9 +53,8 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let destination = AbsolutePath("/destination")
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
             expectation.fulfill()
         })
 
@@ -68,9 +66,8 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip", "/destination")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let destination = AbsolutePath("/destination")
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
             expectation.fulfill()
         })
 


### PR DESCRIPTION
This reverts #78, which breaks the public API for both SwiftPM and SourceKit-LSP.