### PR TITLE
TSCBasic: improve `TemporaryFile` on Windows

### DIFF
--- a/Sources/TSCBasic/TemporaryFile.swift
+++ b/Sources/TSCBasic/TemporaryFile.swift
@@ -135,7 +135,13 @@ public func withTemporaryFile<Result>(
     let tempFile = try TemporaryFile(dir: dir, prefix: prefix, suffix: suffix)
     defer {
         if deleteOnClose {
+#if os(Windows)
+            _ = tempFile.path.pathString.withCString(encodedAs: UTF16.self) {
+              _wunlink($0)
+            }
+#else
             unlink(tempFile.path.pathString)
+#endif
         }
     }
     return try body(tempFile)


### PR DESCRIPTION
Rather than using the ASCII version of the functions which prevent the
use of unicode characters in the path.  Given that `String` in Swift
internally will deal with the encoding, this allows us to encode to
UTF-16 and use the unicode version of the functions.