### PR TITLE
Add 'delete' to PersistentCache

### DIFF
--- a/Sources/TSCUtility/PersistenceCache.swift
+++ b/Sources/TSCUtility/PersistenceCache.swift
@@ -15,6 +15,7 @@ import Foundation
 public protocol PersistentCacheProtocol {
     func get(key: Data) throws -> Data?
     func put(key: Data, value: Data) throws
+    func delete(key: Data) throws
 }
 
 /// SQLite backed persistent cache.
@@ -62,5 +63,15 @@ public final class SQLiteBackedPersistentCache: PersistentCacheProtocol {
         try writeStmt.bind(bindings)
         try writeStmt.step()
         try writeStmt.finalize()
+    }
+    
+    public func delete(key: Data) throws {
+        let deleteStmt = try self.db.prepare(query: "DELETE FROM TSCCACHE WHERE key == ?;")
+        let bindings: [SQLite.SQLiteValue] = [
+            .blob(key)
+        ]
+        try deleteStmt.bind(bindings)
+        try deleteStmt.step()
+        try deleteStmt.finalize()
     }
 }

--- a/Tests/TSCUtilityTests/PersistentCacheTests.swift
+++ b/Tests/TSCUtilityTests/PersistentCacheTests.swift
@@ -59,6 +59,14 @@ class PersistentCacheTests: XCTestCase {
                 try decoder.decode(Value.self, from: $0)
             }
             XCTAssertEqual(retVal3, value1)
+            
+            try cache.delete(key: encoder.encode(key1))
+            
+            XCTAssertNil(try cache.get(key: encoder.encode(key1)))
+            let retVal4 = try cache.get(key: encoder.encode(key2)).map {
+                try decoder.decode(Value.self, from: $0)
+            }
+            XCTAssertEqual(retVal4, value2)
         }
     }
 }


### PR DESCRIPTION
Motivation:
It would be nice to be able to delete a key from a `PersistentCache`.

Modifications:
- Add `delete` to `PersistentCacheProtocol` and implementation `SQLiteBackedPersistentCache`
- Update test

Result:
We can delete from `PersistentCache`.