### PR TITLE
TSCBasic: improve prefix check for Windows

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -134,7 +134,7 @@ public struct AbsolutePath: Hashable {
     /// True if the path is the root directory.
     public var isRoot: Bool {
 #if os(Windows)
-        return _impl.string.withCString(encodedAs: UTF16.self, PathIsRootW)
+        return _impl.string.withCString(encodedAs: UTF16.self, PathCchIsRoot)
 #else
         return _impl == PathImpl.root
 #endif


### PR DESCRIPTION
Change the function we use to check for the root path to ensure that we
can properly handle NT paths and UNC paths.