### PR TITLE
TSCBasic: use the "portable" names for `terminalType`

### DIFF
--- a/Sources/TSCBasic/TerminalController.swift
+++ b/Sources/TSCBasic/TerminalController.swift
@@ -109,11 +109,15 @@ public final class TerminalController {
 
     /// Computes the terminal type of the stream.
     public static func terminalType(_ stream: LocalFileOutputByteStream) -> TerminalType {
+#if os(Windows)
+        return _isatty(_fileno(stream.filePointer)) == 0 ? .file : .tty
+#else
         if ProcessEnv.vars["TERM"] == "dumb" {
             return .dumb
         }
         let isTTY = isatty(fileno(stream.filePointer)) != 0
         return isTTY ? .tty : .file
+#endif
     }
 
     /// Tries to get the terminal width first using COLUMNS env variable and


### PR DESCRIPTION
This adds the Windows path which uses the `_isatty` and `_fileno` for
the conversion.  This is likely still insufficiently to properly detect
the stream.  `_isatty` is okay in the short term, but it is better to
use `GetFileType` on the `HANDLE` associated with the file descriptor.
This requires better auditing to ensure that the handle is convertible
to the underlying Windows handle.