### PR TITLE
Restore the Ability to do per-File Locking

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -552,7 +552,7 @@ public class InMemoryFileSystem: FileSystem {
     /// reality, the only practical use for InMemoryFileSystem is for unit
     /// tests.
     private let lock = Lock()
-    /// Exclusive file system lock vended to clients through `withLock()`.
+    /// A map that keeps weak references to all locked files.
     private var lockFiles = Dictionary<AbsolutePath, WeakReference<DispatchQueue>>()
     /// Used to access lockFiles in a thread safe manner.
     private let lockFilesLock = Lock()


### PR DESCRIPTION
Revert commits made in #152 due to `InMemoryFileSystem` not being thread-safe after #163 made `InMemoryFileSystem` thread-safe.