### PR TITLE
TSCBasic: more special case handling for Windows paths

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -133,7 +133,11 @@ public struct AbsolutePath: Hashable {
 
     /// True if the path is the root directory.
     public var isRoot: Bool {
+#if os(Windows)
+        return _impl.string.withCString(encodedAs: UTF16.self, PathIsRootW)
+#else
         return _impl == PathImpl.root
+#endif
     }
 
     /// Returns the absolute path with the relative path applied.


### PR DESCRIPTION
There is no one canonical root on Windows.  Windows contains a forest of
paths, rooted at a drive (`[A-Z]:\\`), a NT Path `\\??\`, or a UNC path,
`\\UNC\` or `\\`.  Avoid the check against a canonical root on Windows.
This is required for `swift package init` to function.