### PR TITLE
Fix cachesDirectory using a file URL instead of a path

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -342,7 +342,7 @@ private class LocalFileSystem: FileSystem {
     }
     
     var cachesDirectory: AbsolutePath? {
-        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first.flatMap { AbsolutePath($0.absoluteString) }
+        return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first.flatMap { AbsolutePath($0.path) }
     }
 
     func getDirectoryContents(_ path: AbsolutePath) throws -> [String] {


### PR DESCRIPTION
I noticed that `LocalFileSystem.cachesDirectory` returns `AbsolutePath("file:///Users/tim/Library/Caches/")`which is not a valid `AbsolutePath`.