### PR TITLE
Add a way for emittable diagnostics (e.g. Swift.Errors) to provide custom DiagnosticLocations

### DIFF
--- a/Sources/TSCUtility/Diagnostics.swift
+++ b/Sources/TSCUtility/Diagnostics.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -16,6 +16,13 @@ public protocol DiagnosticDataConvertible {
 
     /// Diagnostic data representation of this instance.
     var diagnosticData: DiagnosticData { get }
+}
+
+
+/// Protocol for types that can provide a diagnostic location. A common use is
+/// for specializations of Swift.Error that can have diagnostic locations.
+public protocol DiagnosticLocationProviding {
+    var diagnosticLocation: DiagnosticLocation? { get }
 }
 
 /// DiagnosticData wrapper for Swift errors.
@@ -69,6 +76,7 @@ extension DiagnosticsEngine {
         _ error: Swift.Error,
         location: DiagnosticLocation? = nil
     ) {
+        let location = location ?? (error as? DiagnosticLocationProviding)?.diagnosticLocation
         if let diagnosticData = error as? DiagnosticData {
             emit(.error(diagnosticData), location: location)
         } else if case let convertible as DiagnosticDataConvertible = error {

--- a/Tests/TSCUtilityTests/DiagnosticsUtilityTests.swift
+++ b/Tests/TSCUtilityTests/DiagnosticsUtilityTests.swift
@@ -1,0 +1,60 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+
+import TSCBasic
+import TSCUtility
+
+class DiagnosticsTests: XCTestCase {
+    
+    func testDiagnosticsLocationProviding() throws {
+        let diagnostics = DiagnosticsEngine()
+        
+        struct BazLocation: DiagnosticLocation {
+            let name: String
+
+            var description: String {
+                return name
+            }
+        }
+
+        struct CustomError: Error, CustomStringConvertible, DiagnosticLocationProviding {
+            var location: String?
+            var diagnosticLocation: DiagnosticLocation? {
+                return location.flatMap{ BazLocation(name: $0) }
+            }
+            var description: String {
+                return "provided location is '\(location ?? "nil")'"
+            }
+        }
+
+        diagnostics.with(location: BazLocation(name: "elsewhere")) { diagnostics in
+            diagnostics.wrap {
+                throw CustomError(location: "somewhere")
+            }
+            diagnostics.wrap {
+                throw CustomError(location: nil)
+            }
+        }
+        
+        XCTAssertEqual(diagnostics.diagnostics.count, 2)
+        
+        let firstDiagnostic = try XCTUnwrap(diagnostics.diagnostics.first)
+        XCTAssertEqual(firstDiagnostic.location.description, "somewhere")
+        XCTAssertEqual(firstDiagnostic.description, "provided location is 'somewhere'")
+        XCTAssertEqual(firstDiagnostic.message.behavior, .error)
+        
+        let secondDiagnostic = try XCTUnwrap(diagnostics.diagnostics.last)
+        XCTAssertEqual(secondDiagnostic.location.description, "elsewhere")
+        XCTAssertEqual(secondDiagnostic.description, "provided location is 'nil'")
+        XCTAssertEqual(secondDiagnostic.message.behavior, .error)
+    }
+}


### PR DESCRIPTION
Add a way for specializations of DiagnosticsData and other emittable diagnostics (e.g. Swift.Errors) to provide custom DiagnosticLocations.