### PR TITLE
Fix Git discovery & execution on Windows

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -340,14 +340,15 @@ public final class Process: ObjectIdentifierProtocol {
         }
 
         // Look for executable.
-        guard Process.findExecutable(arguments[0]) != nil else {
-            throw Process.Error.missingExecutableProgram(program: arguments[0])
+        let executable = arguments[0]
+        guard let executablePath = Process.findExecutable(executable) else {
+            throw Process.Error.missingExecutableProgram(program: executable)
         }
 
     #if os(Windows)
         _process = Foundation.Process()
         _process?.arguments = Array(arguments.dropFirst()) // Avoid including the executable URL twice.
-        _process?.executableURL = URL(fileURLWithPath: arguments[0])
+        _process?.executableURL = executablePath.asURL
         _process?.environment = environment
 
         if outputRedirection.redirectsOutput {

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -11,6 +11,12 @@
 import TSCLibc
 import Foundation
 
+#if os(Windows)
+public let executableFileSuffix = ".exe"
+#else
+public let executableFileSuffix = ""
+#endif
+
 /// Replace the current process image with a new process image.
 ///
 /// - Parameters:

--- a/Sources/TSCUtility/Git.swift
+++ b/Sources/TSCUtility/Git.swift
@@ -57,7 +57,7 @@ public class Git {
     }
 
     /// A shell command to run for Git. Can be either a name or a path.
-    public static var tool: String = "git"
+    public static var tool: String = "git\(executableFileSuffix)"
 
     /// Returns true if the git reference name is well formed.
     public static func checkRefFormat(ref: String) -> Bool {


### PR DESCRIPTION
This fixes:
* git discovery by searching for `git.exe` instead of `git`
* git invocation by passing an absolute path instead of just an executable name

For an example of usage please see `GitRepositoryProvider.fetch` in the SwiftPM project.