### PR TITLE
Disable some tests for which dependencies are not available in Windows

### DIFF
--- a/Tests/TSCBasicTests/ProcessSetTests.swift
+++ b/Tests/TSCBasicTests/ProcessSetTests.swift
@@ -15,6 +15,7 @@ import TSCUtility
 import TSCTestSupport
 
 class ProcessSetTests: XCTestCase {
+  #if !os(Windows) // Signals are not supported in Windows
     func script(_ name: String) -> String {
         return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).pathString
     }
@@ -75,4 +76,5 @@ class ProcessSetTests: XCTestCase {
 
         t.join()
     }
+  #endif
 }

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -113,6 +113,7 @@ class ProcessTests: XCTestCase {
         }
     }
 
+  #if !os(Windows) // Signals are not supported in Windows
     func testSignals() throws {
 
         // Test sigint terminates the script.
@@ -161,6 +162,7 @@ class ProcessTests: XCTestCase {
             XCTAssertFalse(try Process.running(ProcessID(child), orDefunct: true))
         }
     }
+  #endif
 
     func testThreadSafetyOnWaitUntilExit() throws {
         let process = Process(args: "echo", "hello")

--- a/Tests/TSCBasicTests/TerminalControllerTests.swift
+++ b/Tests/TSCBasicTests/TerminalControllerTests.swift
@@ -14,6 +14,7 @@ import TSCLibc
 import TSCBasic
 
 final class TerminalControllerTests: XCTestCase {
+  #if !os(Windows) // PseudoTerminal is not supported in Windows
     func testBasic() {
         guard let pty = PseudoTerminal(), let term = TerminalController(stream: pty.outStream) else {
             XCTFail("Couldn't create pseudo terminal.")
@@ -44,4 +45,5 @@ final class TerminalControllerTests: XCTestCase {
         XCTAssertEqual(wrapped, "\u{001B}[32mgreen\u{001B}[0m")
         pty.close()
     }
+  #endif
 }

--- a/Tests/TSCUtilityTests/ProgressAnimationTests.swift
+++ b/Tests/TSCUtilityTests/ProgressAnimationTests.swift
@@ -40,18 +40,6 @@ final class ProgressAnimationTests: XCTestCase {
         XCTAssertEqual(outStream.bytes.validDescription, "")
     }
 
-    func testPercentProgressAnimationTTY() throws {
-        let output = try readingTTY { tty in
-            let animation = PercentProgressAnimation(stream: tty.outStream, header: "TestHeader")
-            runProgressAnimation(animation)
-        }
-
-        let startCyan = "\u{1B}[36m"
-        let bold = "\u{1B}[1m"
-        let end = "\u{1B}[0m"
-        XCTAssertMatch(output.spm_chuzzle(), .prefix("\(startCyan)\(bold)TestHeader\(end)"))
-    }
-
     func testNinjaProgressAnimationDumbTerminal() {
         var outStream = BufferedOutputByteStream()
         var animation = NinjaProgressAnimation(stream: outStream)
@@ -72,6 +60,19 @@ final class ProgressAnimationTests: XCTestCase {
 
         animation.complete(success: true)
         XCTAssertEqual(outStream.bytes.validDescription, "")
+    }
+
+  #if !os(Windows) // PseudoTerminal is not supported in Windows
+    func testPercentProgressAnimationTTY() throws {
+        let output = try readingTTY { tty in
+            let animation = PercentProgressAnimation(stream: tty.outStream, header: "TestHeader")
+            runProgressAnimation(animation)
+        }
+
+        let startCyan = "\u{1B}[36m"
+        let bold = "\u{1B}[1m"
+        let end = "\u{1B}[0m"
+        XCTAssertMatch(output.spm_chuzzle(), .prefix("\(startCyan)\(bold)TestHeader\(end)"))
     }
 
     func testNinjaProgressAnimationTTY() throws {
@@ -122,6 +123,7 @@ final class ProgressAnimationTests: XCTestCase {
 
         return output
     }
+  #endif
 
     private func runProgressAnimation(_ animation: ProgressAnimationProtocol) {
         for i in 0...5 {


### PR DESCRIPTION
This allows building the test suite on Windows.