### PR TITLE
build: ignore deprecation warnings on Windows

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -49,6 +49,11 @@ add_library(TSCBasic
   Thread.swift
   Tuple.swift
   misc.swift)
+target_compile_options(TSCBasic PUBLIC
+  # Don't use GNU strerror_r on Android.
+  "$<$<PLATFORM_ID:Android>:SHELL:-Xcc -U_GNU_SOURCE>"
+  # Ignore secure function warnings on Windows.
+  "$<$<PLATFORM_ID:Windows>:SHELL:-Xcc -D_CRT_SECURE_NO_WARNINGS>")
 target_link_libraries(TSCBasic PUBLIC
   TSCLibc)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
@@ -65,11 +70,6 @@ install(TARGETS TSCBasic
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
-endif()
-
-# Don't use GNU strerror_r on Android.
-if(CMAKE_SYSTEM_NAME STREQUAL Android)
-  target_compile_options(TSCBasic PUBLIC "SHELL:-Xcc -U_GNU_SOURCE")
 endif()
 
 set_property(GLOBAL APPEND PROPERTY TSC_EXPORTS TSCBasic)


### PR DESCRIPTION
Adjust the compile flags for TSCBasic on Windows.  Avoid the separate
checks and addition of flags in favour of generator expressions.