### PR TITLE
fix error in busy timeout units

### DIFF
--- a/Sources/TSCUtility/SQLite.swift
+++ b/Sources/TSCUtility/SQLite.swift
@@ -46,7 +46,7 @@ public struct SQLite {
         }
         self.db = db
         try Self.checkError("Unable to configure database") { sqlite3_extended_result_codes(db, 1) }
-        try Self.checkError("Unable to configure database") { sqlite3_busy_timeout(db, self.configuration.busyTimeoutSeconds) }
+        try Self.checkError("Unable to configure database") { sqlite3_busy_timeout(db, self.configuration.busyTimeoutMilliseconds) }
     }
 
     @available(*, deprecated, message: "use init(location:configuration) instead")
@@ -89,10 +89,29 @@ public struct SQLite {
     public typealias SQLiteExecCallback = ([Column]) -> Void
 
     public struct Configuration {
-        public var busyTimeoutSeconds: Int32
+        public var busyTimeoutMilliseconds: Int32
 
         public init() {
-            self.busyTimeoutSeconds = 5
+            self.busyTimeoutMilliseconds = 5000
+        }
+
+        // FIXME: deprecated 12/2020, remove once clients migrated over
+        @available(*, deprecated, message: "use busyTimeout instead")
+        public var busyTimeoutSeconds: Int32 {
+            get {
+                self._busyTimeoutSeconds
+            } set {
+                self._busyTimeoutSeconds = newValue
+            }
+        }
+
+        // so tests dont warn
+        internal var _busyTimeoutSeconds: Int32 {
+            get {
+                return Int32(truncatingIfNeeded: Int(Double(self.busyTimeoutMilliseconds) / 1000))
+            } set {
+                self.busyTimeoutMilliseconds = newValue * 1000
+            }
         }
     }
 

--- a/Tests/TSCUtilityTests/SQLiteTests.swift
+++ b/Tests/TSCUtilityTests/SQLiteTests.swift
@@ -10,7 +10,7 @@
 
 import TSCBasic
 import TSCTestSupport
-import TSCUtility
+@testable import TSCUtility
 import XCTest
 
 class SQLiteTests: XCTestCase {
@@ -70,5 +70,14 @@ class SQLiteTests: XCTestCase {
             let row = try statement.step()
             XCTAssertNotNil(row, "expected results")
         }
+    }
+
+    func testConfiguration() throws {
+        var configuration = SQLite.Configuration()
+
+        let timeout = Int32.random(in: 1000 ... 10000)
+        configuration.busyTimeoutMilliseconds = timeout
+        XCTAssertEqual(configuration.busyTimeoutMilliseconds, timeout)
+        XCTAssertEqual(configuration._busyTimeoutSeconds, Int32(Double(timeout) / 1000))
     }
 }


### PR DESCRIPTION
motivation: timeout should be in milliseconds but is passed in seconds

cahnges:
* deprecate the SQLite timeout configuration seconds accessor and replace it with a milliseconds one
* add test