### PR TITLE
TSCBasic: remove `signalled` from `ProcessResult` on Windows

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -31,9 +31,10 @@ public struct ProcessResult: CustomStringConvertible {
     public enum ExitStatus: Equatable {
         /// The process was terminated normally with a exit code.
         case terminated(code: Int32)
-
+#if !os(Windows)
         /// The process was terminated due to a signal.
         case signalled(signal: Int32)
+#endif
     }
 
     /// The arguments with which the process was launched.
@@ -758,9 +759,10 @@ extension ProcessResult.Error: CustomStringConvertible {
             switch result.exitStatus {
             case .terminated(let code):
                 stream <<< "terminated(\(code)): "
-
+#if !os(Windows)
             case .signalled(let signal):
                 stream <<< "signalled(\(signal)): "
+#endif
             }
 
             // Strip sandbox information from arguments to keep things pretty.


### PR DESCRIPTION
Windows does not have the concept of signals.  Remove this case from the
enumeration to make this work for Windows.