### PR TITLE
build: allow building with Foundation from the toolchain

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -57,8 +57,10 @@ target_compile_options(TSCBasic PUBLIC
 target_link_libraries(TSCBasic PUBLIC
   TSCLibc)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(TSCBasic PUBLIC
-    Foundation)
+  if(Foundation_FOUND)
+    target_link_libraries(TSCBasic PUBLIC
+      Foundation)
+  endif()
 endif()
 target_link_libraries(TSCBasic PRIVATE
   $<$<PLATFORM_ID:Windows>:Pathcch>)

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -48,8 +48,10 @@ target_link_libraries(TSCUtility PUBLIC
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(TSCUtility PRIVATE
     SQLite::SQLite3)
-  target_link_libraries(TSCUtility PUBLIC
-    FoundationNetworking)
+  if(Foundation_FOUND)
+    target_link_libraries(TSCUtility PUBLIC
+      FoundationNetworking)
+  endif()
 endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCUtility PROPERTIES


### PR DESCRIPTION
This is meant to be used to build the Windows toolchain which uses a
staged build where Foundation is not built and used from the build root.