### PR TITLE
TSCBasic: repair the Windows build after apple/swift-package-manager#…

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -748,6 +748,7 @@ extension Process.Error: CustomStringConvertible {
         }
     }
 }
+#endif
 
 extension ProcessResult.Error: CustomStringConvertible {
     public var description: String {
@@ -787,4 +788,3 @@ extension ProcessResult.Error: CustomStringConvertible {
         }
     }
 }
-#endif


### PR DESCRIPTION
…2925

The `ProcessResult.Error` conformance to `CustomStringConvertible` was
ignored on the Windows target accidentally.  Adjust this to repair the
build.