### PR TITLE
Improve FileSystemError by adding associated path

### DIFF
--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -110,7 +110,7 @@ public final class FileLock {
         if fileDescriptor == nil {
             let fd = TSCLibc.open(lockFile.pathString, O_WRONLY | O_CREAT | O_CLOEXEC, 0o666)
             if fd == -1 {
-                throw FileSystemError(errno: errno)
+                throw FileSystemError(errno: errno, lockFile)
             }
             self.fileDescriptor = fd
         }

--- a/Sources/TSCBasic/WritableByteStream.swift
+++ b/Sources/TSCBasic/WritableByteStream.swift
@@ -672,16 +672,20 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     /// The pointer to the file.
     let filePointer: UnsafeMutablePointer<FILE>
 
-    /// True if there were any IO error during writing.
-    private var error: Bool = false
+    /// Set to an error value if there were any IO error during writing.
+    private var error: FileSystemError?
 
     /// Closes the file on deinit if true.
     private var closeOnDeinit: Bool
+
+    /// Path to the file this stream should operate on.
+    private let path: AbsolutePath?
 
     /// Instantiate using the file pointer.
     public init(filePointer: UnsafeMutablePointer<FILE>, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
         self.filePointer = filePointer
         self.closeOnDeinit = closeOnDeinit
+        self.path = nil
         super.init(buffered: buffered)
     }
 
@@ -700,8 +704,9 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     /// - Throws: FileSystemError
     public init(_ path: AbsolutePath, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
         guard let filePointer = fopen(path.pathString, "wb") else {
-            throw FileSystemError(errno: errno)
+            throw FileSystemError(errno: errno, path)
         }
+        self.path = path
         self.filePointer = filePointer
         self.closeOnDeinit = closeOnDeinit
         super.init(buffered: buffered)
@@ -713,8 +718,12 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
         }
     }
 
-    func errorDetected() {
-        error = true
+    func errorDetected(code: Int32?) {
+        if let code = code {
+            error = .init(.ioError(code: code), path)
+        } else {
+            error = .init(.unknownOSError, path)
+        }
     }
 
     override final func writeImpl<C: Collection>(_ bytes: C) where C.Iterator.Element == UInt8 {
@@ -724,9 +733,9 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
             let n = fwrite(&contents, 1, contents.count, filePointer)
             if n < 0 {
                 if errno == EINTR { continue }
-                errorDetected()
+                errorDetected(code: errno)
             } else if n != contents.count {
-                errorDetected()
+                errorDetected(code: nil)
             }
             break
         }
@@ -738,9 +747,9 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
                 let n = fwrite(bytesPtr.baseAddress, 1, bytesPtr.count, filePointer)
                 if n < 0 {
                     if errno == EINTR { continue }
-                    errorDetected()
+                    errorDetected(code: errno)
                 } else if n != bytesPtr.count {
-                    errorDetected()
+                    errorDetected(code: nil)
                 }
                 break
             }
@@ -758,8 +767,8 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
             closeOnDeinit = false
         }
         // Throw if errors were found during writing.
-        if error {
-            throw FileSystemError.ioError
+        if let error = error {
+            throw error
         }
     }
 }

