### PR TITLE
Fix compiler warning

### DIFF
--- a/Sources/TSCBasic/ObjectIdentifierProtocol.swift
+++ b/Sources/TSCBasic/ObjectIdentifierProtocol.swift
@@ -11,7 +11,7 @@
 /// A protocol which implements Hashable protocol using ObjectIdentifier.
 ///
 /// Classes can conform to this protocol to auto-conform to Hashable and Equatable.
-public protocol ObjectIdentifierProtocol: class, Hashable {}
+public protocol ObjectIdentifierProtocol: AnyObject, Hashable {}
 
 extension ObjectIdentifierProtocol {
     public func hash(into hasher: inout Hasher) {

--- a/Sources/TSCUtility/JSONMessageStreamingParser.swift
+++ b/Sources/TSCUtility/JSONMessageStreamingParser.swift
@@ -12,7 +12,7 @@ import Foundation
 import TSCBasic
 
 /// Protocol for the parser delegate to get notified of parsing events.
-public protocol JSONMessageStreamingParserDelegate: class {
+public protocol JSONMessageStreamingParserDelegate: AnyObject {
 
     /// A decodable type representing the JSON messages being parsed.
     associatedtype Message: Decodable

--- a/Sources/TSCUtility/SimplePersistence.swift
+++ b/Sources/TSCUtility/SimplePersistence.swift
@@ -12,7 +12,7 @@ import TSCBasic
 
 /// A protocol which needs to be implemented by the objects which can be
 /// persisted using SimplePersistence
-public protocol SimplePersistanceProtocol: class, JSONSerializable {
+public protocol SimplePersistanceProtocol: AnyObject, JSONSerializable {
     /// Restores state from the given json object.
     func restore(from json: JSON) throws
 


### PR DESCRIPTION
> using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead