### PR TITLE
Lock Improvements for [SR-12851]

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -48,7 +48,9 @@ add_library(TSCBasic
   TerminalController.swift
   Thread.swift
   Tuple.swift
-  misc.swift)
+  misc.swift
+  WeakDictionary.swift)
+  
 target_compile_options(TSCBasic PUBLIC
   # Don't use GNU strerror_r on Android.
   "$<$<PLATFORM_ID:Android>:SHELL:-Xcc -U_GNU_SOURCE>"

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -40,44 +40,6 @@ public struct Lock {
     }
 }
 
-/// A lock that allows multiple readers but only one write at the same time.
-public class ReadWriteLock {
-    private var lock = pthread_rwlock_t()
-
-    /// Create a new lock.
-    public init() {
-        pthread_rwlock_init(&lock, nil)
-    }
-
-    func readLock() {
-        pthread_rwlock_rdlock(&lock)
-    }
-
-    func writeLock() {
-        pthread_rwlock_wrlock(&lock)
-    }
-
-    func unlock() {
-        pthread_rwlock_unlock(&lock)
-    }
-
-    /// Execute the given block while holding the lock.
-    public func withLock<T>(type lockType: LockType = .exclusive, _ body: () throws -> T) rethrows -> T {
-        switch lockType {
-        case .shared:
-            readLock()
-        case .exclusive:
-            writeLock()
-        }
-        defer { unlock() }
-        return try body()
-    }
-
-    deinit {
-        pthread_rwlock_destroy(&lock)
-    }
-}
-
 enum ProcessLockError: Swift.Error {
     case unableToAquireLock(errno: Int32)
 }

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -80,9 +80,9 @@ enum ProcessLockError: Swift.Error {
 public final class FileLock {
     /// File descriptor to the lock file.
   #if os(Windows)
-    private var handle: HANDLE?
+  @ThreadLocal @AutoClosing private var handle: HANDLE?
   #else
-    private var fileDescriptor: CInt?
+  @ThreadLocal @AutoClosing private var fileDescriptor: CInt?
   #endif
 
     /// Path to the lock file.
@@ -179,18 +179,8 @@ public final class FileLock {
         overlapped.hEvent = nil
         UnlockFileEx(handle, 0, DWORD(INT_MAX), DWORD(INT_MAX), &overlapped)
       #else
-        guard let fd = fileDescriptor else { return }
+      guard let fd = fileDescriptor else { return }
         flock(fd, LOCK_UN)
-      #endif
-    }
-
-    deinit {
-      #if os(Windows)
-        guard let handle = handle else { return }
-        CloseHandle(handle)
-      #else
-        guard let fd = fileDescriptor else { return }
-        close(fd)
       #endif
     }
 

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -72,29 +72,16 @@ public final class FileLock {
     public func lock(type: LockType = .exclusive) throws {
       #if os(Windows)
         if handle == nil {
-            let h = lockFile.pathString.withCString(encodedAs: UTF16.self, {
-                switch mode {
-                case .exclusive:
-                    CreateFileW(
-                        $0,
-                        UInt32(GENERIC_READ) | UInt32(GENERIC_WRITE),
-                        0,
-                        nil,
-                        DWORD(OPEN_ALWAYS),
-                        DWORD(FILE_ATTRIBUTE_NORMAL),
-                        nil
-                    )
-                case .shared:
-                    CreateFileW(
-                        $0,
-                        UInt32(GENERIC_READ) | UInt32(GENERIC_WRITE),
-                        DWORD(FILE_SHARE_READ),
-                        nil,
-                        DWORD(OPEN_ALWAYS),
-                        DWORD(FILE_ATTRIBUTE_NORMAL),
-                        nil
-                    )
-                }
+            let h: HANDLE = lockFile.pathString.withCString(encodedAs: UTF16.self, {
+                CreateFileW(
+                    $0,
+                    UInt32(GENERIC_READ) | UInt32(GENERIC_WRITE),
+                    UInt32(FILE_SHARE_READ) | UInt32(FILE_SHARE_WRITE),
+                    nil,
+                    DWORD(OPEN_ALWAYS),
+                    DWORD(FILE_ATTRIBUTE_NORMAL),
+                    nil
+                )
             })
             if h == INVALID_HANDLE_VALUE {
                 throw FileSystemError(errno: Int32(GetLastError()))
@@ -105,7 +92,7 @@ public final class FileLock {
         overlapped.Offset = 0
         overlapped.OffsetHigh = 0
         overlapped.hEvent = nil
-        switch mode {
+        switch type {
         case .exclusive:
             if !LockFileEx(handle, DWORD(LOCKFILE_EXCLUSIVE_LOCK), 0,
                            DWORD(INT_MAX), DWORD(INT_MAX), &overlapped) {

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -24,10 +24,18 @@ public struct Lock {
     public init() {
     }
 
+    func lock() {
+        _lock.lock()
+    }
+
+    func unlock() {
+        _lock.unlock()
+    }
+
     /// Execute the given block while holding the lock.
     public func withLock<T> (_ body: () throws -> T) rethrows -> T {
-        _lock.lock()
-        defer { _lock.unlock() }
+        lock()
+        defer { unlock() }
         return try body()
     }
 }

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -41,15 +41,27 @@ public class ReadWriteLock {
         pthread_rwlock_init(&lock, nil)
     }
 
+    func readLock() {
+        pthread_rwlock_rdlock(&lock)
+    }
+
+    func writeLock() {
+        pthread_rwlock_wrlock(&lock)
+    }
+
+    func unlock() {
+        pthread_rwlock_unlock(&lock)
+    }
+
     /// Execute the given block while holding the lock.
     public func withLock<T>(type lockType: LockType = .exclusive, _ body: () throws -> T) rethrows -> T {
         switch lockType {
         case .shared:
-            pthread_rwlock_rdlock(&lock)
+            readLock()
         case .exclusive:
-            pthread_rwlock_wrlock(&lock)
+            writeLock()
         }
-        defer { pthread_rwlock_unlock(&lock) }
+        defer { unlock() }
         return try body()
     }
 

--- a/Sources/TSCBasic/Thread.swift
+++ b/Sources/TSCBasic/Thread.swift
@@ -64,6 +64,15 @@ final public class Thread {
             }
         }
     }
+
+    /// Causes the calling thread to yield execution to another thread.
+    public static func yield() {
+        #if os(Windows)
+          SwitchToThread()
+        #else
+          sched_yield()
+        #endif
+    }
 }
 
 #if canImport(Darwin)

--- a/Sources/TSCBasic/Thread.swift
+++ b/Sources/TSCBasic/Thread.swift
@@ -9,6 +9,7 @@
 */
 
 import Foundation
+import TSCLibc
 
 /// This class bridges the gap between Darwin and Linux Foundation Threading API.
 /// It provides closure based execution and a join method to block the calling thread
@@ -94,3 +95,60 @@ final private class ThreadImpl: Foundation.Thread {
 // Thread on Linux supports closure so just use it directly.
 typealias ThreadImpl = Foundation.Thread
 #endif
+
+protocol Defaultable {
+    static var defaultValue: Self { get }
+}
+
+extension Optional: Defaultable {
+    static var defaultValue: Optional<Wrapped> { .none }
+}
+
+/// `ThreadLocal` properties are  thread-specific. Every thread has its own instance of the wrapped property.
+@propertyWrapper final class ThreadLocal<Value: Defaultable> {
+    private var storage: NSMutableDictionary { ThreadImpl.current.threadDictionary }
+    private let key = UUID().uuidString
+
+    var wrappedValue: Value {
+        get {
+            if let value = storage[key] as? Value {
+                return value
+            } else {
+                let value = Value.defaultValue
+                storage[key] = value
+                return value
+            }
+        }
+        set { storage[key] = newValue }
+    }
+
+    init(wrappedValue: Value) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+/// Automatically closes the wrapped file descriptor on deinit.
+@propertyWrapper final class AutoClosing: NSObject, Defaultable {
+    #if os(Windows)
+    typealias T = HANDLE
+    #else
+    typealias T = CInt
+    #endif
+    var wrappedValue: T?
+
+    static var defaultValue: AutoClosing { AutoClosing(wrappedValue: .none) }
+
+    init(wrappedValue: T?) {
+        self.wrappedValue = wrappedValue
+    }
+
+    deinit {
+        if let wrappedValue = wrappedValue {
+            #if os(Windows)
+              CloseHandle(wrappedValue)
+            #else
+              close(wrappedValue)
+            #endif
+        }
+    }
+}

--- a/Sources/TSCBasic/WeakDictionary.swift
+++ b/Sources/TSCBasic/WeakDictionary.swift
@@ -1,0 +1,28 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+/// A dictionary that only keeps weak references to its values.
+struct WeakDictionary<Key: Hashable, Value: AnyObject> {
+
+    private struct WeakReference<Value: AnyObject> {
+        weak var reference: Value?
+
+        init(_ value: Value?) {
+            self.reference = value
+        }
+    }
+
+    private var storage = Dictionary<Key, WeakReference<Value>>()
+
+    subscript(key: Key) -> Value? {
+        get { storage[key]?.reference }
+        set(newValue) { storage[key] = WeakReference(newValue) }
+    }
+}

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -602,6 +602,183 @@ class FileSystemTests: XCTestCase {
         }
       #endif
     }
+
+    func testInMemoryFileSystemFileLock() throws {
+        let fs = InMemoryFileSystem()
+        let path = AbsolutePath("/")
+        try fs.createDirectory(path)
+
+        let fileA = path.appending(component: "fileA")
+        let fileB = path.appending(component: "fileB")
+        let lockFile = path.appending(component: "lockfile")
+
+        let writerThreads = (0..<100).map { _ in
+            return Thread {
+                try! fs.withLock(on: lockFile, type: .exclusive) {
+                    // Get thr current contents of the file if any.
+                    let valueA: Int
+                    if fs.exists(fileA) {
+                        valueA = Int(try fs.readFileContents(fileA).description) ?? 0
+                    } else {
+                        valueA = 0
+                    }
+                    // Sum and write back to file.
+                    try fs.writeFileContents(fileA, bytes: ByteString(encodingAsUTF8: String(valueA + 1)))
+
+                    Thread.yield()
+
+                    // Get thr current contents of the file if any.
+                    let valueB: Int
+                    if fs.exists(fileB) {
+                        valueB = Int(try fs.readFileContents(fileB).description) ?? 0
+                    } else {
+                        valueB = 0
+                    }
+                    // Sum and write back to file.
+                    try fs.writeFileContents(fileB, bytes: ByteString(encodingAsUTF8: String(valueB + 1)))
+                }
+            }
+        }
+
+        let readerThreads = (0..<20).map { _ in
+            return Thread {
+                try! fs.withLock(on: lockFile, type: .shared) {
+                    try XCTAssertEqual(fs.readFileContents(fileA), fs.readFileContents(fileB))
+
+                    Thread.yield()
+
+                    try XCTAssertEqual(fs.readFileContents(fileA), fs.readFileContents(fileB))
+                }
+            }
+        }
+
+        writerThreads.forEach { $0.start() }
+        readerThreads.forEach { $0.start() }
+        writerThreads.forEach { $0.join() }
+        readerThreads.forEach { $0.join() }
+
+        try XCTAssertEqual(fs.readFileContents(fileA), "100")
+        try XCTAssertEqual(fs.readFileContents(fileB), "100")
+    }
+
+    func testLocalFileSystemFileLock() throws {
+        try withTemporaryDirectory { tempDir in
+            let fileA = tempDir.appending(component: "fileA")
+            let fileB = tempDir.appending(component: "fileB")
+            let lockFile = tempDir.appending(component: "lockfile")
+
+            let writerThreads = (0..<100).map { _ in
+                return Thread {
+                    try! localFileSystem.withLock(on: lockFile, type: .exclusive) {
+                        // Get thr current contents of the file if any.
+                        let valueA: Int
+                        if localFileSystem.exists(fileA) {
+                            valueA = Int(try localFileSystem.readFileContents(fileA).description) ?? 0
+                        } else {
+                            valueA = 0
+                        }
+                        // Sum and write back to file.
+                        try localFileSystem.writeFileContents(fileA, bytes: ByteString(encodingAsUTF8: String(valueA + 1)))
+
+                        Thread.yield()
+
+                        // Get thr current contents of the file if any.
+                        let valueB: Int
+                        if localFileSystem.exists(fileB) {
+                            valueB = Int(try localFileSystem.readFileContents(fileB).description) ?? 0
+                        } else {
+                            valueB = 0
+                        }
+                        // Sum and write back to file.
+                        try localFileSystem.writeFileContents(fileB, bytes: ByteString(encodingAsUTF8: String(valueB + 1)))
+                    }
+                }
+            }
+
+            let readerThreads = (0..<20).map { _ in
+                return Thread {
+                    try! localFileSystem.withLock(on: lockFile, type: .shared) {
+                        try XCTAssertEqual(localFileSystem.readFileContents(fileA), localFileSystem.readFileContents(fileB))
+
+                        Thread.yield()
+
+                        try XCTAssertEqual(localFileSystem.readFileContents(fileA), localFileSystem.readFileContents(fileB))
+                    }
+                }
+            }
+
+            writerThreads.forEach { $0.start() }
+            readerThreads.forEach { $0.start() }
+            writerThreads.forEach { $0.join() }
+            readerThreads.forEach { $0.join() }
+
+            try XCTAssertEqual(localFileSystem.readFileContents(fileA), "100")
+            try XCTAssertEqual(localFileSystem.readFileContents(fileB), "100")
+        }
+    }
+
+    func testRerootedFileSystemViewFileLock() throws {
+        let inMemoryFS = InMemoryFileSystem()
+        let rootPath = AbsolutePath("/tmp")
+        try inMemoryFS.createDirectory(rootPath)
+
+        let fs = RerootedFileSystemView(inMemoryFS, rootedAt: rootPath)
+        let path = AbsolutePath("/")
+        try fs.createDirectory(path)
+
+        let fileA = path.appending(component: "fileA")
+        let fileB = path.appending(component: "fileB")
+        let lockFile = path.appending(component: "lockfile")
+
+        let writerThreads = (0..<100).map { _ in
+            return Thread {
+                try! fs.withLock(on: lockFile, type: .exclusive) {
+                    // Get thr current contents of the file if any.
+                    let valueA: Int
+                    if fs.exists(fileA) {
+                        valueA = Int(try! fs.readFileContents(fileA).description) ?? 0
+                    } else {
+                        valueA = 0
+                    }
+                    // Sum and write back to file.
+                    try! fs.writeFileContents(fileA, bytes: ByteString(encodingAsUTF8: String(valueA + 1)))
+
+                    Thread.yield()
+
+                    // Get thr current contents of the file if any.
+                    let valueB: Int
+                    if fs.exists(fileB) {
+                        valueB = Int(try fs.readFileContents(fileB).description) ?? 0
+                    } else {
+                        valueB = 0
+                    }
+                    // Sum and write back to file.
+                    try fs.writeFileContents(fileB, bytes: ByteString(encodingAsUTF8: String(valueB + 1)))
+                }
+            }
+        }
+
+        let readerThreads = (0..<20).map { _ in
+            return Thread {
+                try! fs.withLock(on: lockFile, type: .shared) {
+                    try XCTAssertEqual(fs.readFileContents(fileA), fs.readFileContents(fileB))
+
+                    Thread.yield()
+
+                    try XCTAssertEqual(fs.readFileContents(fileA), fs.readFileContents(fileB))
+                }
+            }
+        }
+
+        writerThreads.forEach { $0.start() }
+        readerThreads.forEach { $0.start() }
+        writerThreads.forEach { $0.join() }
+        readerThreads.forEach { $0.join() }
+
+        try XCTAssertEqual(fs.readFileContents(fileA), "100")
+        try XCTAssertEqual(fs.readFileContents(fileB), "100")
+    }
+
 }
 
 /// Helper method to test file tree removal method on the given file system.

--- a/Tests/TSCBasicTests/LockTests.swift
+++ b/Tests/TSCBasicTests/LockTests.swift
@@ -49,38 +49,6 @@ class LockTests: XCTestCase {
         }
     }
 
-    func testReadWriteLock() throws {
-        var a = 0
-        var b = 0
-
-        let lock = ReadWriteLock()
-
-        let writerThreads = (0..<100).map { _ in
-           return Thread {
-                lock.withLock(type: .exclusive) {
-                    a+=1
-                    sched_yield()
-                    b+=1
-                }
-            }
-        }
-
-        let readerThreads = (0..<20).map { _ in
-            return Thread {
-                lock.withLock(type: .shared) {
-                    XCTAssertEqual(a,b)
-                    sched_yield()
-                    XCTAssertEqual(a,b)
-                }
-            }
-        }
-
-        writerThreads.forEach { $0.start() }
-        readerThreads.forEach { $0.start() }
-        writerThreads.forEach { $0.join() }
-        readerThreads.forEach { $0.join() }
-    }
-
     func testReadWriteFileLock() throws {
         try withTemporaryDirectory { tempDir in
             let fileA = tempDir.appending(component: "fileA")

--- a/Tests/TSCBasicTests/LockTests.swift
+++ b/Tests/TSCBasicTests/LockTests.swift
@@ -81,4 +81,63 @@ class LockTests: XCTestCase {
         readerThreads.forEach { $0.join() }
     }
 
+    func testReadWriteFileLock() throws {
+        try withTemporaryDirectory { tempDir in
+            let fileA = tempDir.appending(component: "fileA")
+            let fileB = tempDir.appending(component: "fileB")
+
+            let lock = FileLock(name: "lockfile", cachePath: tempDir)
+
+            let writerThreads = (0..<100).map { _ in
+                return Thread {
+                    let lock = FileLock(name: "foo", cachePath: tempDir)
+                    try! lock.withLock(type: .exclusive) {
+                        // Get thr current contents of the file if any.
+                        let valueA: Int
+                        if localFileSystem.exists(fileA) {
+                            valueA = Int(try localFileSystem.readFileContents(fileA).description) ?? 0
+                        } else {
+                            valueA = 0
+                        }
+                        // Sum and write back to file.
+                        try localFileSystem.writeFileContents(fileA, bytes: ByteString(encodingAsUTF8: String(valueA + 1)))
+
+                        Thread.yield()
+
+                        // Get thr current contents of the file if any.
+                        let valueB: Int
+                        if localFileSystem.exists(fileB) {
+                            valueB = Int(try localFileSystem.readFileContents(fileB).description) ?? 0
+                        } else {
+                            valueB = 0
+                        }
+                        // Sum and write back to file.
+                        try localFileSystem.writeFileContents(fileB, bytes: ByteString(encodingAsUTF8: String(valueB + 1)))
+                    }
+                }
+            }
+
+            let readerThreads = (0..<20).map { _ in
+                return Thread {
+                    let lock = FileLock(name: "foo", cachePath: tempDir)
+                    try! lock.withLock(type: .shared) {
+                        try XCTAssertEqual( localFileSystem.readFileContents(fileA), localFileSystem.readFileContents(fileB))
+
+                        Thread.yield()
+
+                        try XCTAssertEqual( localFileSystem.readFileContents(fileA), localFileSystem.readFileContents(fileB))
+                    }
+                }
+            }
+
+            writerThreads.forEach { $0.start() }
+            readerThreads.forEach { $0.start() }
+            writerThreads.forEach { $0.join() }
+            readerThreads.forEach { $0.join() }
+
+            try XCTAssertEqual(localFileSystem.readFileContents(fileA), "100")
+            try XCTAssertEqual(localFileSystem.readFileContents(fileB), "100")
+        }
+    }
+
 }

--- a/Tests/TSCBasicTests/LockTests.swift
+++ b/Tests/TSCBasicTests/LockTests.swift
@@ -90,7 +90,6 @@ class LockTests: XCTestCase {
 
             let writerThreads = (0..<100).map { _ in
                 return Thread {
-                    let lock = FileLock(name: "foo", cachePath: tempDir)
                     try! lock.withLock(type: .exclusive) {
                         // Get thr current contents of the file if any.
                         let valueA: Int
@@ -119,13 +118,12 @@ class LockTests: XCTestCase {
 
             let readerThreads = (0..<20).map { _ in
                 return Thread {
-                    let lock = FileLock(name: "foo", cachePath: tempDir)
                     try! lock.withLock(type: .shared) {
-                        try XCTAssertEqual( localFileSystem.readFileContents(fileA), localFileSystem.readFileContents(fileB))
+                        try XCTAssertEqual(localFileSystem.readFileContents(fileA), localFileSystem.readFileContents(fileB))
 
                         Thread.yield()
 
-                        try XCTAssertEqual( localFileSystem.readFileContents(fileA), localFileSystem.readFileContents(fileB))
+                        try XCTAssertEqual(localFileSystem.readFileContents(fileA), localFileSystem.readFileContents(fileB))
                     }
                 }
             }


### PR DESCRIPTION
This PR contains the following improvements to locks needed for [SR-12851](https://github.com/apple/swift-package-manager/pull/2835).

~~1. Added `ReadWriteLock`.~~ (Using GCD instead for windows compatiblity)
2. Added property wrapper @ThreadLocal to address an issue where `FileLock` could be used in way that would unlock/lock the lock from another thread without the user realizing. --> Making `FileLock` thread safe
3. Enabled `FileLock` to obtain an exclusive or a shared lock.