### PR TITLE
build: make `SQLite` a private dependency

### DIFF
--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -39,6 +39,8 @@ add_library(TSCUtility
 )
 target_link_libraries(TSCUtility PUBLIC
   TSCBasic)
+target_link_libraries(TSCUtility PRIVATE
+  SQLite::SQLite3)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(TSCUtility PUBLIC
     FoundationNetworking)

--- a/Sources/TSCclibc/CMakeLists.txt
+++ b/Sources/TSCclibc/CMakeLists.txt
@@ -11,9 +11,6 @@ add_library(TSCclibc STATIC
 target_include_directories(TSCclibc PUBLIC
   include)
 
-target_link_libraries(TSCclibc PUBLIC
-  SQLite::SQLite3)
-
 if(NOT BUILD_SHARED_LIBS)
   install(TARGETS TSCclibc
     ARCHIVE DESTINATION lib)


### PR DESCRIPTION
Since the SQLite3 import is marked as `@_implementationOnly` this is
perfectly reasonable to assume that the symbols from SQLite3 should not
be required by consumers of this library and thus the consumers of this
library do not need to link against SQLite3 themselves.  Reflect this in
the build.  This is needed to ensure that the dependency handling works
properly for building swift-driver.