### PR TITLE
Fix and use posix_spawn_file_actions_addchdir_np() check for Android

### DIFF
--- a/Sources/TSCclibc/process.c
+++ b/Sources/TSCclibc/process.c
@@ -5,16 +5,24 @@
 #include "process.h"
 
 int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restrict file_actions, const char *restrict path) {
-#if __GLIBC_PREREQ(2, 29)
+#if defined(__GLIBC__)
+#  if __GLIBC_PREREQ(2, 29)
     return posix_spawn_file_actions_addchdir_np(file_actions, path);
+#  else
+    return ENOSYS;
+#  endif
 #else
     return ENOSYS;
 #endif
 }
 
 bool SPM_posix_spawn_file_actions_addchdir_np_supported() {
-#if __GLIBC_PREREQ(2, 29)
+#if defined(__GLIBC__)
+#  if __GLIBC_PREREQ(2, 29)
     return true;
+#  else
+    return false;
+#  endif
 #else
     return false;
 #endif

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -271,7 +271,7 @@ class ProcessTests: XCTestCase {
             return
         }
 
-      #if os(Linux)
+      #if os(Linux) || os(Android)
         guard SPM_posix_spawn_file_actions_addchdir_np_supported() else {
             // Skip this test since it's not supported in this OS.
             return


### PR DESCRIPTION
This function and `__GLIBC_PREREQ()` are not available in Bionic.