### PR TITLE
TSCBasic: repair the build on Windows after #139

### DIFF
--- a/Sources/TSCBasic/Thread.swift
+++ b/Sources/TSCBasic/Thread.swift
@@ -9,6 +9,9 @@
 */
 
 import Foundation
+#if os(Windows)
+import WinSDK
+#endif
 
 /// This class bridges the gap between Darwin and Linux Foundation Threading API.
 /// It provides closure based execution and a join method to block the calling thread


### PR DESCRIPTION
Import WinSDK to get access to `SwitchToThread`.