### PR TITLE
TSCBasic: `class` to `AnyObject` conformance

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -133,7 +133,7 @@ public enum FileMode {
 /// substitute a virtual file system or redirect file system operations.
 ///
 /// - Note: All of these APIs are synchronous and can block.
-public protocol FileSystem: class {
+public protocol FileSystem: AnyObject {
     /// Check whether the given path exists and is accessible.
     func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool
 

--- a/Sources/TSCBasic/WritableByteStream.swift
+++ b/Sources/TSCBasic/WritableByteStream.swift
@@ -43,7 +43,7 @@ public protocol ByteStreamable {
 ///
 /// would write each item in the list to the stream, separating them with a
 /// space.
-public protocol WritableByteStream: class, TextOutputStream, Closable {
+public protocol WritableByteStream: AnyObject, TextOutputStream, Closable {
     /// The current offset within the output stream.
     var position: Int { get }
 


### PR DESCRIPTION
The `class` conformance has been deprecated in favour of `AnyObject`.
Update the code accordingly.