### PR TITLE
Windows: replace `MSVCRT` with `CRT`

### DIFF
--- a/Sources/TSCBasic/TerminalController.swift
+++ b/Sources/TSCBasic/TerminalController.swift
@@ -10,7 +10,7 @@
 
 import TSCLibc
 #if os(Windows)
-import MSVCRT
+import CRT
 #endif
 
 /// A class to have better control on tty output streams: standard output and standard error.

--- a/Sources/TSCLibc/libc.swift
+++ b/Sources/TSCLibc/libc.swift
@@ -11,7 +11,7 @@
 #if canImport(Glibc)
 @_exported import Glibc
 #elseif os(Windows)
-@_exported import MSVCRT
+@_exported import CRT
 @_exported import WinSDK
 #else
 @_exported import Darwin.C


### PR DESCRIPTION
This is part of the migration path to remove the use of the `visualc`
module from the Swift SDK for Windows.  The use of the `stdout` and
`stderr` types requires the use of the Swift overlay as the C library
interfaces are not directly usable with the same name.