### PR TITLE
Fix PATH retrieval on Windows

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -314,7 +314,7 @@ public final class Process: ObjectIdentifierProtocol {
             }
             // FIXME: This can be cached.
             let envSearchPaths = getEnvSearchPaths(
-                pathString: ProcessEnv.vars["PATH"],
+                pathString: ProcessEnv.path,
                 currentWorkingDirectory: localFileSystem.currentWorkingDirectory
             )
             // Lookup and cache the executable path.

--- a/Sources/TSCBasic/ProcessEnv.swift
+++ b/Sources/TSCBasic/ProcessEnv.swift
@@ -57,6 +57,16 @@ public enum ProcessEnv {
         invalidateEnv()
     }
 
+    /// `PATH` variable in the process's environment (`Path` under Windows).
+    public static var path: String? {
+#if os(Windows)
+        let pathArg = "Path"
+#else
+        let pathArg = "PATH"
+#endif
+        return vars[pathArg]
+    }
+
     /// The current working directory of the process.
     public static var cwd: AbsolutePath? {
         return localFileSystem.currentWorkingDirectory


### PR DESCRIPTION
This is needed to discover `git.exe` in `PATH` while running `resolve` command.