### PR TITLE
Remove fatalError from implementation of ByteString description

### DIFF
--- a/Sources/TSCBasic/ByteString.swift
+++ b/Sources/TSCBasic/ByteString.swift
@@ -108,11 +108,7 @@ public struct ByteString: ExpressibleByArrayLiteral, Hashable {
 extension ByteString: CustomStringConvertible {
     /// Return the string decoded as a UTF8 sequence, or traps if not possible.
     public var description: String {
-        guard let description = validDescription else {
-            fatalError("invalid byte string: \(cString)")
-        }
-
-        return description
+        return cString
     }
 
     /// Return the string decoded as a UTF8 sequence, if possible.


### PR DESCRIPTION
The current implementation of the `description` property required for `ByteString` to conform to `CustomStringConvertible` includes a call to `fatalError` if the buffer constitutes an invalid UTF-8 byte sequence: 

https://github.com/apple/swift-tools-support-core/blob/e618e0f0f82fbfcff1a5a097ba0d019c7d6ddcc5/Sources/TSCBasic/ByteString.swift#L110-L116

According to the [header documentation](https://github.com/apple/swift-tools-support-core/blob/e618e0f0f82fbfcff1a5a097ba0d019c7d6ddcc5/Sources/TSCBasic/ByteString.swift#L13-L25):

> A `ByteString` represents a sequence of bytes.
> 
> This struct provides useful operations for working with buffers of
> bytes. Conceptually it is just a contiguous array of bytes (UInt8), but it
> contains methods and default behavor suitable for common operations done
> using bytes strings.
> 
> This struct *is not* intended to be used for significant mutation of byte
> strings, we wish to retain the flexibility to micro-optimize the memory
> allocation of the storage (for example, by inlining the storage for small
> strings or and by eliminating wasted space in growable arrays). For
> construction of byte arrays, clients should use the `WritableByteStream` class
> and then convert to a `ByteString` when complete.

Based on that, it's surprising to me that the type would enforce that the byte string is UTF-8 valid, or that calling `description` (most often implicitly) could cause a program to trap. I encountered this behavior when generating and verifying `SHA256` checksums.

```swift
enum Error: Swift.Error {
  case mismatchedChecksums(actual: ByteString, expected: ByteString)
}
```

In the process of `throw`-ing that `mismatchedChecksums` error in a unit test, `XCTest` attempted to call the synthesized `description` property, which delegated to `ByteString`'s implementation. My workaround was to change the associated value types to `String` and use each checksum's `hexadecimalRepresentation`.

Unfortunately, the context of this change appears to have been lost when TSCBasic et al. were consolidated into this monorepo (fcaa2ce), so I can only guess at the original motivation here. This PR replaces the existing implementation with a call to `cString`. Tests pass all the same (though FWIW, `PkgConfigParserTests.testBrewPrefix` is failing locally before and after the commit...), though I don't have particularly strong feelings with `cString` as the thing to use here. If anyone has a any different ideas, I'd be interested to hear them.

