### PR TITLE
TSCBasic: correct `resolveSymlink` on Windows

### DIFF
--- a/Sources/TSCBasic/PathShims.swift
+++ b/Sources/TSCBasic/PathShims.swift
@@ -23,12 +23,12 @@ import Foundation
 /// Returns the "real path" corresponding to `path` by resolving any symbolic links.
 public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
 #if os(Windows)
-    let resolved: String =
-        (try? FileManager.default.destinationOfSymbolicLink(atPath: path.pathString))
-            ?? path.pathString
+    var resolved: URL = URL(fileURLWithPath: path.pathString)
+    if let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: path.pathString) {
+        resolved = URL(fileURLWithPath: destination, relativeTo: URL(fileURLWithPath: path.pathString))
+    }
 
-    return URL(fileURLWithPath: resolved.standardizingPath)
-              .withUnsafeFileSystemRepresentation {
+    return resolved.standardized.withUnsafeFileSystemRepresentation {
         try! AbsolutePath(validating: String(cString: $0!))
     }
 #else


### PR DESCRIPTION
This would fail to properly resolve the symbolic links on Windows since
the result of the resolution would be a path relative to the location of
the original path.  However, we would instead treat the path as the
absolute path.  Correct this which is required to resolve modulemaps
inside of directories with symbolic links.

This was found by building IndexStoreDB on Windows with SwiftPM.