### PR TITLE
NFC: Rename OutputByteStream to WritableByteStream for a more semantic meaning of the type.

### DIFF
--- a/Sources/TSCBasic/ByteString.swift
+++ b/Sources/TSCBasic/ByteString.swift
@@ -21,7 +21,7 @@ import Foundation
 /// strings, we wish to retain the flexibility to micro-optimize the memory
 /// allocation of the storage (for example, by inlining the storage for small
 /// strings or and by eliminating wasted space in growable arrays). For
-/// construction of byte arrays, clients should use the `OutputByteStream` class
+/// construction of byte arrays, clients should use the `WritableByteStream` class
 /// and then convert to a `ByteString` when complete.
 public struct ByteString: ExpressibleByArrayLiteral, Hashable {
     /// The buffer contents.
@@ -142,7 +142,7 @@ extension ByteString: CustomStringConvertible {
 /// ByteStreamable conformance for a ByteString.
 extension ByteString: ByteStreamable {
     @inlinable
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         stream.write(_bytes)
     }
 }

--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(TSCBasic
   ObjectIdentifierProtocol.swift
   OrderedDictionary.swift
   OrderedSet.swift
-  OutputByteStream.swift
+  WritableByteStream.swift
   Path.swift
   PathShims.swift
   Process.swift

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -230,7 +230,7 @@ public extension FileSystem {
     }
 
     /// Write to a file from a stream producer.
-    func writeFileContents(_ path: AbsolutePath, body: (OutputByteStream) -> Void) throws {
+    func writeFileContents(_ path: AbsolutePath, body: (WritableByteStream) -> Void) throws {
         let contents = BufferedOutputByteStream()
         body(contents)
         try createDirectory(path.parentDirectory, recursive: true)

--- a/Sources/TSCBasic/JSON.swift
+++ b/Sources/TSCBasic/JSON.swift
@@ -115,11 +115,11 @@ extension JSON {
 
 /// Support writing to a byte stream.
 extension JSON: ByteStreamable {
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         write(to: stream, indent: nil)
     }
 
-    public func write(to stream: OutputByteStream, indent: Int?) {
+    public func write(to stream: WritableByteStream, indent: Int?) {
         func indentStreamable(offset: Int? = nil) -> ByteStreamable {
             return Format.asRepeating(string: " ", count: indent.flatMap({ $0 + (offset ?? 0) }) ?? 0)
         }

--- a/Sources/TSCBasic/TerminalController.swift
+++ b/Sources/TSCBasic/TerminalController.swift
@@ -58,7 +58,7 @@ public final class TerminalController {
     }
 
     /// Pointer to output stream to operate on.
-    private var stream: OutputByteStream
+    private var stream: WritableByteStream
 
     /// Width of the terminal.
     public let width: Int
@@ -73,7 +73,7 @@ public final class TerminalController {
     private let boldString = "\u{001B}[1m"
 
     /// Constructs the instance if the stream is a tty.
-    public init?(stream: OutputByteStream) {
+    public init?(stream: WritableByteStream) {
         let realStream = (stream as? ThreadSafeOutputByteStream)?.stream ?? stream
 
         // Make sure it is a file stream and it is tty.
@@ -188,7 +188,7 @@ public final class TerminalController {
         return stream.bytes.description
     }
 
-    private func writeWrapped(_ string: String, inColor color: Color, bold: Bool = false, stream: OutputByteStream) {
+    private func writeWrapped(_ string: String, inColor color: Color, bold: Bool = false, stream: WritableByteStream) {
         // Don't wrap if string is empty or color is no color.
         guard !string.isEmpty && color != .noColor else {
             stream <<< string

--- a/Sources/TSCBasic/WritableyteStream.swift
+++ b/Sources/TSCBasic/WritableyteStream.swift
@@ -18,7 +18,7 @@ private func hexdigit(_ value: UInt8) -> UInt8 {
 
 /// Describes a type which can be written to a byte stream.
 public protocol ByteStreamable {
-    func write(to stream: OutputByteStream)
+    func write(to stream: WritableByteStream)
 }
 
 /// An output byte stream.
@@ -43,7 +43,7 @@ public protocol ByteStreamable {
 ///
 /// would write each item in the list to the stream, separating them with a
 /// space.
-public protocol OutputByteStream: class, TextOutputStream {
+public protocol WritableByteStream: class, TextOutputStream {
     /// The current offset within the output stream.
     var position: Int { get }
 
@@ -57,7 +57,10 @@ public protocol OutputByteStream: class, TextOutputStream {
     func flush()
 }
 
-extension OutputByteStream {
+// Public alias to the old name to not introduce API compatibility.
+public typealias OutputByteStream = WritableByteStream
+
+extension WritableByteStream {
     /// Write a sequence of bytes to the buffer.
     public func write<S: Sequence>(sequence: S) where S.Iterator.Element == UInt8 {
         // Iterate the sequence and append byte by byte since sequence's append
@@ -124,12 +127,12 @@ extension OutputByteStream {
     }
 }
 
-/// The `OutputByteStream` base class.
+/// The `WritableByteStream` base class.
 ///
-/// This class provides a base and efficient implementation of the `OutputByteStream`
+/// This class provides a base and efficient implementation of the `WritableByteStream`
 /// protocol. It can not be used as is-as subclasses as several functions need to be
 /// implemented in subclasses.
-public class _OutputByteStreamBase: OutputByteStream {
+public class _WritableByteStreamBase: WritableByteStream {
     /// If buffering is enabled
     @usableFromInline let _buffered : Bool
 
@@ -149,7 +152,7 @@ public class _OutputByteStreamBase: OutputByteStream {
 
         // When not buffered we still reserve 1 byte, as it is used by the
         // by the single byte write() variant.
-        self._buffer.reserveCapacity(buffered ? _OutputByteStreamBase.bufferSize : 1)
+        self._buffer.reserveCapacity(buffered ? _WritableByteStreamBase.bufferSize : 1)
     }
 
     // MARK: Data Access API
@@ -268,13 +271,13 @@ public class _OutputByteStreamBase: OutputByteStream {
 
 /// The thread-safe wrapper around output byte streams.
 ///
-/// This class wraps any `OutputByteStream` conforming type to provide a type-safe
-/// access to its operations. If the provided stream inherits from `_OutputByteStreamBase`,
+/// This class wraps any `WritableByteStream` conforming type to provide a type-safe
+/// access to its operations. If the provided stream inherits from `_WritableByteStreamBase`,
 /// it will also ensure it is type-safe will all other `ThreadSafeOutputByteStream` instances
 /// around the same stream.
-public final class ThreadSafeOutputByteStream: OutputByteStream {
+public final class ThreadSafeOutputByteStream: WritableByteStream {
     private static let defaultQueue = DispatchQueue(label: "org.swift.swiftpm.basic.thread-safe-output-byte-stream")
-    public let stream: OutputByteStream
+    public let stream: WritableByteStream
     private let queue: DispatchQueue
 
     public var position: Int {
@@ -283,9 +286,9 @@ public final class ThreadSafeOutputByteStream: OutputByteStream {
         }
     }
 
-    public init(_ stream: OutputByteStream) {
+    public init(_ stream: WritableByteStream) {
         self.stream = stream
-        self.queue = (stream as? _OutputByteStreamBase)?.queue ?? ThreadSafeOutputByteStream.defaultQueue
+        self.queue = (stream as? _WritableByteStreamBase)?.queue ?? ThreadSafeOutputByteStream.defaultQueue
     }
 
     public func write(_ byte: UInt8) {
@@ -331,73 +334,73 @@ precedencegroup StreamingPrecedence {
 // FIXME: This override shouldn't be necesary but removing it causes a 30% performance regression. This problem is
 // tracked by the following bug: https://bugs.swift.org/browse/SR-8535
 @discardableResult
-public func <<< (stream: OutputByteStream, value: ArraySlice<UInt8>) -> OutputByteStream {
+public func <<< (stream: WritableByteStream, value: ArraySlice<UInt8>) -> WritableByteStream {
     value.write(to: stream)
     return stream
 }
 
 @discardableResult
-public func <<< (stream: OutputByteStream, value: ByteStreamable) -> OutputByteStream {
+public func <<< (stream: WritableByteStream, value: ByteStreamable) -> WritableByteStream {
     value.write(to: stream)
     return stream
 }
 
 @discardableResult
-public func <<< (stream: OutputByteStream, value: CustomStringConvertible) -> OutputByteStream {
+public func <<< (stream: WritableByteStream, value: CustomStringConvertible) -> WritableByteStream {
     value.description.write(to: stream)
     return stream
 }
 
 @discardableResult
-public func <<< (stream: OutputByteStream, value: ByteStreamable & CustomStringConvertible) -> OutputByteStream {
+public func <<< (stream: WritableByteStream, value: ByteStreamable & CustomStringConvertible) -> WritableByteStream {
     value.write(to: stream)
     return stream
 }
 
 extension UInt8: ByteStreamable {
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         stream.write(self)
     }
 }
 
 extension Character: ByteStreamable {
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         stream.write(String(self))
     }
 }
 
 extension String: ByteStreamable {
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         stream.write(self.utf8)
     }
 }
 
 extension Substring: ByteStreamable {
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         stream.write(self.utf8)
     }
 }
 
 extension StaticString: ByteStreamable {
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         withUTF8Buffer { stream.write($0) }
     }
 }
 
 extension Array: ByteStreamable where Element == UInt8 {
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         stream.write(self)
     }
 }
 
 extension ArraySlice: ByteStreamable where Element == UInt8 {
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         stream.write(self)
     }
 }
 
 extension ContiguousArray: ByteStreamable where Element == UInt8 {
-    public func write(to stream: OutputByteStream) {
+    public func write(to stream: WritableByteStream) {
         stream.write(self)
     }
 }
@@ -413,7 +416,7 @@ public struct Format {
     private struct JSONEscapedBoolStreamable: ByteStreamable {
         let value: Bool
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             stream <<< (value ? "true" : "false")
         }
     }
@@ -425,7 +428,7 @@ public struct Format {
     private struct JSONEscapedIntStreamable: ByteStreamable {
         let value: Int
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             // FIXME: Diagnose integers which cannot be represented in JSON.
             stream <<< value.description
         }
@@ -438,7 +441,7 @@ public struct Format {
     private struct JSONEscapedDoubleStreamable: ByteStreamable {
         let value: Double
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             // FIXME: What should we do about NaN, etc.?
             //
             // FIXME: Is Double.debugDescription the best representation?
@@ -457,7 +460,7 @@ public struct Format {
     private struct JSONEscapedStringStreamable: ByteStreamable {
         let value: String
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             stream <<< UInt8(ascii: "\"")
             stream.writeJSONEscaped(value)
             stream <<< UInt8(ascii: "\"")
@@ -477,7 +480,7 @@ public struct Format {
     private struct JSONEscapedStringListStreamable: ByteStreamable {
         let items: [String]
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             stream <<< UInt8(ascii: "[")
             for (i, item) in items.enumerated() {
                 if i != 0 { stream <<< "," }
@@ -494,7 +497,7 @@ public struct Format {
     private struct JSONEscapedDictionaryStreamable: ByteStreamable {
         let items: [String: String]
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             stream <<< UInt8(ascii: "{")
             for (offset: i, element: (key: key, value: value)) in items.enumerated() {
                 if i != 0 { stream <<< "," }
@@ -514,7 +517,7 @@ public struct Format {
         let items: [T]
         let transform: (T) -> String
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             stream <<< UInt8(ascii: "[")
             for (i, item) in items.enumerated() {
                 if i != 0 { stream <<< "," }
@@ -532,7 +535,7 @@ public struct Format {
         let items: [T]
         let separator: String
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             for (i, item) in items.enumerated() {
                 // Add the separator, if necessary.
                 if i != 0 {
@@ -558,7 +561,7 @@ public struct Format {
         let transform: (T) -> ByteStreamable
         let separator: String
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             for (i, item) in items.enumerated() {
                 if i != 0 { stream <<< separator }
                 stream <<< transform(item)
@@ -579,7 +582,7 @@ public struct Format {
             self.count = count
         }
 
-        func write(to stream: OutputByteStream) {
+        func write(to stream: WritableByteStream) {
             for _ in 0..<count {
                 stream <<< string
             }
@@ -587,14 +590,14 @@ public struct Format {
     }
 }
 
-/// In memory implementation of OutputByteStream.
-public final class BufferedOutputByteStream: _OutputByteStreamBase {
+/// In memory implementation of WritableByteStream.
+public final class BufferedOutputByteStream: _WritableByteStreamBase {
 
     /// Contents of the stream.
     private var contents = [UInt8]()
 
     public init() {
-        // We disable the buffering of the underlying _OutputByteStreamBase as
+        // We disable the buffering of the underlying _WritableByteStreamBase as
         // we are explicitly buffering the whole stream in memory
         super.init(buffered: false)
     }
@@ -625,7 +628,7 @@ public final class BufferedOutputByteStream: _OutputByteStreamBase {
 }
 
 /// Represents a stream which is backed to a file. Not for instantiating.
-public class FileOutputByteStream: _OutputByteStreamBase {
+public class FileOutputByteStream: _WritableByteStreamBase {
 
     /// Closes the file flushing any buffered data.
     public final func close() throws {

--- a/Sources/TSCUtility/ArgumentParser.swift
+++ b/Sources/TSCUtility/ArgumentParser.swift
@@ -888,7 +888,7 @@ public final class ArgumentParser {
     }
 
     /// Prints usage text for this parser on the provided stream.
-    public func printUsage(on stream: OutputByteStream) {
+    public func printUsage(on stream: WritableByteStream) {
         /// Space settings.
         let maxWidthDefault = 24
         let padding = 2
@@ -905,7 +905,7 @@ public final class ArgumentParser {
         }
 
         /// Prints an argument on a stream if it has usage.
-        func print(formatted argument: String, usage: String, on stream: OutputByteStream) {
+        func print(formatted argument: String, usage: String, on stream: WritableByteStream) {
             // Start with a new line and add some padding.
             stream <<< "\n" <<< Format.asRepeating(string: " ", count: padding)
             let count = argument.count

--- a/Sources/TSCUtility/ArgumentParserShellCompletion.swift
+++ b/Sources/TSCUtility/ArgumentParserShellCompletion.swift
@@ -20,7 +20,7 @@ extension ArgumentParser {
     /// These aren't complete scripts, as some setup code is required. See
     /// `Sources/Commands/Completions+bash.swift` and
     /// `Sources/Commands/Completions+zsh.swift` for example usage.
-    public func generateCompletionScript(for shell: Shell, on stream: OutputByteStream) {
+    public func generateCompletionScript(for shell: Shell, on stream: WritableByteStream) {
         guard let commandName = commandName else { abort() }
         let name = "_\(commandName.replacingOccurrences(of: " ", with: "_"))"
 
@@ -56,7 +56,7 @@ extension ArgumentParser {
 
     // MARK: - BASH
 
-    fileprivate func generateBashSwiftTool(name: String, on stream: OutputByteStream) {
+    fileprivate func generateBashSwiftTool(name: String, on stream: WritableByteStream) {
         stream <<< """
             function \(name)
             {
@@ -123,7 +123,7 @@ extension ArgumentParser {
         }
     }
 
-    fileprivate func generateBashCasePrev(on stream: OutputByteStream) {
+    fileprivate func generateBashCasePrev(on stream: WritableByteStream) {
         stream <<< "    case $prev in\n"
         for argument in optionArguments {
             let flags = [argument.name] + (argument.shortName.map({ [$0] }) ?? [])
@@ -134,7 +134,7 @@ extension ArgumentParser {
         stream <<< "    esac\n"
     }
 
-    fileprivate func generateBashCompletion(_ argument: AnyArgument, on stream: OutputByteStream) {
+    fileprivate func generateBashCompletion(_ argument: AnyArgument, on stream: WritableByteStream) {
         switch argument.completion {
         case .none:
             // return; no value to complete
@@ -165,7 +165,7 @@ extension ArgumentParser {
 
     // MARK: - ZSH
 
-    private func generateZshSwiftTool(name: String, on stream: OutputByteStream) {
+    private func generateZshSwiftTool(name: String, on stream: WritableByteStream) {
         // Completions are provided by zsh's _arguments builtin.
         stream <<< """
             \(name)() {
@@ -242,7 +242,7 @@ extension ArgumentParser {
     }
 
     /// Generates an option argument for `_arguments`, complete with description and completion values.
-    fileprivate func generateZshArgument(_ argument: AnyArgument, on stream: OutputByteStream) {
+    fileprivate func generateZshArgument(_ argument: AnyArgument, on stream: WritableByteStream) {
         stream <<< "        \""
         switch argument.shortName {
         case .none: stream <<< "\(argument.name)"
@@ -261,7 +261,7 @@ extension ArgumentParser {
     }
 
     /// Generates completion values, as part of an item for `_arguments`.
-    fileprivate func generateZshCompletion(_ argument: AnyArgument, on stream: OutputByteStream) {
+    fileprivate func generateZshCompletion(_ argument: AnyArgument, on stream: WritableByteStream) {
         let message = removeDefaultRegex
             .replace(in: argument.usage ?? " ", with: "")
             .replacingOccurrences(of: "\"", with: "\\\"")

--- a/Sources/TSCUtility/ProgressAnimation.swift
+++ b/Sources/TSCUtility/ProgressAnimation.swift
@@ -30,12 +30,12 @@ public protocol ProgressAnimationProtocol {
 
 /// A single line percent-based progress animation.
 public final class SingleLinePercentProgressAnimation: ProgressAnimationProtocol {
-    private let stream: OutputByteStream
+    private let stream: WritableByteStream
     private let header: String?
     private var displayedPercentages: Set<Int> = []
     private var hasDisplayedHeader = false
 
-    init(stream: OutputByteStream, header: String?) {
+    init(stream: WritableByteStream, header: String?) {
         self.stream = stream
         self.header = header
     }
@@ -77,10 +77,10 @@ public final class MultiLineNinjaProgressAnimation: ProgressAnimationProtocol {
         let text: String
     }
 
-    private let stream: OutputByteStream
+    private let stream: WritableByteStream
     private var lastDisplayedText: String? = nil
 
-    public init(stream: OutputByteStream) {
+    public init(stream: WritableByteStream) {
         self.stream = stream
     }
 
@@ -141,7 +141,7 @@ public final class RedrawingNinjaProgressAnimation: ProgressAnimationProtocol {
 
 /// A ninja-like progress animation that adapts to the provided output stream.
 public final class NinjaProgressAnimation: DynamicProgressAnimation {
-    public init(stream: OutputByteStream) {
+    public init(stream: WritableByteStream) {
         super.init(
             stream: stream,
             ttyTerminalAnimationFactory: { RedrawingNinjaProgressAnimation(terminal: $0) },
@@ -157,12 +157,12 @@ public final class MultiLinePercentProgressAnimation: ProgressAnimationProtocol 
         let text: String
     }
 
-    private let stream: OutputByteStream
+    private let stream: WritableByteStream
     private let header: String
     private var hasDisplayedHeader = false
     private var lastDisplayedText: String? = nil
 
-    public init(stream: OutputByteStream, header: String) {
+    public init(stream: WritableByteStream, header: String) {
         self.stream = stream
         self.header = header
     }
@@ -258,7 +258,7 @@ public final class RedrawingLitProgressAnimation: ProgressAnimationProtocol {
 
 /// A percent-based progress animation that adapts to the provided output stream.
 public final class PercentProgressAnimation: DynamicProgressAnimation {
-    public init(stream: OutputByteStream, header: String) {
+    public init(stream: WritableByteStream, header: String) {
         super.init(
             stream: stream,
             ttyTerminalAnimationFactory: { RedrawingLitProgressAnimation(terminal: $0, header: header) },
@@ -272,7 +272,7 @@ public class DynamicProgressAnimation: ProgressAnimationProtocol {
     private let animation: ProgressAnimationProtocol
 
     public init(
-        stream: OutputByteStream,
+        stream: WritableByteStream,
         ttyTerminalAnimationFactory: (TerminalController) -> ProgressAnimationProtocol,
         dumbTerminalAnimationFactory: () -> ProgressAnimationProtocol,
         defaultAnimationFactory: () -> ProgressAnimationProtocol

--- a/Tests/TSCBasicPerformanceTests/WritableByteStreamPerfTests.swift
+++ b/Tests/TSCBasicPerformanceTests/WritableByteStreamPerfTests.swift
@@ -23,7 +23,7 @@ struct ByteSequence: Sequence {
 }
 
 extension ByteSequence: ByteStreamable {
-    func write(to stream: OutputByteStream) {
+    func write(to stream: WritableByteStream) {
         stream.write(sequence: self)
     }
 }

--- a/Tests/TSCBasicTests/WritableByteStreamTests.swift
+++ b/Tests/TSCBasicTests/WritableByteStreamTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 import TSCBasic
 
-class OutputByteStreamTests: XCTestCase {
+class WritableByteStreamTests: XCTestCase {
     func testBasics() {
         var stream = BufferedOutputByteStream()
         


### PR DESCRIPTION
This just replaces the OutputByteStream type name with `WritableByteStream`. The implementation classes of this protocol were not renamed to avoid messing with the types too much, and a OutputByteBuffer typealias was added to prevent breakages because of this change.