### PR TITLE
TSCBasic: avoid POSIX name on Windows for `strdup`

### DIFF
--- a/Sources/TSCBasic/CStringArray.swift
+++ b/Sources/TSCBasic/CStringArray.swift
@@ -20,7 +20,11 @@ public final class CStringArray {
 
     /// Creates an instance from an array of strings.
     public init(_ array: [String]) {
+#if os(Windows)
+        cArray = array.map({ $0.withCString({ _strdup($0) }) }) + [nil]
+#else
         cArray = array.map({ $0.withCString({ strdup($0) }) }) + [nil]
+#endif
     }
 
     deinit {


### PR DESCRIPTION
THis generates a warning, so use the "portable" name `_strdup` instead.
This should be functionally identical.