### PR TITLE
Use @_implementationOnly import for TSCclibc

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 /*
  This source file is part of the Swift.org open source project
  
- Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Copyright (c) 2019 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
  
  See http://swift.org/LICENSE.txt for license information
@@ -45,15 +45,15 @@ let package = Package(
         .target(
             /** Cross-platform access to bare `libc` functionality. */
             name: "TSCLibc",
-            dependencies: ["TSCclibc"]),
+            dependencies: []),
         .target(
             /** TSCBasic support library */
             name: "TSCBasic",
-            dependencies: ["TSCLibc"]),
+            dependencies: ["TSCLibc", "TSCclibc"]),
         .target(
             /** Abstractions for common operations, should migrate to TSCBasic */
             name: "TSCUtility",
-            dependencies: ["TSCBasic"]),
+            dependencies: ["TSCBasic", "TSCclibc"]),
         
         // MARK: Additional Test Dependencies
         
@@ -71,7 +71,7 @@ let package = Package(
         
         .testTarget(
             name: "TSCBasicTests",
-            dependencies: ["TSCTestSupport", "TSCTestSupportExecutable"]),
+            dependencies: ["TSCTestSupport", "TSCTestSupportExecutable", "TSCclibc"]),
         .testTarget(
             name: "TSCBasicPerformanceTests",
             dependencies: ["TSCBasic", "TSCTestSupport"]),

--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -57,6 +57,8 @@ target_compile_options(TSCBasic PUBLIC
   "$<$<PLATFORM_ID:Windows>:SHELL:-Xcc -D_CRT_SECURE_NO_WARNINGS>")
 target_link_libraries(TSCBasic PUBLIC
   TSCLibc)
+target_link_libraries(TSCBasic PRIVATE
+   TSCclibc)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   if(Foundation_FOUND)
     target_link_libraries(TSCBasic PUBLIC

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -14,6 +14,7 @@ import class Foundation.ProcessInfo
 import Foundation
 #endif
 
+@_implementationOnly import TSCclibc
 import TSCLibc
 import Dispatch
 

--- a/Sources/TSCLibc/CMakeLists.txt
+++ b/Sources/TSCLibc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
@@ -13,8 +13,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   target_compile_options(TSCLibc PRIVATE
     -autolink-force-load)
 endif()
-target_link_libraries(TSCLibc PUBLIC
-  TSCclibc)
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCLibc PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/TSCLibc/libc.swift
+++ b/Sources/TSCLibc/libc.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -16,8 +16,6 @@
 #else
 @_exported import Darwin.C
 #endif
-
-@_exported import TSCclibc
 
 #if os(Windows)
 private func __randname(_ buffer: UnsafeMutablePointer<CChar>) {

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See http://swift.org/LICENSE.txt for license information
@@ -45,6 +45,8 @@ add_library(TSCUtility
 )
 target_link_libraries(TSCUtility PUBLIC
   TSCBasic)
+target_link_libraries(TSCUtility PRIVATE
+  TSCclibc)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(TSCUtility PRIVATE
     SQLite::SQLite3)

--- a/Sources/TSCUtility/Versioning.swift
+++ b/Sources/TSCUtility/Versioning.swift
@@ -1,14 +1,14 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import TSCclibc
+@_implementationOnly import TSCclibc
 
 /// A Swift version number.
 ///

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -10,8 +10,9 @@
 
 import TSCTestSupport
 import XCTest
-import TSCLibc
 
+@_implementationOnly import TSCclibc
+import TSCLibc
 import TSCBasic
 
 typealias ProcessID = TSCBasic.Process.ProcessID


### PR DESCRIPTION
This change is courtesy of @aciidb0mb3r, who originally opened this as https://github.com/apple/swift-package-manager/pull/2379 against SwiftPM.  Reopening it here as a WIP after discussion with him, because it would be nice to no longer have to copy around header files for clients that use libSwiftPM.dylib and libSwiftPMDataModel.dylib.  TSCclibc is only used by versioning and IndexStore, but the need to have access to the headers extends to all clients.

The IndexStore diffs here get a bit complicated, due to https://bugs.swift.org/browse/SR-11613.  Everything seems to work fine, but we might want to have more discussion about whether there is a better way to get IndexStore to be able to use TSCclibc in an implementation-only manner.

rdar://problem/56219970