### PR TITLE
Revert "build: allow building with Foundation from the toolchain"

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -57,10 +57,8 @@ target_compile_options(TSCBasic PUBLIC
 target_link_libraries(TSCBasic PUBLIC
   TSCLibc)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(Foundation_FOUND)
-    target_link_libraries(TSCBasic PUBLIC
-      Foundation)
-  endif()
+  target_link_libraries(TSCBasic PUBLIC
+    Foundation)
 endif()
 target_link_libraries(TSCBasic PRIVATE
   $<$<PLATFORM_ID:Windows>:Pathcch>)

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -48,10 +48,8 @@ target_link_libraries(TSCUtility PUBLIC
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(TSCUtility PRIVATE
     SQLite::SQLite3)
-  if(Foundation_FOUND)
-    target_link_libraries(TSCUtility PUBLIC
-      FoundationNetworking)
-  endif()
+  target_link_libraries(TSCUtility PUBLIC
+    FoundationNetworking)
 endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCUtility PROPERTIES


### PR DESCRIPTION
Reverts apple/swift-tools-support-core#141, as I suspect it broke TSC tests on Linux.

TSC tests last passed at 11:33 ~~pm~~ am; then we have a couple builds that fail earlier while trying to build the Swift runtime. Starting at 1:55 pm, TSC tests on Linux begin [failing or timing out with many "read error: Bad file descriptor (9)" and "close error: Unknown error -1" messages](https://ci.swift.org/job/swift-PR-Linux-smoke-test/25345/console).

I'm not sure how #141 could have caused these symptoms, but it entered the build during this timeframe and it could have an effect on Linux, and I can't figure out how `Foundation_FOUND` would be set.