### PR TITLE
Fix Absolute Path Dependencies in `.pc` Files

### DIFF
--- a/Tests/TSCUtilityTests/pkgconfigInputs/gobject-2.0.pc
+++ b/Tests/TSCUtilityTests/pkgconfigInputs/gobject-2.0.pc
@@ -1,0 +1,12 @@
+prefix=/usr/local/Cellar/glib/2.64.3
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: GObject
+Description: GLib Type, Object, Parameter and Signal Library
+Version: 2.64.3
+# Requires: glib-2.0
+Requires.private: /usr/local/opt/libffi/lib/pkgconfig/libffi.pc >=  3.0.0
+Libs: -L${libdir} -lgobject-2.0
+Libs.private: -lintl
+Cflags:-I${includedir}

--- a/Tests/TSCUtilityTests/pkgconfigInputs/libffi.pc
+++ b/Tests/TSCUtilityTests/pkgconfigInputs/libffi.pc
@@ -1,0 +1,11 @@
+prefix=/usr/local/Cellar/libffi/3.3
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+toolexeclibdir=${libdir}
+includedir=${prefix}/include
+
+Name: libffi
+Description: Library supporting Foreign Function Interfaces
+Version: 3.3
+Libs: -L${toolexeclibdir} -lffi
+Cflags: -I${includedir}


### PR DESCRIPTION
This pulls in the changes from https://github.com/apple/swift-package-manager/pull/2779.