### PR TITLE
build: correct typo in option description (NFC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
 endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-option(BUILD_SHARED_LIBS "Build shared libraryes by default" YES)
+option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 
 find_package(dispatch QUIET)
 find_package(Foundation QUIET)


### PR DESCRIPTION
This simply fixes a typo in the description of the option.