--- a/Sources/TSCUtility/Archiver.swift
+++ b/Sources/TSCUtility/Archiver.swift
@@ -51,12 +51,12 @@ public struct ZipArchiver: Archiver {
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         guard fileSystem.exists(archivePath) else {
-            completion(.failure(FileSystemError.noEntry))
+            completion(.failure(FileSystemError(.noEntry, archivePath)))
             return
         }
 
         guard fileSystem.isDirectory(destinationPath) else {
-            completion(.failure(FileSystemError.notDirectory))
+            completion(.failure(FileSystemError(.notDirectory, destinationPath)))
             return
         }
 

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -245,42 +245,45 @@ class FileSystemTests: XCTestCase {
             XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
             // Check read/write of a directory.
-            XCTAssertThrows(FileSystemError.ioError) {
+            XCTAssertThrows(FileSystemError(.ioError(code: TSCLibc.EPERM), filePath.parentDirectory)) {
                 _ = try fs.readFileContents(filePath.parentDirectory)
             }
-            XCTAssertThrows(FileSystemError.isDirectory) {
+            XCTAssertThrows(FileSystemError(.isDirectory, filePath.parentDirectory)) {
                 try fs.writeFileContents(filePath.parentDirectory, bytes: [])
             }
             XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
             // Check read/write against root.
-            XCTAssertThrows(FileSystemError.ioError) {
-              #if os(Android)
-                _ = try fs.readFileContents(AbsolutePath("/system/"))
-              #else
-                _ = try fs.readFileContents(AbsolutePath("/"))
-              #endif
+            #if os(Android)
+            let root = AbsolutePath("/system/")
+            #else
+            let root = AbsolutePath("/")
+            #endif
+            XCTAssertThrows(FileSystemError(.ioError(code: TSCLibc.EPERM), root)) {
+                _ = try fs.readFileContents(root)
+
             }
-            XCTAssertThrows(FileSystemError.isDirectory) {
-                try fs.writeFileContents(AbsolutePath("/"), bytes: [])
+            XCTAssertThrows(FileSystemError(.isDirectory, root)) {
+                try fs.writeFileContents(root, bytes: [])
             }
             XCTAssert(fs.exists(filePath))
 
             // Check read/write into a non-directory.
-            XCTAssertThrows(FileSystemError.notDirectory) {
-                _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
+            let notDirectoryPath = filePath.appending(component: "not-possible")
+            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath)) {
+                _ = try fs.readFileContents(notDirectoryPath)
             }
-            XCTAssertThrows(FileSystemError.notDirectory) {
+            XCTAssertThrows(FileSystemError(.notDirectory, notDirectoryPath)) {
                 try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
             }
             XCTAssert(fs.exists(filePath))
 
             // Check read/write into a missing directory.
             let missingDir = tmpDirPath.appending(components: "does", "not", "exist")
-            XCTAssertThrows(FileSystemError.noEntry) {
+            XCTAssertThrows(FileSystemError(.noEntry, missingDir)) {
                 _ = try fs.readFileContents(missingDir)
             }
-            XCTAssertThrows(FileSystemError.noEntry) {
+            XCTAssertThrows(FileSystemError(.noEntry, missingDir)) {
                 try fs.writeFileContents(missingDir, bytes: [])
             }
             XCTAssert(!fs.exists(missingDir))
@@ -302,10 +305,10 @@ class FileSystemTests: XCTestCase {
 
             // Copy with no source
 
-            XCTAssertThrows(FileSystemError.noEntry) {
+            XCTAssertThrows(FileSystemError(.noEntry, source)) {
                 try fs.copy(from: source, to: destination)
             }
-            XCTAssertThrows(FileSystemError.noEntry) {
+            XCTAssertThrows(FileSystemError(.noEntry, source)) {
                 try fs.move(from: source, to: destination)
             }
 
@@ -314,10 +317,10 @@ class FileSystemTests: XCTestCase {
             try fs.writeFileContents(source, bytes: "source1")
             try fs.writeFileContents(destination, bytes: "destination")
 
-            XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
+            XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
                 try fs.copy(from: source, to: destination)
             }
-            XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
+            XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
                 try fs.move(from: source, to: destination)
             }
 
@@ -373,22 +376,23 @@ class FileSystemTests: XCTestCase {
 
     func testInMemoryBasics() throws {
         let fs = InMemoryFileSystem()
+        let doesNotExist = AbsolutePath("/does-not-exist")
 
         // exists()
-        XCTAssert(!fs.exists(AbsolutePath("/does-not-exist")))
+        XCTAssert(!fs.exists(doesNotExist))
 
         // isDirectory()
-        XCTAssert(!fs.isDirectory(AbsolutePath("/does-not-exist")))
+        XCTAssert(!fs.isDirectory(doesNotExist))
 
         // isFile()
-        XCTAssert(!fs.isFile(AbsolutePath("/does-not-exist")))
+        XCTAssert(!fs.isFile(doesNotExist))
 
         // isSymlink()
-        XCTAssert(!fs.isSymlink(AbsolutePath("/does-not-exist")))
+        XCTAssert(!fs.isSymlink(doesNotExist))
 
         // getDirectoryContents()
-        XCTAssertThrows(FileSystemError.noEntry) {
-            _ = try fs.getDirectoryContents(AbsolutePath("/does-not-exist"))
+        XCTAssertThrows(FileSystemError(.noEntry, doesNotExist)) {
+            _ = try fs.getDirectoryContents(doesNotExist)
         }
 
         // createDirectory()
@@ -422,9 +426,10 @@ class FileSystemTests: XCTestCase {
         XCTAssert(fs.isDirectory(subsubdir))
 
         // Check non-recursive failing subdir case.
-        let newsubdir = AbsolutePath("/very-new-dir/subdir")
+        let veryNewDir = AbsolutePath("/very-new-dir")
+        let newsubdir = veryNewDir.appending(component: "subdir")
         XCTAssert(!fs.isDirectory(newsubdir))
-        XCTAssertThrows(FileSystemError.noEntry) {
+        XCTAssertThrows(FileSystemError(.noEntry, veryNewDir)) {
             try fs.createDirectory(newsubdir, recursive: false)
         }
         XCTAssert(!fs.isDirectory(newsubdir))
@@ -433,10 +438,10 @@ class FileSystemTests: XCTestCase {
         let filePath = AbsolutePath("/mach_kernel")
         try! fs.writeFileContents(filePath, bytes: [0xCD, 0x0D])
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
-        XCTAssertThrows(FileSystemError.notDirectory) {
+        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
             try fs.createDirectory(filePath, recursive: true)
         }
-        XCTAssertThrows(FileSystemError.notDirectory) {
+        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
             try fs.createDirectory(filePath.appending(component: "not-possible"), recursive: true)
         }
         XCTAssert(fs.exists(filePath) && !fs.isDirectory(filePath))
@@ -493,42 +498,45 @@ class FileSystemTests: XCTestCase {
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
         // Check read/write of a directory.
-        XCTAssertThrows(FileSystemError.isDirectory) {
+        XCTAssertThrows(FileSystemError(.isDirectory, filePath.parentDirectory)) {
             _ = try fs.readFileContents(filePath.parentDirectory)
         }
-        XCTAssertThrows(FileSystemError.isDirectory) {
+        XCTAssertThrows(FileSystemError(.isDirectory, filePath.parentDirectory)) {
             try fs.writeFileContents(filePath.parentDirectory, bytes: [])
         }
         XCTAssertEqual(try! fs.readFileContents(filePath), "Hello, new world!")
 
         // Check read/write against root.
-        XCTAssertThrows(FileSystemError.isDirectory) {
-            _ = try fs.readFileContents(AbsolutePath("/"))
+        let root = AbsolutePath("/")
+        XCTAssertThrows(FileSystemError(.isDirectory, root)) {
+            _ = try fs.readFileContents(root)
         }
-        XCTAssertThrows(FileSystemError.isDirectory) {
-            try fs.writeFileContents(AbsolutePath("/"), bytes: [])
+        XCTAssertThrows(FileSystemError(.isDirectory, root)) {
+            try fs.writeFileContents(root, bytes: [])
         }
         XCTAssert(fs.exists(filePath))
         XCTAssertTrue(fs.isFile(filePath))
 
         // Check read/write into a non-directory.
-        XCTAssertThrows(FileSystemError.notDirectory) {
-            _ = try fs.readFileContents(filePath.appending(component: "not-possible"))
+        let notDirectory = filePath.appending(component: "not-possible")
+        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
+            _ = try fs.readFileContents(notDirectory)
         }
-        XCTAssertThrows(FileSystemError.notDirectory) {
-            try fs.writeFileContents(filePath.appending(component: "not-possible"), bytes: [])
+        XCTAssertThrows(FileSystemError(.notDirectory, filePath)) {
+            try fs.writeFileContents(notDirectory, bytes: [])
         }
         XCTAssert(fs.exists(filePath))
 
         // Check read/write into a missing directory.
-        let missingDir = AbsolutePath("/does/not/exist")
-        XCTAssertThrows(FileSystemError.noEntry) {
-            _ = try fs.readFileContents(missingDir)
+        let missingParent = AbsolutePath("/does/not")
+        let missingFile = missingParent.appending(component: "exist")
+        XCTAssertThrows(FileSystemError(.noEntry, missingFile)) {
+            _ = try fs.readFileContents(missingFile)
         }
-        XCTAssertThrows(FileSystemError.noEntry) {
-            try fs.writeFileContents(missingDir, bytes: [])
+        XCTAssertThrows(FileSystemError(.noEntry, missingParent)) {
+            try fs.writeFileContents(missingFile, bytes: [])
         }
-        XCTAssert(!fs.exists(missingDir))
+        XCTAssert(!fs.exists(missingFile))
     }
 
     func testInMemoryFsCopy() throws {
@@ -560,10 +568,10 @@ class FileSystemTests: XCTestCase {
 
         // Copy with no source
 
-        XCTAssertThrows(FileSystemError.noEntry) {
+        XCTAssertThrows(FileSystemError(.noEntry, source)) {
             try fs.copy(from: source, to: destination)
         }
-        XCTAssertThrows(FileSystemError.noEntry) {
+        XCTAssertThrows(FileSystemError(.noEntry, source)) {
             try fs.move(from: source, to: destination)
         }
 
@@ -572,10 +580,10 @@ class FileSystemTests: XCTestCase {
         try fs.writeFileContents(source, bytes: "source1")
         try fs.writeFileContents(destination, bytes: "destination")
 
-        XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
+        XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
             try fs.copy(from: source, to: destination)
         }
-        XCTAssertThrows(FileSystemError.alreadyExistsAtDestination) {
+        XCTAssertThrows(FileSystemError(.alreadyExistsAtDestination, destination)) {
             try fs.move(from: source, to: destination)
         }
 
@@ -703,13 +711,13 @@ class FileSystemTests: XCTestCase {
 
             // Set foo to unwritable.
             try fs.chmod(.userUnWritable, path: foo)
-            XCTAssertThrows(FileSystemError.invalidAccess) {
+            XCTAssertThrows(FileSystemError(.invalidAccess, foo)) {
                 try fs.writeFileContents(foo, bytes: "test")
             }
 
             // Set the directory as unwritable.
             try fs.chmod(.userUnWritable, path: dir, options: [.recursive, .onlyFiles])
-            XCTAssertThrows(FileSystemError.invalidAccess) {
+            XCTAssertThrows(FileSystemError(.invalidAccess, bar)) {
                 try fs.writeFileContents(bar, bytes: "test")
             }
 
@@ -721,8 +729,9 @@ class FileSystemTests: XCTestCase {
 
             // But not anymore.
             try fs.chmod(.userUnWritable, path: dir, options: [.recursive])
-            XCTAssertThrows(FileSystemError.invalidAccess) {
-                try fs.writeFileContents(dir.appending(component: "new2"), bytes: "")
+            let newFile = dir.appending(component: "new2")
+            XCTAssertThrows(FileSystemError(.invalidAccess, newFile)) {
+                try fs.writeFileContents(newFile, bytes: "")
             }
 
             try? fs.removeFileTree(bar)

--- a/Tests/TSCUtilityTests/ArchiverTests.swift
+++ b/Tests/TSCUtilityTests/ArchiverTests.swift
@@ -40,8 +40,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem()
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.noEntry)
+        let archive = AbsolutePath("/archive.zip")
+        archiver.extract(from: archive, to: AbsolutePath("/"), completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.noEntry, archive))
             expectation.fulfill()
         })
 
@@ -53,8 +54,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
+        let destination = AbsolutePath("/destination")
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
 
@@ -66,8 +68,9 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip", "/destination")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: AbsolutePath("/destination"), completion: { result in
-            XCTAssertResultFailure(result, equals: FileSystemError.notDirectory)
+        let destination = AbsolutePath("/destination")
+        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+            XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
 


### PR DESCRIPTION
Another attempt to apply https://github.com/apple/swift-tools-support-core/pull/78, which was previously reverted due to breakage in SourceKit-LSP.

I've recently stumbled upon this error when running `swift build`:

```
error: noEntry
```

This is the exact and only output of this `swift build` invocation. Unfortunately, I think it's impossible to diagnose without an attached debugger. It's also hard to pinpoint where exactly the error comes from in the source code, since `FileSystemError.noEntry` is thrown from multiple places.

In my opinion, for an error value to be helpful it should have associated information attached to it. In this case, it would make sense for almost all cases of `FileSystemError` to have an associated `AbsolutePath` value.

`FileSystemError` now also has to be explicitly declared `Equatable` to make the tests compile, but previously it was `Equatable` anyway, although implicitly by virtue of being an enum with no associated values.