### PR TITLE
Allow specifying environment for Process on Windows

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -326,6 +326,7 @@ public final class Process: ObjectIdentifierProtocol {
         _process = Foundation.Process()
         _process?.arguments = arguments
         _process?.executableURL = URL(fileURLWithPath: arguments[0])
+        _process?.environment = environment
 
         if outputRedirection.redirectsOutput {
             let stdoutPipe = Pipe()


### PR DESCRIPTION
This is going to be useful for getting the package structure from `Package.swift`:
Currently SwiftPM compiles the package manifest with an `-rpath` linker argument which is not supported on Windows.
On Windows it should instead execute the compiled manifest with an additional `PATH` component representing the `PackageDescription.dll` location.

(corresponding PR with the actual usage in SwiftPM is coming soon)