### PR TITLE
TSCTestSupport: remove `PseudoTerminal` on Windows temporarily

### DIFF
--- a/Sources/TSCTestSupport/PseudoTerminal.swift
+++ b/Sources/TSCTestSupport/PseudoTerminal.swift
@@ -11,6 +11,8 @@
 import TSCBasic
 import TSCLibc
 
+#if os(Windows)
+#else
 public final class PseudoTerminal {
     let master: Int32
     let slave: Int32
@@ -51,3 +53,4 @@ public final class PseudoTerminal {
         closeMaster()
     }
 }
+#endif


### PR DESCRIPTION
While swift-package-manager is being brought up on Windows, we do not
have the tests running.  Windows does not have the `pty` concept nor the
supporting APIs.  For now disable the class to allow
swift-tools-support-core to build on Windows with swift-package-manager
which is required to bootstrap swift-package-manager.