### PR TITLE
Add some general-purpose path utilities from swift-driver

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -157,11 +157,15 @@ public struct AbsolutePath: Hashable {
     /// This method should only be used in cases where the input is guaranteed
     /// to be a valid path component (i.e., it cannot be empty, contain a path
     /// separator, or be a pseudo-path like '.' or '..').
-    public func appending(components names: String...) -> AbsolutePath {
+    public func appending(components names: [String]) -> AbsolutePath {
         // FIXME: This doesn't seem a particularly efficient way to do this.
         return names.reduce(self, { path, name in
             path.appending(component: name)
         })
+    }
+
+    public func appending(components names: String...) -> AbsolutePath {
+        appending(components: names)
     }
 
     /// NOTE: We will most likely want to add other `appending()` methods, such
@@ -288,11 +292,15 @@ public struct RelativePath: Hashable {
     /// This method should only be used in cases where the input is guaranteed
     /// to be a valid path component (i.e., it cannot be empty, contain a path
     /// separator, or be a pseudo-path like '.' or '..').
-    public func appending(components names: String...) -> RelativePath {
+    public func appending(components names: [String]) -> RelativePath {
         // FIXME: This doesn't seem a particularly efficient way to do this.
         return names.reduce(self, { path, name in
             path.appending(component: name)
         })
+    }
+
+    public func appending(components names: String...) -> RelativePath {
+        appending(components: names)
     }
 }
 

--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -247,6 +247,14 @@ public struct RelativePath: Hashable {
         return _impl.basename
     }
 
+    /// Returns the basename without the extension.
+    public var basenameWithoutExt: String {
+        if let ext = self.extension {
+            return String(basename.dropLast(ext.count + 1))
+        }
+        return basename
+    }
+
     /// Suffix (including leading `.` character) if any.  Note that a basename
     /// that starts with a `.` character is not considered a suffix, nor is a
     /// trailing `.` character.

--- a/Tests/TSCBasicTests/PathTests.swift
+++ b/Tests/TSCBasicTests/PathTests.swift
@@ -149,6 +149,29 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath(".").basename, ".")
     }
 
+    func testBaseNameWithoutExt() {
+        XCTAssertEqual(AbsolutePath("/").basenameWithoutExt, "/")
+        XCTAssertEqual(AbsolutePath("/a").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath("/./a").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath("/../..").basenameWithoutExt, "/")
+        XCTAssertEqual(RelativePath("../..").basenameWithoutExt, "..")
+        XCTAssertEqual(RelativePath("../a").basenameWithoutExt, "a")
+        XCTAssertEqual(RelativePath("../a/..").basenameWithoutExt, "..")
+        XCTAssertEqual(RelativePath("a/..").basenameWithoutExt, ".")
+        XCTAssertEqual(RelativePath("./..").basenameWithoutExt, "..")
+        XCTAssertEqual(RelativePath("a/../////../////./////").basenameWithoutExt, "..")
+        XCTAssertEqual(RelativePath("abc").basenameWithoutExt, "abc")
+        XCTAssertEqual(RelativePath("").basenameWithoutExt, ".")
+        XCTAssertEqual(RelativePath(".").basenameWithoutExt, ".")
+
+        XCTAssertEqual(AbsolutePath("/a.txt").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath("/./a.txt").basenameWithoutExt, "a")
+        XCTAssertEqual(RelativePath("../a.bc").basenameWithoutExt, "a")
+        XCTAssertEqual(RelativePath("abc.swift").basenameWithoutExt, "abc")
+        XCTAssertEqual(RelativePath("../a.b.c").basenameWithoutExt, "a.b")
+        XCTAssertEqual(RelativePath("abc.xyz.123").basenameWithoutExt, "abc.xyz")
+    }
+
     func testSuffixExtraction() {
         XCTAssertEqual(RelativePath("a").suffix, nil)
         XCTAssertEqual(RelativePath("a").extension, nil)


### PR DESCRIPTION
This moves a couple general purpose path utilities from swift-driver to TSC

- array-accepting overloads of `appending(components:)`, to make composition easier
- `basenameWithoutExt` for RelativePath in addition to AbsolutePath

