### PR TITLE
Parse compiler messages properly on Windows

### DIFF
--- a/Sources/TSCUtility/JSONMessageStreamingParser.swift
+++ b/Sources/TSCUtility/JSONMessageStreamingParser.swift
@@ -101,6 +101,11 @@ private extension JSONMessageStreamingParser {
 
     /// Throwing implementation of the parse function.
     func parseImpl<C>(bytes: C) throws where C: Collection, C.Element == UInt8 {
+#if os(Windows)
+        let carriageReturn = UInt8(ascii: "\r")
+        let bytes = bytes.filter { $0 != carriageReturn }
+#endif
+
         switch state {
         case .parsingMessageSize:
             if let newlineIndex = bytes.firstIndex(of: newline) {


### PR DESCRIPTION
Currently SwiftPM dumps raw JSON data while compiling on Windows instead of the actual build status. This happens because `JSONMessageStreamingParser` splits the output lines by `\n` without taking `\r` into account on Windows.
After this change the compiler messages are parsed and displayed properly.