### PR TITLE
Introduce a new visitor-based API for reading LLVM bitstreams

### DIFF
--- a/Sources/TSCUtility/Bits.swift
+++ b/Sources/TSCUtility/Bits.swift
@@ -84,6 +84,15 @@ struct Bits: RandomAccessCollection {
       return buffer.buffer.dropFirst(offset >> 3).prefix((newOffset - offset) >> 3)
     }
 
+    mutating func skip(bytes count: Int) throws {
+      precondition(count >= 0)
+      precondition(offset & 0b111 == 0)
+      let newOffset = offset &+ (count << 3)
+      precondition(newOffset >= offset)
+      if newOffset > buffer.count { throw Error.bufferOverflow }
+      offset = newOffset
+    }
+
     mutating func advance(toBitAlignment align: Int) throws {
       precondition(align > 0)
       precondition(offset &+ (align&-1) >= offset)

--- a/Sources/TSCUtility/Bitstream.swift
+++ b/Sources/TSCUtility/Bitstream.swift
@@ -10,43 +10,43 @@
 
 import Foundation
 
-enum BitcodeElement {
-  struct Block {
-    var id: UInt64
-    var elements: [BitcodeElement]
+public enum BitcodeElement {
+  public struct Block {
+    public var id: UInt64
+    public var elements: [BitcodeElement]
   }
 
-  struct Record {
-    enum Payload {
+  public struct Record {
+    public enum Payload {
       case none
       case array([UInt64])
       case char6String(String)
       case blob(Data)
     }
 
-    var id: UInt64
-    var fields: [UInt64]
-    var payload: Payload
+    public var id: UInt64
+    public var fields: [UInt64]
+    public var payload: Payload
   }
 
   case block(Block)
   case record(Record)
 }
 
-struct BlockInfo {
-  var name: String = ""
-  var recordNames: [UInt64: String] = [:]
+public struct BlockInfo {
+  public var name: String = ""
+  public var recordNames: [UInt64: String] = [:]
 }
 
 extension Bitcode {
-  struct Signature: Equatable {
+  public struct Signature: Equatable {
     private var value: UInt32
 
-    init(value: UInt32) {
+    public init(value: UInt32) {
       self.value = value
     }
 
-    init(string: String) {
+    public init(string: String) {
       precondition(string.utf8.count == 4)
       var result: UInt32 = 0
       for byte in string.utf8.reversed() {
@@ -58,10 +58,10 @@ extension Bitcode {
   }
 }
 
-struct Bitcode {
-  let signature: Signature
-  let elements: [BitcodeElement]
-  let blockInfo: [UInt64: BlockInfo]
+public struct Bitcode {
+  public let signature: Signature
+  public let elements: [BitcodeElement]
+  public let blockInfo: [UInt64: BlockInfo]
 }
 
 private extension Bits.Cursor {
@@ -297,22 +297,22 @@ private struct BitstreamReader {
     }
   }
 
-  mutating func readBlock(id: UInt64, abbrevWidth: Int, abbrevInfo: [Abbrev]) throws -> [BitcodeElement] {
+  mutating func readBlock<Visitor: BitstreamVisitor>(id: UInt64, abbrevWidth: Int, abbrevInfo: [Abbrev], visitor: inout Visitor) throws {
     var abbrevInfo = abbrevInfo
-    var elements = [BitcodeElement]()
 
     while !cursor.isAtEnd {
       switch try cursor.read(abbrevWidth) {
       case 0: // END_BLOCK
         try cursor.advance(toBitAlignment: 32)
         // FIXME: check expected length
-        return elements
+        try visitor.didExitBlock()
+        return
 
       case 1: // ENTER_SUBBLOCK
         let blockID = try cursor.readVBR(8)
         let newAbbrevWidth = Int(try cursor.readVBR(4))
         try cursor.advance(toBitAlignment: 32)
-        _ = try cursor.read(32) // FIXME: use expected length
+        let blockLength = try cursor.read(32) * 4
 
         switch blockID {
         case 0:
@@ -321,9 +321,13 @@ private struct BitstreamReader {
           // Metadata blocks we don't understand yet
           fallthrough
         default:
-          let innerElements = try readBlock(
-            id: blockID, abbrevWidth: newAbbrevWidth, abbrevInfo: globalAbbrevs[blockID] ?? [])
-          elements.append(.block(.init(id: blockID, elements: innerElements)))
+          guard try visitor.shouldEnterBlock(id: blockID) else {
+            try cursor.skip(bytes: Int(blockLength))
+            break
+          }
+          try readBlock(
+            id: blockID, abbrevWidth: newAbbrevWidth,
+            abbrevInfo: globalAbbrevs[blockID] ?? [], visitor: &visitor)
         }
 
       case 2: // DEFINE_ABBREV
@@ -337,33 +341,88 @@ private struct BitstreamReader {
         for _ in 0..<numOps {
           operands.append(try cursor.readVBR(6))
         }
-        elements.append(.record(.init(id: code, fields: operands, payload: .none)))
+        try visitor.visit(record: .init(id: code, fields: operands, payload: .none))
 
       case let abbrevID:
         guard Int(abbrevID) - 4 < abbrevInfo.count else {
           throw Error.noSuchAbbrev(blockID: id, abbrevID: Int(abbrevID))
         }
-        elements.append(.record(try readAbbreviatedRecord(abbrevInfo[Int(abbrevID) - 4])))
+        try visitor.visit(record: try readAbbreviatedRecord(abbrevInfo[Int(abbrevID) - 4]))
       }
     }
 
     guard id == Self.fakeTopLevelBlockID else {
       throw Error.missingEndBlock(blockID: id)
     }
-    return elements
   }
 
   static let fakeTopLevelBlockID: UInt64 = ~0
 }
 
+public protocol BitstreamVisitor {
+  func validate(signature: Bitcode.Signature) throws
+  mutating func shouldEnterBlock(id: UInt64) throws -> Bool
+  mutating func didExitBlock() throws
+  mutating func visit(record: BitcodeElement.Record) throws
+}
+
+/// A basic visitor that collects all the blocks and records in a stream.
+private struct CollectingVisitor: BitstreamVisitor {
+  var stack: [(UInt64, [BitcodeElement])] = [(BitstreamReader.fakeTopLevelBlockID, [])]
+
+  func validate(signature: Bitcode.Signature) throws {}
+
+  mutating func shouldEnterBlock(id: UInt64) throws -> Bool {
+    stack.append((id, []))
+    return true
+  }
+
+  mutating func didExitBlock() throws {
+    guard let (id, elements) = stack.popLast() else {
+      fatalError("Unbalanced calls to shouldEnterBlock/didExitBlock")
+    }
+
+    let block = BitcodeElement.Block(id: id, elements: elements)
+    stack[stack.endIndex-1].1.append(.block(block))
+  }
+
+  mutating func visit(record: BitcodeElement.Record) throws {
+    stack[stack.endIndex-1].1.append(.record(record))
+  }
+
+  func finalizeTopLevelElements() -> [BitcodeElement] {
+    assert(stack.count == 1)
+    return stack[0].1
+  }
+}
+
 extension Bitcode {
-  init(data: Data) throws {
+  public init(data: Data) throws {
     precondition(data.count > 4)
     let signatureValue = UInt32(Bits(buffer: data).readBits(atOffset: 0, count: 32))
     let bitstreamData = data[4..<data.count]
 
     var reader = BitstreamReader(buffer: bitstreamData)
-    let topLevelElements = try reader.readBlock(id: BitstreamReader.fakeTopLevelBlockID, abbrevWidth: 2, abbrevInfo: [])
-    self.init(signature: .init(value: signatureValue), elements: topLevelElements, blockInfo: reader.blockInfo)
+    var visitor = CollectingVisitor()
+    try reader.readBlock(id: BitstreamReader.fakeTopLevelBlockID,
+                         abbrevWidth: 2,
+                         abbrevInfo: [],
+                         visitor: &visitor)
+    self.init(signature: .init(value: signatureValue),
+              elements: visitor.finalizeTopLevelElements(),
+              blockInfo: reader.blockInfo)
+  }
+
+  public static func read<Visitor: BitstreamVisitor>(stream data: Data, using visitor: inout Visitor) throws {
+    precondition(data.count > 4)
+    let signatureValue = UInt32(Bits(buffer: data).readBits(atOffset: 0, count: 32))
+    try visitor.validate(signature: .init(value: signatureValue))
+
+    let bitstreamData = data[4..<data.count]
+    var reader = BitstreamReader(buffer: bitstreamData)
+    try reader.readBlock(id: BitstreamReader.fakeTopLevelBlockID,
+                         abbrevWidth: 2,
+                         abbrevInfo: [],
+                         visitor: &visitor)
   }
 }

--- a/Tests/TSCUtilityTests/BitstreamTests.swift
+++ b/Tests/TSCUtilityTests/BitstreamTests.swift
@@ -1,0 +1,186 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+import TSCBasic
+import TSCUtility
+import XCTest
+
+final class BitstreamTests: XCTestCase {
+    func testBitstreamVisitor() throws {
+        struct LoggingVisitor: BitstreamVisitor {
+            var log: [String] = []
+
+            func validate(signature: Bitcode.Signature) throws {}
+
+            mutating func shouldEnterBlock(id: UInt64) throws -> Bool {
+                log.append("entering block: \(id)")
+                return true
+            }
+
+            mutating func didExitBlock() throws {
+                log.append("exiting block")
+            }
+
+            mutating func visit(record: BitcodeElement.Record) throws {
+                log.append("Record (id: \(record.id), fields: \(record.fields), payload: \(record.payload)")
+            }
+        }
+
+        let bitstreamPath = AbsolutePath(#file).parentDirectory
+            .appending(components: "Inputs", "serialized.dia")
+        let contents = try localFileSystem.readFileContents(bitstreamPath)
+        var visitor = LoggingVisitor()
+        try Bitcode.read(stream: Data(contents.contents), using: &visitor)
+        XCTAssertEqual(visitor.log, [
+            "entering block: 8",
+            "Record (id: 1, fields: [1], payload: none",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 6, fields: [1, 0, 0, 100], payload: blob(100 bytes)",
+            "Record (id: 2, fields: [3, 1, 53, 28, 0, 0, 0, 34], payload: blob(34 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 1, 53, 28, 0, 0, 0, 59], payload: blob(59 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 1, 113, 1, 0, 0, 0, 38], payload: blob(38 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 1, 113, 1, 0, 0, 0, 20], payload: blob(20 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 6, fields: [2, 0, 0, 98], payload: blob(98 bytes)",
+            "Record (id: 2, fields: [3, 2, 21, 69, 0, 0, 0, 34], payload: blob(34 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 2, 21, 69, 0, 0, 0, 22], payload: blob(22 bytes)",
+            "Record (id: 7, fields: [2, 21, 69, 0, 2, 21, 69, 0, 1], payload: blob(1 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 2, 21, 69, 0, 0, 0, 42], payload: blob(42 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 2, 21, 69, 0, 0, 0, 22], payload: blob(22 bytes)",
+            "Record (id: 7, fields: [2, 21, 69, 0, 2, 21, 69, 0, 1], payload: blob(1 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 6, fields: [3, 0, 0, 84], payload: blob(84 bytes)",
+            "Record (id: 2, fields: [3, 3, 38, 28, 0, 0, 0, 34], payload: blob(34 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 3, 38, 28, 0, 0, 0, 59], payload: blob(59 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 3, 66, 1, 0, 0, 0, 38], payload: blob(38 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 3, 66, 1, 0, 0, 0, 20], payload: blob(20 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 6, fields: [4, 0, 0, 93], payload: blob(93 bytes)",
+            "Record (id: 2, fields: [3, 4, 15, 46, 0, 0, 0, 40], payload: blob(40 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 4, 15, 46, 0, 0, 0, 22], payload: blob(22 bytes)",
+            "Record (id: 7, fields: [4, 15, 46, 0, 4, 15, 46, 0, 1], payload: blob(1 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 4, 15, 46, 0, 0, 0, 42], payload: blob(42 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 2, fields: [3, 4, 15, 46, 0, 0, 0, 22], payload: blob(22 bytes)",
+            "Record (id: 7, fields: [4, 15, 46, 0, 4, 15, 46, 0, 1], payload: blob(1 bytes)",
+            "exiting block",
+            "entering block: 9",
+            "Record (id: 6, fields: [5, 0, 0, 72], payload: blob(72 bytes)",
+            "Record (id: 2, fields: [3, 5, 34, 13, 0, 0, 0, 44], payload: blob(44 bytes)",
+            "Record (id: 3, fields: [5, 34, 13, 0, 5, 34, 26, 0], payload: none",
+            "exiting block"
+        ])
+    }
+
+    func testReadSkippingBlocks() throws {
+        struct LoggingVisitor: BitstreamVisitor {
+            var log: [String] = []
+
+            func validate(signature: Bitcode.Signature) throws {}
+
+            mutating func shouldEnterBlock(id: UInt64) throws -> Bool {
+                log.append("skipping block: \(id)")
+                return false
+            }
+
+            mutating func didExitBlock() throws {
+                log.append("exiting block")
+            }
+
+            mutating func visit(record: BitcodeElement.Record) throws {
+                log.append("visiting record")
+            }
+        }
+
+        let bitstreamPath = AbsolutePath(#file).parentDirectory
+            .appending(components: "Inputs", "serialized.dia")
+        let contents = try localFileSystem.readFileContents(bitstreamPath)
+        var visitor = LoggingVisitor()
+        try Bitcode.read(stream: Data(contents.contents), using: &visitor)
+        XCTAssertEqual(visitor.log, ["skipping block: 8",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9",
+                                     "skipping block: 9"])
+    }
+
+    func testStandardInit() throws {
+        let bitstreamPath = AbsolutePath(#file).parentDirectory
+            .appending(components: "Inputs", "serialized.dia")
+        let contents = try localFileSystem.readFileContents(bitstreamPath)
+        let bitcode = try Bitcode(data: Data(contents.contents))
+        XCTAssertEqual(bitcode.signature, .init(string: "DIAG"))
+        XCTAssertEqual(bitcode.elements.count, 18)
+        guard case .block(let metadataBlock) = bitcode.elements.first else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(metadataBlock.id, 8)
+        XCTAssertEqual(metadataBlock.elements.count, 1)
+        guard case .record(let versionRecord) = metadataBlock.elements[0] else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(versionRecord.id, 1)
+        XCTAssertEqual(versionRecord.fields, [1])
+        guard case .block(let lastBlock) = bitcode.elements.last else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(lastBlock.id, 9)
+        XCTAssertEqual(lastBlock.elements.count, 3)
+        guard case .record(let lastRecord) = lastBlock.elements[2] else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(lastRecord.id, 3)
+        XCTAssertEqual(lastRecord.fields, [5, 34, 13, 0, 5, 34, 26, 0])
+    }
+}


### PR DESCRIPTION
This gives clients more manual control over the decoding process. It will allow reading .dia and .swiftdeps files in a single pass, and extracting cross-module dependency info from .swiftmodule files while skipping irrelevant blocks and records. The corresponding swift-driver PR (https://github.com/apple/swift-driver/pull/299) gives a better idea of the applications I have in mind.

The core of this change is the new `BitstreamVisitor` protocol, which has four requirements:
`func validate(signature: Bitcode.Signature) throws`: used to check the signature of a bitstream
`mutating func shouldEnterBlock(id: UInt64) throws -> Bool`: determines if the contents of a block should be read or skipped over
`mutating func didExitBlock() throws`: callback when finished reading a block
`mutating func visit(record: BitcodeElement.Record) throws`: callback whenever a record is read