### PR TITLE
TSCBasic: always report a dumb terminal on Windows

### DIFF
--- a/Sources/TSCBasic/TerminalController.swift
+++ b/Sources/TSCBasic/TerminalController.swift
@@ -110,7 +110,7 @@ public final class TerminalController {
     /// Computes the terminal type of the stream.
     public static func terminalType(_ stream: LocalFileOutputByteStream) -> TerminalType {
 #if os(Windows)
-        return _isatty(_fileno(stream.filePointer)) == 0 ? .file : .tty
+        return _isatty(_fileno(stream.filePointer)) == 0 ? .file : .dumb
 #else
         if ProcessEnv.vars["TERM"] == "dumb" {
             return .dumb


### PR DESCRIPTION
Although Windows Terminal should provide a proper tty, for now, always
report a dumb terminal.  This repairs the rendering of C/C++
diagnostics.

Thanks to @albertelrud for the amazing pointer on what it may be!