### PR TITLE
Add support for Netrc for Downloader

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ import PackageDescription
 
 let package = Package(
     name: "swift-tools-support-core",
+    platforms: [.macOS(.v10_13)],
     products: [
         .library(
             name: "SwiftToolsSupport",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,6 @@ import PackageDescription
 
 let package = Package(
     name: "swift-tools-support-core",
-    platforms: [.macOS(.v10_13)],
     products: [
         .library(
             name: "SwiftToolsSupport",

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(TSCUtility
   IndexStore.swift
   InterruptHandler.swift
   JSONMessageStreamingParser.swift
+  misc.swift
+  Netrc.swift
   OSLog.swift
   PersistenceCache.swift
   PkgConfig.swift

--- a/Sources/TSCUtility/Downloader.swift
+++ b/Sources/TSCUtility/Downloader.swift
@@ -115,20 +115,20 @@ public final class FoundationDownloader: NSObject, Downloader {
         progress: @escaping Downloader.Progress,
         completion: @escaping Downloader.Completion
     ) {
-        queue.addOperation { [self] in
+        queue.addOperation {
             var request = URLRequest(url: url)
             
             if let authorization = authorizationProvider?.authorization(for: url) {
                 request.addValue(authorization, forHTTPHeaderField: "Authorization")
             }
             
-            let task = session.downloadTask(with: request)
+            let task = self.session.downloadTask(with: request)
             let download = Download(
                 task: task,
                 destination: destination,
                 progress: progress,
                 completion: completion)
-            downloads[task.taskIdentifier] = download
+            self.downloads[task.taskIdentifier] = download
             task.resume()
         }
     }

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -7,9 +7,13 @@ public struct Netrc {
     /// Representation of `machine` connection settings & `default` connection settings.  If `default` connection settings present, they will be last element.
     public let machines: [Machine]
     
-    init(machines: [Machine]) {
+    private init(machines: [Machine]) {
         self.machines = machines
     }
+    
+    /// Testing API.  Not for productive use.
+    /// See:  [Remove @testable from codebase](https://github.com/apple/swift-package-manager/commit/b6349d516d2f9b2f26ddae9de2c594ede24af7d6)
+    public static var _mock: Netrc? = nil
     
     /// Basic authorization header string
     /// - Parameter url: URI of network resource to be accessed
@@ -26,6 +30,9 @@ public struct Netrc {
     /// - Parameter fileURL: Location of netrc file, defaults to `~/.netrc`
     /// - Returns: `Netrc` container with parsed connection settings, or error
     public static func load(from fileURL: Foundation.URL = Foundation.URL(fileURLWithPath: "\(NSHomeDirectory())/.netrc")) -> Result<Netrc, Netrc.Error> {
+        
+        guard _mock == nil else { return .success(_mock!) }
+        
         guard FileManager.default.fileExists(atPath: fileURL.path) else { return .failure(.fileNotFound(fileURL)) }
         guard FileManager.default.isReadableFile(atPath: fileURL.path),
             let fileContents = try? String(contentsOf: fileURL, encoding: .utf8) else { return .failure(.unreadableFile(fileURL)) }

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -31,7 +31,6 @@ public struct Netrc {
         case fileNotFound(Foundation.URL)
         case unreadableFile(Foundation.URL)
         case machineNotFound
-        case missingToken(String)
         case invalidDefaultMachinePosition
     }
     
@@ -105,6 +104,11 @@ public struct Netrc {
 fileprivate enum RegexUtil {
     static let loginPassword: [String] = ["login", "password"]
     static let passwordLogin: [String] = ["password", "login"]
+    
+    
+    /// netrc parser logic
+    // 1. matches string `machine` or `default`, followed by `login <value> `password <value>` or `password <value> login value>`
+    
     static let pattern: String = #"(?:(?:(\#(namedTrailingCapture("machine"))|\#(namedMatch("default"))))(?:\#(namedTrailingCapture(loginPassword, prefix: "lp"))|\#(namedTrailingCapture(passwordLogin, prefix: "pl"))))"#
     static let commentsPattern: String = "\\#[\\s\\S]*?.*$"
     

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+public struct NetrcMachine {
+    public let name: String
+    public let login: String
+    public let password: String
+}
+
+public struct Netrc {
+	
+    public enum NetrcError: Error {
+        case fileNotFound(Foundation.URL)
+        case unreadableFile(Foundation.URL)
+		case machineNotFound
+		case missingToken(String)
+		case missingValueForToken(String)
+	}
+	
+	public let machines: [NetrcMachine]
+	
+	init(machines: [NetrcMachine]) {
+		self.machines = machines
+	}
+	
+    public func authorization(for url: Foundation.URL) -> String? {
+		guard let index = machines.firstIndex(where: { $0.name == url.host }) else { return nil }
+		let machine = machines[index]
+		let authString = "\(machine.login):\(machine.password)"
+		guard let authData = authString.data(using: .utf8) else { return nil }
+		return "Basic \(authData.base64EncodedString())"
+	}
+	
+    public static func load(from fileURL: Foundation.URL = Foundation.URL(fileURLWithPath: "\(NSHomeDirectory())/.netrc")) -> Result<Netrc, NetrcError> {
+		guard FileManager.default.fileExists(atPath: fileURL.path) else { return .failure(NetrcError.fileNotFound(fileURL)) }
+		guard FileManager.default.isReadableFile(atPath: fileURL.path),
+            let fileContents = try? String(contentsOf: fileURL, encoding: .utf8) else { return .failure(NetrcError.unreadableFile(fileURL)) }
+		
+        return Netrc.from(fileContents)
+	}
+	
+    public static func from(_ content: String) -> Result<Netrc, NetrcError> {
+		let trimmedCommentsContent = trimComments(from: content)
+		let tokens = trimmedCommentsContent
+			.trimmingCharacters(in: .whitespacesAndNewlines)
+			.components(separatedBy: .whitespacesAndNewlines)
+			.filter({ $0 != "" })
+		
+		var machines: [NetrcMachine] = []
+		
+		let machineTokens = tokens.split { $0 == "machine" }
+		guard tokens.contains("machine"), machineTokens.count > 0 else { return .failure(NetrcError.machineNotFound) }
+		
+		for machine in machineTokens {
+			let values = Array(machine)
+			guard let name = values.first else { continue }
+			guard let login = values["login"] else { return .failure(NetrcError.missingValueForToken("login")) }
+			guard let password = values["password"] else { return .failure(NetrcError.missingValueForToken("password")) }
+			machines.append(NetrcMachine(name: name, login: login, password: password))
+		}
+		
+		guard machines.count > 0 else { return .failure(NetrcError.machineNotFound) }
+		return .success(Netrc(machines: machines))
+	}
+	
+	private static func trimComments(from text: String) -> String {
+		let regex = try! NSRegularExpression(pattern: "\\#[\\s\\S]*?.*$", options: .anchorsMatchLines)
+		let nsString = text as NSString
+		let range = NSRange(location: 0, length: nsString.length)
+		let matches = regex.matches(in: text, range: range)
+		var trimmedCommentsText = text
+		matches.forEach {
+			trimmedCommentsText = trimmedCommentsText
+				.replacingOccurrences(of: nsString.substring(with: $0.range), with: "")
+		}
+		return trimmedCommentsText
+	}
+}
+
+fileprivate extension Array where Element == String {
+	subscript(_ token: String) -> String? {
+		guard let tokenIndex = firstIndex(of: token),
+			count > tokenIndex,
+			!["machine", "login", "password"].contains(self[tokenIndex + 1]) else {
+				return nil
+		}
+		return self[tokenIndex + 1]
+	}
+}

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -1,8 +1,5 @@
 import Foundation
 import TSCBasic
-
-
-
 /// Supplies `Authorization` header, typically to be appended to `URLRequest`
 public protocol AuthorizationProviding {
     /// Optional `Authorization` header, likely added to `URLRequest`

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -2,6 +2,7 @@ import Foundation
 import TSCBasic
 
 
+
 /// Supplies `Authorization` header, typically to be appended to `URLRequest`
 public protocol AuthorizationProviding {
     /// Optional `Authorization` header, likely added to `URLRequest`
@@ -13,6 +14,12 @@ extension AuthorizationProviding {
         return nil
     }
 }
+
+#if os(macOS)
+/*
+ Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
+ which is only available in macOS 10.13+ at this time.
+ */
 
 @available (OSX 10.13, *)
 /// Container of parsed netrc connection settings
@@ -159,3 +166,4 @@ fileprivate enum RegexUtil {
         return #"\s*\#(string)\s+(?<\#(prefix + string)>\S++)"#
     }
 }
+#endif

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -84,8 +84,6 @@ public struct Netrc: AuthorizationProviding {
         guard machines.count > 0 else { return .failure(.machineNotFound) }
         return .success(Netrc(machines: machines))
     }
-    
-    
     /// Utility method to trim comments from netrc content
     /// - Parameter text: String text of netrc file
     /// - Returns: String text of netrc file *sans* comments

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -45,9 +45,7 @@ public struct Netrc: AuthorizationProviding {
     /// - Returns: `Netrc` container with parsed connection settings, or error
     public static func load(fromFileAtPath filePath: AbsolutePath? = nil) -> Result<Netrc, Netrc.Error> {
                 
-        guard let filePath = filePath ?? AbsolutePath("\(NSHomeDirectory())/.netrc") else {
-            return .failure(.invalidFilePath)
-        }
+        let filePath = filePath ?? AbsolutePath("\(NSHomeDirectory())/.netrc")
         
         guard FileManager.default.fileExists(atPath: filePath.pathString) else { return .failure(.fileNotFound(filePath)) }
         guard FileManager.default.isReadableFile(atPath: filePath.pathString),

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -9,7 +9,7 @@ public protocol AuthorizationProviding {
 }
 
 extension AuthorizationProviding {
-    func authorization(for url: Foundation.URL) -> String? {
+    public func authorization(for url: Foundation.URL) -> String? {
         return nil
     }
 }

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -1,5 +1,6 @@
 import Foundation
 import TSCBasic
+
 /// Supplies `Authorization` header, typically to be appended to `URLRequest`
 public protocol AuthorizationProviding {
     /// Optional `Authorization` header, likely added to `URLRequest`
@@ -11,6 +12,7 @@ extension AuthorizationProviding {
         return nil
     }
 }
+
 #if os(Windows)
 // FIXME: - add support for Windows when regex function available
 #endif
@@ -24,11 +26,9 @@ extension AuthorizationProviding {
  Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
  which is only available in macOS 10.13+ at this time.
  */
-
 @available (OSX 10.13, *)
 /// Container of parsed netrc connection settings
 public struct Netrc: AuthorizationProviding {
-    
     /// Representation of `machine` connection settings & `default` connection settings.
     /// If `default` connection settings present, they will be last element.
     public let machines: [Machine]
@@ -60,7 +60,6 @@ public struct Netrc: AuthorizationProviding {
         
         return Netrc.from(fileContents)
     }
-    
     
     /// Regex matching logic for deriving `Netrc` container from string content
     /// - Parameter content: String text of netrc file
@@ -100,7 +99,6 @@ public struct Netrc: AuthorizationProviding {
 
 @available (OSX 10.13, *)
 public extension Netrc {
-    
     enum Error: Swift.Error {
         case invalidFilePath
         case fileNotFound(AbsolutePath)
@@ -139,9 +137,7 @@ public extension Netrc {
 
 @available (OSX 10.13, *)
 fileprivate enum RegexUtil {
-    
     @frozen fileprivate enum Token: String, CaseIterable {
-        
         case machine, login, password, account, macdef, `default`
         
         func capture(prefix: String = "", in match: NSTextCheckingResult, string: String) -> String? {
@@ -151,15 +147,12 @@ fileprivate enum RegexUtil {
     }
 
     static let comments: String = "\\#[\\s\\S]*?.*$"
-    
     static let `default`: String = #"(?:\s*(?<default>default))"#
     static let accountOptional: String = #"(?:\s*account\s+\S++)?"#
-    
     static let loginPassword: String = #"\#(namedTrailingCapture("login", prefix: "lp"))\#(accountOptional)\#(namedTrailingCapture("password", prefix: "lp"))"#
     static let passwordLogin: String = #"\#(namedTrailingCapture("password", prefix: "pl"))\#(accountOptional)\#(namedTrailingCapture("login", prefix: "pl"))"#
-    
     static let netrcPattern = #"(?:(?:(\#(namedTrailingCapture("machine"))|\#(namedMatch("default"))))(?:\#(loginPassword)|\#(passwordLogin)))"#
-        
+    
     static func namedMatch(_ string: String) -> String {
         return #"(?:\s*(?<\#(string)>\#(string)))"#
     }

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -18,17 +18,14 @@ extension AuthorizationProviding {
 /// Container of parsed netrc connection settings
 public struct Netrc: AuthorizationProviding {
     
-    /// Representation of `machine` connection settings & `default` connection settings.  If `default` connection settings present, they will be last element.
+    /// Representation of `machine` connection settings & `default` connection settings.
+    /// If `default` connection settings present, they will be last element.
     public let machines: [Machine]
     
     private init(machines: [Machine]) {
         self.machines = machines
     }
     
-//    /// Testing API.  Not for productive use.
-//    /// See:  [Remove @testable from codebase](https://github.com/apple/swift-package-manager/commit/b6349d516d2f9b2f26ddae9de2c594ede24af7d6)
-//    public static var _mock: Netrc? = nil
-        
     /// Basic authorization header string
     /// - Parameter url: URI of network resource to be accessed
     /// - Returns: (optional) Basic Authorization header string to be added to the request
@@ -40,11 +37,10 @@ public struct Netrc: AuthorizationProviding {
         return "Basic \(authData.base64EncodedString())"
     }
     
-    ///
+    /// Reads file at path or default location, and returns parsed Netrc representation
     /// - Parameter fileURL: Location of netrc file, defaults to `~/.netrc`
     /// - Returns: `Netrc` container with parsed connection settings, or error
     public static func load(fromFileAtPath filePath: AbsolutePath? = nil) -> Result<Netrc, Netrc.Error> {
-                
         let filePath = filePath ?? AbsolutePath("\(NSHomeDirectory())/.netrc")
         
         guard FileManager.default.fileExists(atPath: filePath.pathString) else { return .failure(.fileNotFound(filePath)) }
@@ -59,7 +55,6 @@ public struct Netrc: AuthorizationProviding {
     /// - Parameter content: String text of netrc file
     /// - Returns: `Netrc` container with parsed connection settings, or error
     public static func from(_ content: String) -> Result<Netrc, Netrc.Error> {
-        
         let content = trimComments(from: content)
         let regex = try! NSRegularExpression(pattern: RegexUtil.netrcPattern, options: [])
         let matches = regex.matches(in: content, options: [], range: NSRange(content.startIndex..<content.endIndex, in: content))

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -14,6 +14,13 @@ extension AuthorizationProviding {
         return nil
     }
 }
+#if os(Windows)
+// FIXME: - add support for Windows when regex function available
+#endif
+
+#if os(Linux)
+// FIXME: - add support for Linux when regex function available
+#endif
 
 #if os(macOS)
 /*

--- a/Tests/TSCUtilityTests/DownloaderTests.swift
+++ b/Tests/TSCUtilityTests/DownloaderTests.swift
@@ -18,6 +18,7 @@ import FoundationNetworking
 #endif
 
 class DownloaderTests: XCTestCase {
+
     func testSuccess() {
       // FIXME: Remove once https://github.com/apple/swift-corelibs-foundation/pull/2593 gets inside a toolchain.
       #if os(macOS)

--- a/Tests/TSCUtilityTests/DownloaderTests.swift
+++ b/Tests/TSCUtilityTests/DownloaderTests.swift
@@ -18,6 +18,12 @@ import FoundationNetworking
 #endif
 
 class DownloaderTests: XCTestCase {
+    
+    override func tearDown() {
+        if #available(OSX 10.13, *) {
+            Netrc._mock = nil
+        }
+    }
 
     func testSuccess() {
       // FIXME: Remove once https://github.com/apple/swift-corelibs-foundation/pull/2593 gets inside a toolchain.
@@ -69,6 +75,140 @@ class DownloaderTests: XCTestCase {
             MockURLProtocol.sendData(Data(repeating: 0xef, count: 512), for: url)
             wait(for: [progress100Expectation], timeout: 1.0)
             MockURLProtocol.sendCompletion(for: url)
+            wait(for: [successExpectation], timeout: 1.0)
+        }
+      #endif
+    }
+    
+    @available(OSX 10.13, *)
+    func testAuthenticatedSuccess() {
+
+        let netrcContent = "machine protected.downloader-tests.com login anonymous password qwerty"
+        guard case .success(let netrc) = Netrc.from(netrcContent) else {
+            return XCTFail("Cannot load netrc content")
+        }
+        let authData = "anonymous:qwerty".data(using: .utf8)!
+        let testAuthHeader = "Basic \(authData.base64EncodedString())"
+        Netrc._mock = netrc
+        
+      #if os(macOS)
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockAuthenticatingURLProtocol.self]
+        let downloader = FoundationDownloader(configuration: configuration)
+
+        mktmpdir { tmpdir in
+            let url = URL(string: "https://protected.downloader-tests.com/testBasics.zip")!
+            let destination = tmpdir.appending(component: "download")
+
+            let didStartLoadingExpectation = XCTestExpectation(description: "didStartLoading")
+            let progress50Expectation = XCTestExpectation(description: "progress50")
+            let progress100Expectation = XCTestExpectation(description: "progress100")
+            let successExpectation = XCTestExpectation(description: "success")
+            MockAuthenticatingURLProtocol.notifyDidStartLoading(for: url, completion: { didStartLoadingExpectation.fulfill() })
+
+            downloader.downloadFile(at: url, to: destination, progress: { bytesDownloaded, totalBytesToDownload in
+                
+                XCTAssertEqual(MockAuthenticatingURLProtocol.authenticationHeader(for: url), testAuthHeader)
+
+                switch (bytesDownloaded, totalBytesToDownload) {
+                case (512, 1024):
+                    progress50Expectation.fulfill()
+                case (1024, 1024):
+                    progress100Expectation.fulfill()
+                default:
+                    XCTFail("unexpected progress")
+                }
+            }, completion: { result in
+                switch result {
+                case .success:
+                    XCTAssert(localFileSystem.exists(destination))
+                    let bytes = ByteString(Array(repeating: 0xbe, count: 512) + Array(repeating: 0xef, count: 512))
+                    XCTAssertEqual(try! localFileSystem.readFileContents(destination), bytes)
+                    successExpectation.fulfill()
+                case .failure(let error):
+                    XCTFail("\(error)")
+                }
+            })
+
+            wait(for: [didStartLoadingExpectation], timeout: 1.0)
+
+            let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "1.1", headerFields: [
+                "Content-Length": "1024"
+            ])!
+
+            MockAuthenticatingURLProtocol.sendResponse(response, for: url)
+            MockAuthenticatingURLProtocol.sendData(Data(repeating: 0xbe, count: 512), for: url)
+            wait(for: [progress50Expectation], timeout: 1.0)
+            MockAuthenticatingURLProtocol.sendData(Data(repeating: 0xef, count: 512), for: url)
+            wait(for: [progress100Expectation], timeout: 1.0)
+            MockAuthenticatingURLProtocol.sendCompletion(for: url)
+            wait(for: [successExpectation], timeout: 1.0)
+        }
+      #endif
+    }
+    
+    @available(OSX 10.13, *)
+    func testDefaultAuthenticationSuccess() {
+
+        let netrcContent = "default login default password default"
+        guard case .success(let netrc) = Netrc.from(netrcContent) else {
+            return XCTFail("Cannot load netrc content")
+        }
+        let authData = "default:default".data(using: .utf8)!
+        let testAuthHeader = "Basic \(authData.base64EncodedString())"
+        Netrc._mock = netrc
+        
+      #if os(macOS)
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockAuthenticatingURLProtocol.self]
+        let downloader = FoundationDownloader(configuration: configuration)
+
+        mktmpdir { tmpdir in
+            let url = URL(string: "https://restricted.downloader-tests.com/testBasics.zip")!
+            let destination = tmpdir.appending(component: "download")
+
+            let didStartLoadingExpectation = XCTestExpectation(description: "didStartLoading")
+            let progress50Expectation = XCTestExpectation(description: "progress50")
+            let progress100Expectation = XCTestExpectation(description: "progress100")
+            let successExpectation = XCTestExpectation(description: "success")
+            MockAuthenticatingURLProtocol.notifyDidStartLoading(for: url, completion: { didStartLoadingExpectation.fulfill() })
+
+            downloader.downloadFile(at: url, to: destination, progress: { bytesDownloaded, totalBytesToDownload in
+                
+                XCTAssertEqual(MockAuthenticatingURLProtocol.authenticationHeader(for: url), testAuthHeader)
+
+                switch (bytesDownloaded, totalBytesToDownload) {
+                case (512, 1024):
+                    progress50Expectation.fulfill()
+                case (1024, 1024):
+                    progress100Expectation.fulfill()
+                default:
+                    XCTFail("unexpected progress")
+                }
+            }, completion: { result in
+                switch result {
+                case .success:
+                    XCTAssert(localFileSystem.exists(destination))
+                    let bytes = ByteString(Array(repeating: 0xbe, count: 512) + Array(repeating: 0xef, count: 512))
+                    XCTAssertEqual(try! localFileSystem.readFileContents(destination), bytes)
+                    successExpectation.fulfill()
+                case .failure(let error):
+                    XCTFail("\(error)")
+                }
+            })
+
+            wait(for: [didStartLoadingExpectation], timeout: 1.0)
+
+            let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "1.1", headerFields: [
+                "Content-Length": "1024"
+            ])!
+
+            MockAuthenticatingURLProtocol.sendResponse(response, for: url)
+            MockAuthenticatingURLProtocol.sendData(Data(repeating: 0xbe, count: 512), for: url)
+            wait(for: [progress50Expectation], timeout: 1.0)
+            MockAuthenticatingURLProtocol.sendData(Data(repeating: 0xef, count: 512), for: url)
+            wait(for: [progress100Expectation], timeout: 1.0)
+            MockAuthenticatingURLProtocol.sendCompletion(for: url)
             wait(for: [successExpectation], timeout: 1.0)
         }
       #endif
@@ -209,6 +349,16 @@ private struct DummyError: Error {
 
 private typealias Action = () -> Void
 
+private class MockAuthenticatingURLProtocol: MockURLProtocol {
+    
+    fileprivate static func authenticationHeader(for url: Foundation.URL) -> String? {
+        guard let instance = instance(for: url) else {
+            fatalError("url did not start loading")
+        }
+        return instance.request.allHTTPHeaderFields?["Authorization"]
+    }
+}
+
 private class MockURLProtocol: URLProtocol {
     private static var queue = DispatchQueue(label: "org.swift.swiftpm.basic-tests.mock-url-protocol")
     private static var observers: [Foundation.URL: Action] = [:]
@@ -309,6 +459,10 @@ private class MockURLProtocol: URLProtocol {
             let url = self.request.url!
             Self.instances[url] = nil
         }
+    }
+    
+    fileprivate static func instance(for url: Foundation.URL) -> URLProtocol? {
+        return Self.instances[url]
     }
 }
 

--- a/Tests/TSCUtilityTests/DownloaderTests.swift
+++ b/Tests/TSCUtilityTests/DownloaderTests.swift
@@ -76,7 +76,6 @@ class DownloaderTests: XCTestCase {
     
     @available(OSX 10.13, *)
     func testAuthenticatedSuccess() {
-
         let netrcContent = "machine protected.downloader-tests.com login anonymous password qwerty"
         guard case .success(let netrc) = Netrc.from(netrcContent) else {
             return XCTFail("Cannot load netrc content")
@@ -142,7 +141,6 @@ class DownloaderTests: XCTestCase {
     
     @available(OSX 10.13, *)
     func testDefaultAuthenticationSuccess() {
-
         let netrcContent = "default login default password default"
         guard case .success(let netrc) = Netrc.from(netrcContent) else {
             return XCTFail("Cannot load netrc content")

--- a/Tests/TSCUtilityTests/DownloaderTests.swift
+++ b/Tests/TSCUtilityTests/DownloaderTests.swift
@@ -18,12 +18,6 @@ import FoundationNetworking
 #endif
 
 class DownloaderTests: XCTestCase {
-    
-    override func tearDown() {
-        if #available(OSX 10.13, *) {
-            Netrc._mock = nil
-        }
-    }
 
     func testSuccess() {
       // FIXME: Remove once https://github.com/apple/swift-corelibs-foundation/pull/2593 gets inside a toolchain.
@@ -89,7 +83,6 @@ class DownloaderTests: XCTestCase {
         }
         let authData = "anonymous:qwerty".data(using: .utf8)!
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
-        Netrc._mock = netrc
         
       #if os(macOS)
         let configuration = URLSessionConfiguration.default
@@ -106,7 +99,7 @@ class DownloaderTests: XCTestCase {
             let successExpectation = XCTestExpectation(description: "success")
             MockAuthenticatingURLProtocol.notifyDidStartLoading(for: url, completion: { didStartLoadingExpectation.fulfill() })
 
-            downloader.downloadFile(at: url, to: destination, progress: { bytesDownloaded, totalBytesToDownload in
+            downloader.downloadFile(at: url, to: destination, withAuthorizationProvider: netrc, progress: { bytesDownloaded, totalBytesToDownload in
                 
                 XCTAssertEqual(MockAuthenticatingURLProtocol.authenticationHeader(for: url), testAuthHeader)
 
@@ -156,7 +149,6 @@ class DownloaderTests: XCTestCase {
         }
         let authData = "default:default".data(using: .utf8)!
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
-        Netrc._mock = netrc
         
       #if os(macOS)
         let configuration = URLSessionConfiguration.default
@@ -173,7 +165,7 @@ class DownloaderTests: XCTestCase {
             let successExpectation = XCTestExpectation(description: "success")
             MockAuthenticatingURLProtocol.notifyDidStartLoading(for: url, completion: { didStartLoadingExpectation.fulfill() })
 
-            downloader.downloadFile(at: url, to: destination, progress: { bytesDownloaded, totalBytesToDownload in
+            downloader.downloadFile(at: url, to: destination, withAuthorizationProvider: netrc, progress: { bytesDownloaded, totalBytesToDownload in
                 
                 XCTAssertEqual(MockAuthenticatingURLProtocol.authenticationHeader(for: url), testAuthHeader)
 

--- a/Tests/TSCUtilityTests/DownloaderTests.swift
+++ b/Tests/TSCUtilityTests/DownloaderTests.swift
@@ -74,7 +74,10 @@ class DownloaderTests: XCTestCase {
       #endif
     }
     
+    #if os(macOS)
     @available(OSX 10.13, *)
+    /// Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
+    /// which is only available in macOS 10.13+ at this time.
     func testAuthenticatedSuccess() {
         let netrcContent = "machine protected.downloader-tests.com login anonymous password qwerty"
         guard case .success(let netrc) = Netrc.from(netrcContent) else {
@@ -83,7 +86,6 @@ class DownloaderTests: XCTestCase {
         let authData = "anonymous:qwerty".data(using: .utf8)!
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
         
-      #if os(macOS)
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockAuthenticatingURLProtocol.self]
         let downloader = FoundationDownloader(configuration: configuration)
@@ -136,10 +138,13 @@ class DownloaderTests: XCTestCase {
             MockAuthenticatingURLProtocol.sendCompletion(for: url)
             wait(for: [successExpectation], timeout: 1.0)
         }
-      #endif
     }
+    #endif
     
+    #if os(macOS)
     @available(OSX 10.13, *)
+    /// Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
+    /// which is only available in macOS 10.13+ at this time.
     func testDefaultAuthenticationSuccess() {
         let netrcContent = "default login default password default"
         guard case .success(let netrc) = Netrc.from(netrcContent) else {
@@ -148,7 +153,6 @@ class DownloaderTests: XCTestCase {
         let authData = "default:default".data(using: .utf8)!
         let testAuthHeader = "Basic \(authData.base64EncodedString())"
         
-      #if os(macOS)
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockAuthenticatingURLProtocol.self]
         let downloader = FoundationDownloader(configuration: configuration)
@@ -201,8 +205,8 @@ class DownloaderTests: XCTestCase {
             MockAuthenticatingURLProtocol.sendCompletion(for: url)
             wait(for: [successExpectation], timeout: 1.0)
         }
-      #endif
     }
+    #endif
 
     func testClientError() {
       // FIXME: Remove once https://github.com/apple/swift-corelibs-foundation/pull/2593 gets inside a toolchain.

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+import TSCUtility
+
+class NetrcTests: XCTestCase {
+    func testLoadMachinesInline() {
+        //			it("should load machines for a given inline format") {
+        let content = "machine example.com login anonymous password qwerty"
+        
+        let machines = try? Netrc.from(content).get().machines
+        XCTAssertEqual(machines?.count, 1)
+        
+        let machine = machines?.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+    }
+    
+    func testLoadMachinesMultiLine() {
+        //			it("should load machines for a given multi-line format") {
+        let content = """
+                    machine example.com
+                    login anonymous
+                    password qwerty
+                    """
+        
+        let machines = try? Netrc.from(content).get().machines
+        XCTAssertEqual(machines?.count, 1)
+        
+        let machine = machines?.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+    }
+    
+    func testLoadMachinesMultilineComments() {
+        
+        //			it("should load machines for a given multi-line format with comments") {
+        let content = """
+                    ## This is a comment
+                    # This is another comment
+                    machine example.com # This is an inline comment
+                    login anonymous
+                    password qwerty # and # another #one
+                    """
+        
+        let machines = try? Netrc.from(content).get().machines
+        XCTAssertEqual(machines?.count, 1)
+        
+        let machine = machines?.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+    }
+    
+    func testLoadMachinesMultilineWhitespaces() {
+        //			it("should load machines for a given multi-line + whitespaces format") {
+        let content = """
+                    machine  example.com login     anonymous
+                    password                  qwerty
+                    """
+        
+        let machines = try? Netrc.from(content).get().machines
+        XCTAssertEqual(machines?.count, 1)
+        
+        let machine = machines?.first
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+    }
+    
+    func testLoadMultipleMachinesInline() {
+        //			it("should load multiple machines for a given inline format") {
+        let content = "machine example.com login anonymous password qwerty machine example2.com login anonymous2 password qwerty2"
+        
+        let machines = try? Netrc.from(content).get().machines
+        XCTAssertEqual(machines?.count, 2)
+        
+        var machine = machines?[0]
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+        
+        machine = machines?[1]
+        XCTAssertEqual(machine?.name, "example2.com")
+        XCTAssertEqual(machine?.login, "anonymous2")
+        XCTAssertEqual(machine?.password, "qwerty2")
+    }
+    
+    func testLoadMultipleMachinesMultiline() {
+        //			it("should load multiple machines for a given multi-line format") {
+        let content = """
+                    machine  example.com login     anonymous
+                    password                  qwerty
+                    machine example2.com
+                    login anonymous2
+                    password qwerty2
+                    """
+        
+        let machines = try? Netrc.from(content).get().machines
+        XCTAssertEqual(machines?.count, 2)
+        
+        var machine = machines?[0]
+        XCTAssertEqual(machine?.name, "example.com")
+        XCTAssertEqual(machine?.login, "anonymous")
+        XCTAssertEqual(machine?.password, "qwerty")
+        
+        machine = machines?[1]
+        XCTAssertEqual(machine?.name, "example2.com")
+        XCTAssertEqual(machine?.login, "anonymous2")
+        XCTAssertEqual(machine?.password, "qwerty2")
+    }
+    
+    func testErrorMachineParameterMissing() {
+        //			it("should throw error when machine parameter is missing") {
+        let content = "login anonymous password qwerty"
+        
+        guard case .failure(.machineNotFound) = Netrc.from(content) else {
+            return XCTFail("Expected machineNotFound error")
+        }
+    }
+    
+    func testErrorEmptyMachineValue() {
+        //			it("should throw error for an empty machine values") {
+        let content = "machine"
+        
+        guard case .failure(.machineNotFound) = Netrc.from(content) else {
+            return XCTFail("Expected machineNotFound error")
+        }
+    }
+    
+    func testErrorLoginParameterMissing() {
+        //			it("should throw error when login parameter is missing") {
+        let content = "machine example.com anonymous password qwerty"
+        
+        guard case .failure(.missingValueForToken(let token)) = Netrc.from(content) else {
+            return XCTFail("Expected missingValueForToken error")
+        }
+        
+        XCTAssertEqual(token, "login")
+    }
+    
+    func testErrorPasswordParameterMissing() {
+        //			it("should throw error when password parameter is missing") {
+        let content = "machine example.com login anonymous"
+        
+        guard case .failure(.missingValueForToken(let token)) = Netrc.from(content) else {
+            return XCTFail("Expected missingValueForToken error")
+        }
+        
+        XCTAssertEqual(token, "password")
+    }
+    
+    func testErrorLoginPasswordParameterMissing() {
+        //            it("should throw error when both login and password parameters are missing") {
+        let content = "machine example.com"
+        
+        guard case .failure(.missingValueForToken(let token)) = Netrc.from(content) else {
+            return XCTFail("Expected missingValueForToken error")
+        }
+        
+        XCTAssertEqual(token, "login")
+    }
+    
+    func testReturnAuthorizationForMachineMatch() {
+        //			it("should return authorization when config contains a given machine") {
+        let content = "machine example.com login anonymous password qwerty"
+        
+        guard let netrc = try? Netrc.from(content).get(),
+              let result = netrc.authorization(for: URL(string: "https://example.com")!) else {
+            return XCTFail()
+        }
+        
+        let data = "anonymous:qwerty".data(using: .utf8)!.base64EncodedString()
+        XCTAssertEqual(result, "Basic \(data)")
+    }
+    
+    func testNoReturnAuthorizationForNoMachineMatch() {
+        //			it("should not return authorization when config does not contain a given machine") {
+        let content = "machine example.com login anonymous password qwerty"
+        
+        guard let netrc = try? Netrc.from(content).get() else {
+            return XCTFail()
+        }
+        XCTAssertNil(netrc.authorization(for: URL(string: "https://example99.com")!))
+    }
+}

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -377,7 +377,7 @@ class NetrcTests: XCTestCase {
               login my@email.com
               password 01230123012301230123012301230123
 
-            machine api.github.com password something login somebody
+            machine api.github.com password something account ghi login somebody
 
             machine ftp.server login abc account ghi password def macdef somemacro
             cd somehwhere

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -183,4 +183,56 @@ class NetrcTests: XCTestCase {
         }
         XCTAssertNil(netrc.authorization(for: URL(string: "https://example99.com")!))
     }
+    
+    func testIBMDocumentation() {
+        // test case: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/filesreference/netrc.html
+        let content = "machine host1.austin.century.com login fred password bluebonnet"
+        
+        guard let netrc = try? Netrc.from(content).get() else {
+            return XCTFail()
+        }
+        
+        let machine = netrc.machines.first
+        XCTAssertEqual(machine?.name, "host1.austin.century.com")
+        XCTAssertEqual(machine?.login, "fred")
+        XCTAssertEqual(machine?.password, "bluebonnet")
+        
+    }
+    
+    func testNoErrorTrailingAccountMacdefDefault() {
+        // test case: https://gist.github.com/tpope/4247721
+        
+        // should not fail on presence of `account`, `macdef`, `default`
+        let content = """
+            machine api.heroku.com
+              login my@email.com
+              password 01230123012301230123012301230123
+
+            machine api.github.com password something login somebody
+
+            machine ftp.server login abc password def account ghi macdef somemacro
+            cd somehwhere
+            continues until end of paragraph
+
+            default login anonymous password my@email.com
+            """
+        
+        guard let netrc = try? Netrc.from(content).get() else {
+            return XCTFail()
+        }
+        
+        XCTAssertEqual(netrc.machines.count, 3)
+        
+        XCTAssertEqual(netrc.machines[0].name, "api.heroku.com")
+        XCTAssertEqual(netrc.machines[0].login, "my@email.com")
+        XCTAssertEqual(netrc.machines[0].password, "01230123012301230123012301230123")
+        
+        XCTAssertEqual(netrc.machines[1].name, "api.github.com")
+        XCTAssertEqual(netrc.machines[1].login, "somebody")
+        XCTAssertEqual(netrc.machines[1].password, "something")
+        
+        XCTAssertEqual(netrc.machines[2].name, "ftp.server")
+        XCTAssertEqual(netrc.machines[2].login, "abc")
+        XCTAssertEqual(netrc.machines[2].password, "def")
+    }
 }

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -368,6 +368,47 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(netrc.machines[3].password, "my@email.com")
     }
     
+    func testNoErrorMixedAccount() {
+        // test case: https://gist.github.com/tpope/4247721
+        
+        // should not fail on presence of `account`, `macdef`, `default`
+        let content = """
+            machine api.heroku.com
+              login my@email.com
+              password 01230123012301230123012301230123
+
+            machine api.github.com password something login somebody
+
+            machine ftp.server login abc account ghi password def macdef somemacro
+            cd somehwhere
+            continues until end of paragraph
+
+            default login anonymous password my@email.com
+            """
+        
+        guard let netrc = try? Netrc.from(content).get() else {
+            return XCTFail()
+        }
+        
+        XCTAssertEqual(netrc.machines.count, 4)
+        
+        XCTAssertEqual(netrc.machines[0].name, "api.heroku.com")
+        XCTAssertEqual(netrc.machines[0].login, "my@email.com")
+        XCTAssertEqual(netrc.machines[0].password, "01230123012301230123012301230123")
+        
+        XCTAssertEqual(netrc.machines[1].name, "api.github.com")
+        XCTAssertEqual(netrc.machines[1].login, "somebody")
+        XCTAssertEqual(netrc.machines[1].password, "something")
+        
+        XCTAssertEqual(netrc.machines[2].name, "ftp.server")
+        XCTAssertEqual(netrc.machines[2].login, "abc")
+        XCTAssertEqual(netrc.machines[2].password, "def")
+        
+        XCTAssertEqual(netrc.machines[3].name, "default")
+        XCTAssertEqual(netrc.machines[3].login, "anonymous")
+        XCTAssertEqual(netrc.machines[3].password, "my@email.com")
+    }
+    
     func testNoErrorMultipleMacdefAndComments() {
         // test case: https://renenyffenegger.ch/notes/Linux/fhs/home/username/_netrc
         

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -17,7 +17,7 @@ class NetrcTests: XCTestCase {
         
         let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
         XCTAssertNotNil(authorization)
-       
+        
         let authData = "anonymous:qwerty".data(using: .utf8)!
         XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
         
@@ -42,13 +42,13 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(machine?.password, "qwerty")
         
         let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
-         XCTAssertNotNil(authorization)
+        XCTAssertNotNil(authorization)
         
-         let authData = "anonymous:qwerty".data(using: .utf8)!
-         XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
-         
-         XCTAssertNil(netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!))
-         XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
+        let authData = "anonymous:qwerty".data(using: .utf8)!
+        XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
+        
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!))
+        XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
     }
     
     func testLoadDefaultMachine() {
@@ -78,8 +78,8 @@ class NetrcTests: XCTestCase {
         let authorization = netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!)
         XCTAssertNotNil(authorization)
         
-         let authData = "id:secret".data(using: .utf8)!
-         XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
+        let authData = "id:secret".data(using: .utf8)!
+        XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
     }
     
     func testRegexParsing() {
@@ -123,8 +123,8 @@ class NetrcTests: XCTestCase {
         let authorization = netrc.authorization(for: URL(string: "http://example2.com/resource.zip")!)
         XCTAssertNotNil(authorization)
         
-         let authData = "id:secret".data(using: .utf8)!
-         XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
+        let authData = "id:secret".data(using: .utf8)!
+        XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
     }
     
     func testOutOfOrderDefault() {
@@ -275,20 +275,20 @@ class NetrcTests: XCTestCase {
         guard case .success(let netrc) = Netrc.from(content) else { return XCTFail() }
         let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
         let authData = "id:secret".data(using: .utf8)!
-         XCTAssertNotNil(authorization)
-         XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
+        XCTAssertNotNil(authorization)
+        XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
     }
     
     func testReturnAuthorizationForMachineMatch() {
         //			it("should return authorization when config contains a given machine") {
         let content = "machine example.com login anonymous password qwerty"
-         
-         guard case .success(let netrc) = Netrc.from(content) else { return XCTFail() }
-         
-         let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
+        
+        guard case .success(let netrc) = Netrc.from(content) else { return XCTFail() }
+        
+        let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
         let authData = "anonymous:qwerty".data(using: .utf8)!
-         XCTAssertNotNil(authorization)
-         XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
+        XCTAssertNotNil(authorization)
+        XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
     }
     
     func testReturnNoAuthorizationForUnmatched() {
@@ -303,7 +303,7 @@ class NetrcTests: XCTestCase {
     func testNoReturnAuthorizationForNoMachineMatch() {
         //			it("should not return authorization when config does not contain a given machine") {
         let content = "machine example.com login anonymous password qwerty"
-
+        
         guard case .success(let netrc) = Netrc.from(content) else { return XCTFail() }
         XCTAssertNil(netrc.authorization(for: URL(string: "https://example99.com")!))
         XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example.com/resource.zip")!))
@@ -403,6 +403,6 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(netrc.machines[1].name, "other.server.org")
         XCTAssertEqual(netrc.machines[1].login, "fred")
         XCTAssertEqual(netrc.machines[1].password, "sunshine4ever")
-
+        
     }
 }

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -1,7 +1,10 @@
 import XCTest
 import TSCUtility
 
+#if os(macOS)
 @available(macOS 10.13, *)
+/// Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
+/// which is only available in macOS 10.13+ at this time.
 class NetrcTests: XCTestCase {
     
     /// should load machines for a given inline format
@@ -443,3 +446,4 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(netrc.machines[1].password, "sunshine4ever")
     }
 }
+#endif

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -6,7 +6,6 @@ import TSCUtility
 /// Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
 /// which is only available in macOS 10.13+ at this time.
 class NetrcTests: XCTestCase {
-    
     /// should load machines for a given inline format
     func testLoadMachinesInline() {
         let content = "machine example.com login anonymous password qwerty"

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -3,8 +3,9 @@ import TSCUtility
 
 @available(macOS 10.13, *)
 class NetrcTests: XCTestCase {
+    
+    /// should load machines for a given inline format
     func testLoadMachinesInline() {
-        //			it("should load machines for a given inline format") {
         let content = "machine example.com login anonymous password qwerty"
         
         guard case .success(let netrc) = Netrc.from(content) else { return XCTFail() }
@@ -25,8 +26,8 @@ class NetrcTests: XCTestCase {
         XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
     }
     
+    /// should load machines for a given multi-line format
     func testLoadMachinesMultiLine() {
-        //			it("should load machines for a given multi-line format") {
         let content = """
                     machine example.com
                     login anonymous
@@ -51,6 +52,7 @@ class NetrcTests: XCTestCase {
         XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
     }
     
+    /// Should fall back to default machine when not matching host
     func testLoadDefaultMachine() {
         let content = """
                     machine example.com
@@ -175,9 +177,8 @@ class NetrcTests: XCTestCase {
         guard case .failure(.invalidDefaultMachinePosition) = Netrc.from(content) else { return XCTFail() }
     }
     
+    /// should load machines for a given multi-line format with comments
     func testLoadMachinesMultilineComments() {
-        
-        //			it("should load machines for a given multi-line format with comments") {
         let content = """
                     ## This is a comment
                     # This is another comment
@@ -195,8 +196,8 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(machine?.password, "qwerty")
     }
     
+    /// should load machines for a given multi-line + whitespaces format
     func testLoadMachinesMultilineWhitespaces() {
-        //			it("should load machines for a given multi-line + whitespaces format") {
         let content = """
                     machine  example.com login     anonymous
                     password                  qwerty
@@ -211,8 +212,8 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(machine?.password, "qwerty")
     }
     
+    /// should load multiple machines for a given inline format
     func testLoadMultipleMachinesInline() {
-        //			it("should load multiple machines for a given inline format") {
         let content = "machine example.com login anonymous password qwerty machine example2.com login anonymous2 password qwerty2"
         
         guard case .success(let netrc) = Netrc.from(content) else { return XCTFail() }
@@ -227,8 +228,8 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(netrc.machines[1].password, "qwerty2")
     }
     
+    /// should load multiple machines for a given multi-line format
     func testLoadMultipleMachinesMultiline() {
-        //			it("should load multiple machines for a given multi-line format") {
         let content = """
                     machine  example.com login     anonymous
                     password                  qwerty
@@ -251,8 +252,8 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(machine?.password, "qwerty2")
     }
     
+    /// should throw error when machine parameter is missing
     func testErrorMachineParameterMissing() {
-        //			it("should throw error when machine parameter is missing") {
         let content = "login anonymous password qwerty"
         
         guard case .failure(.machineNotFound) = Netrc.from(content) else {
@@ -260,8 +261,8 @@ class NetrcTests: XCTestCase {
         }
     }
     
+    /// should throw error for an empty machine values
     func testErrorEmptyMachineValue() {
-        //			it("should throw error for an empty machine values") {
         let content = "machine"
         
         guard case .failure(.machineNotFound) = Netrc.from(content) else {
@@ -269,8 +270,8 @@ class NetrcTests: XCTestCase {
         }
     }
     
+    /// should throw error for an empty machine values
     func testEmptyMachineValueFollowedByDefaultNoError() {
-        //            it("should throw error for an empty machine values") {
         let content = "machine default login id password secret"
         guard case .success(let netrc) = Netrc.from(content) else { return XCTFail() }
         let authorization = netrc.authorization(for: URL(string: "http://example.com/resource.zip")!)
@@ -279,8 +280,8 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(authorization, "Basic \(authData.base64EncodedString())")
     }
     
+    /// should return authorization when config contains a given machine
     func testReturnAuthorizationForMachineMatch() {
-        //			it("should return authorization when config contains a given machine") {
         let content = "machine example.com login anonymous password qwerty"
         
         guard case .success(let netrc) = Netrc.from(content) else { return XCTFail() }
@@ -300,8 +301,8 @@ class NetrcTests: XCTestCase {
         XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
     }
     
+    /// should not return authorization when config does not contain a given machine
     func testNoReturnAuthorizationForNoMachineMatch() {
-        //			it("should not return authorization when config does not contain a given machine") {
         let content = "machine example.com login anonymous password qwerty"
         
         guard case .success(let netrc) = Netrc.from(content) else { return XCTFail() }
@@ -312,8 +313,8 @@ class NetrcTests: XCTestCase {
         XCTAssertNil(netrc.authorization(for: URL(string: "http://www.example2.com/resource.zip")!))
     }
     
+    /// Test case: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/filesreference/netrc.html
     func testIBMDocumentation() {
-        // test case: https://www.ibm.com/support/knowledgecenter/en/ssw_aix_72/filesreference/netrc.html
         let content = "machine host1.austin.century.com login fred password bluebonnet"
         
         guard let netrc = try? Netrc.from(content).get() else {
@@ -324,13 +325,11 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(machine?.name, "host1.austin.century.com")
         XCTAssertEqual(machine?.login, "fred")
         XCTAssertEqual(machine?.password, "bluebonnet")
-        
     }
     
+    /// Should not fail on presence of `account`, `macdef`, `default`
+    /// test case: https://gist.github.com/tpope/4247721
     func testNoErrorTrailingAccountMacdefDefault() {
-        // test case: https://gist.github.com/tpope/4247721
-        
-        // should not fail on presence of `account`, `macdef`, `default`
         let content = """
             machine api.heroku.com
               login my@email.com
@@ -368,10 +367,9 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(netrc.machines[3].password, "my@email.com")
     }
     
+    /// Should not fail on presence of `account`, `macdef`, `default`
+    /// test case: https://gist.github.com/tpope/4247721
     func testNoErrorMixedAccount() {
-        // test case: https://gist.github.com/tpope/4247721
-        
-        // should not fail on presence of `account`, `macdef`, `default`
         let content = """
             machine api.heroku.com
               login my@email.com
@@ -409,10 +407,9 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(netrc.machines[3].password, "my@email.com")
     }
     
+    /// Should not fail on presence of `account`, `macdef`, `default`
+    /// test case: https://renenyffenegger.ch/notes/Linux/fhs/home/username/_netrc
     func testNoErrorMultipleMacdefAndComments() {
-        // test case: https://renenyffenegger.ch/notes/Linux/fhs/home/username/_netrc
-        
-        // should not fail on presence of `account`, `macdef`, `default`
         let content = """
             machine  ftp.foobar.baz
             login    john
@@ -444,6 +441,5 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(netrc.machines[1].name, "other.server.org")
         XCTAssertEqual(netrc.machines[1].login, "fred")
         XCTAssertEqual(netrc.machines[1].password, "sunshine4ever")
-        
     }
 }


### PR DESCRIPTION
Implemented handling for [netrc](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) files.  Matches connection settings for binary artifact host, and returns Basic authentication header to be appended to internal `URLRequest` of the `Downloader`.  Will resolve [Supporting basic auth for non-git binary dependency hosts](https://forums.swift.org/t/spm-support-basic-auth-for-non-git-binary-dependency-hosts/37878).

`Netrc` parser based on [Carthage implementation and tests](https://github.com/Carthage/Carthage/pull/2774), and migrated to regex for flexibility.

## Features supported
 - Parse Netrc string text:  single and multi-line
 - Match `machine`, `login`, `password` key values
 - Ignore comments
 - Ignore `account` and `macdef` entries (relevant only to ftp remotes)
 - Accept any order of `login`, `password`, `account` key values
 - Match `default` connection settings.
 - Validates single instance of `default` connection setting, and that `default` connection setting is last entry
 - Checks for netrc file in `NSHomeDirectory()/.netrc` by default
 - `Workspace` supports custom `netrcFilePath` parameter
## Sequence Flow (including SPM)
<img width="1321" alt="Screen Shot 2020-07-18 at 12 13 19 AM" src="https://user-images.githubusercontent.com/377404/87869312-ad965300-c953-11ea-9bbc-2e31e04362ac.png">

In SPM, a netrc file absolute path is resolved during (3) `getActiveWorkspace()` call of `run()` procedure, from  (1) optional command argument.  Optional absolute path is passed to initialized `Workspace`(5). 
 
If binary artifacts should be updated, then the (7) `download(...)` operation attempts to load the netrc machine definitions from a file at the resolved `netrcFilePath`(8), or at `NSHomeDirectory()/.netrc` if `nil`.  The optional resulting `Netrc` instance is passed to the created `FoundationDownloader` for each artifact (11).  The downloader attempts to match a credential in the list of the `Netrc` instance's `Machine` definitions for the artifact host (13).  If matched, the base64-encoded `<user>:<password>` pair is set to the `Authorization` header for the respective `URLRequest`.

## Notes
1. The main question wrt API addition was: how to efficiently pass the netrc content to the `Downloader` protocol, which is lightweight by design.  Though netrc is a common technique, it is not necessarily a universal solution--perhaps in the future we should also support application tokens, etc., which might similarly pollute the protocol.  So, this implementation introduces the `AuthorizationProviding` interface, under which additional authentication techniques could in the future be added to the `Workspace`, and injected to the binary update process in `Downloader` implementations. 

```swift
public protocol AuthorizationProviding {
    /// Optional `Authorization` header, likely added to `URLRequest`
    func authorization(for url: Foundation.URL) -> String?
}
```
`Downloader` is extended as follows:
```swift
/// The `Downloader` protocol abstract away the download of a file with a progress report.
public protocol Downloader {
    /**/
    /// Downloads a file and keeps the caller updated on the progress and completion.
    ///
    /// - Parameters:
    ///   - url: The `URL` to the file to download.
    ///   - destination: The `AbsolutePath` to download the file to.
    ///   - authorizationProvider: Optional provider supplying `Authorization` header to be added to `URLRequest`.
    ///   - progress: A closure to receive the download's progress as number of bytes.
    ///   - completion: A closure to be notifed of the completion of the download.
    func downloadFile(
        at url: Foundation.URL,
        to destination: AbsolutePath,
        withAuthorizationProvider authorizationProvider: AuthorizationProviding?,
        progress: @escaping Progress,
        completion: @escaping Completion
    )
}
```
2. The netrc credential injection is added to `FoundationDownloader`.  Other `Downloaders` should implement handling according to their requirements.
3. Requires OSX 10.13.  Will obligate `swift-driver` and `swift-package-manager` packages to raise minimum to 10.13 also.  Discussed in [thread](https://forums.swift.org/t/spm-support-basic-auth-for-non-git-binary-dependency-hosts/37878/11?u=sstadelman).
4. An associated PR will be necessary in `swift-package-manager` to support `--netrc-file` option.  However, the default `NSHomeDirectory()/.netrc` location for the netrc file can be supported immediately upon merging this PR in TSC.