### PR TITLE
Link against missing libraries in TSCUtility CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 
 find_package(dispatch QUIET)
 find_package(Foundation QUIET)
+find_package(Threads QUIET)
 find_package(SQLite3 REQUIRED)
 
 add_subdirectory(Sources)

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -46,7 +46,10 @@ add_library(TSCUtility
 target_link_libraries(TSCUtility PUBLIC
   TSCBasic)
 target_link_libraries(TSCUtility PRIVATE
-  TSCclibc)
+  TSCclibc
+  ${CMAKE_DL_LIBS}
+  Threads::Threads)
+
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(TSCUtility PRIVATE
     SQLite::SQLite3)


### PR DESCRIPTION
TSUtility uses functions from pthread and dlfcn so it should link
against them to not have undefined symbols.