### PR TITLE
Fix a unit test (`testBrewPrefix`) that only fails when running all the tests

### DIFF
--- a/Sources/TSCUtility/PkgConfig.swift
+++ b/Sources/TSCUtility/PkgConfig.swift
@@ -33,6 +33,9 @@ public struct PCFileFinder {
     let diagnostics: DiagnosticsEngine
 
     /// Cached results of locations `pkg-config` will search for `.pc` files
+    /// FIXME: This shouldn't use a static variable, since the first lookup
+    /// will cache the result of whatever `brewPrefix` was passed in.  It is
+    /// also not threadsafe.
     public private(set) static var pkgConfigPaths: [AbsolutePath]? // FIXME: @testable(internal)
     private static var shouldEmitPkgConfigPathsDiagnostic = false
 
@@ -69,6 +72,14 @@ public struct PCFileFinder {
                 PCFileFinder.pkgConfigPaths = []
             }
         }
+    }
+    
+    /// Reset the cached `pkgConfigPaths` property, so that it will be evaluated
+    /// again when instantiating a `PCFileFinder()`.  This is intended only for
+    /// use by testing.  This is a temporary workaround for the use of a static
+    /// variable by this class.
+    internal static func resetCachedPkgConfigPaths() {
+        PCFileFinder.pkgConfigPaths = nil
     }
 
     public func locatePCFile(

--- a/Tests/TSCUtilityTests/PkgConfigParserTests.swift
+++ b/Tests/TSCUtilityTests/PkgConfigParserTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -12,7 +12,7 @@ import XCTest
 import TSCBasic
 import TSCTestSupport
 
-import TSCUtility
+@testable import TSCUtility
 
 final class PkgConfigParserTests: XCTestCase {
 
@@ -91,6 +91,9 @@ final class PkgConfigParserTests: XCTestCase {
 
     /// Test custom search path get higher priority for locating pc files.
     func testCustomPcFileSearchPath() throws {
+        /// Temporary workaround for PCFileFinder's use of static variables.
+        PCFileFinder.resetCachedPkgConfigPaths()
+
         let diagnostics = DiagnosticsEngine()
 
         let fs = InMemoryFileSystem(emptyFiles:
@@ -109,6 +112,9 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     func testBrewPrefix() throws {
+        /// Temporary workaround for PCFileFinder's use of static variables.
+        PCFileFinder.resetCachedPkgConfigPaths()
+
         try testWithTemporaryDirectory { tmpdir in
             let fakePkgConfig = tmpdir.appending(components: "bin", "pkg-config")
             try localFileSystem.createDirectory(fakePkgConfig.parentDirectory)


### PR DESCRIPTION
This fixes a unit test (`testBrewPrefix`) that only fails when running the whole test suite.  This is because it was dependent on whether package config paths had already been cached.  This adds way to clear the cache.