### PR TITLE
Remove more environment variables when launching inferior swift-test binaries from Xcode to prevent a timeout

### DIFF
--- a/Sources/TSCTestSupport/Product.swift
+++ b/Sources/TSCTestSupport/Product.swift
@@ -89,6 +89,8 @@ extension Product {
       #if Xcode
          // Unset these variables which causes issues when running tests via Xcode.
         environment["XCTestConfigurationFilePath"] = nil
+        environment["XCTestSessionIdentifier"] = nil
+        environment["XCTestBundlePath"] = nil
         environment["NSUnbufferedIO"] = nil
       #endif
         // FIXME: We use this private environment variable hack to be able to


### PR DESCRIPTION
These environment variables are intended for the superior xctest invocation, and we need to make sure we're not passing them on so that the xctest invocation being invoked by swift-test thinks it's invoked directly from Xcode.  We should possibly be filtering out all environment variables prefixed with "XCTest", or maybe even better, use an allow-list of environment variables to avoid having the environment leaking into the test.  But this is a minimal change that gets these unit tests working again from Xcode.

rdar://68362616