### PR TITLE
make Platform::darwinCacheDirectories thread shafe

### DIFF
--- a/Tests/TSCUtilityTests/PlatformTests.swift
+++ b/Tests/TSCUtilityTests/PlatformTests.swift
@@ -12,33 +12,33 @@ import XCTest
 import TSCBasic
 import TSCTestSupport
 
-import TSCUtility
+@testable import TSCUtility
 
 final class PlatformTests: XCTestCase {
     func testFindCurrentPlatformDebian() {
         let fs = InMemoryFileSystem(files: ["/etc/debian_version": "xxx"])
-        XCTAssertEqual(Platform.linux(.debian), Platform._findCurrentPlatformLinux(fs))
+        XCTAssertEqual(Platform.linux(.debian), Platform.findCurrentPlatformLinux(fs))
     }
 
     func testFindCurrentPlatformAndroid() {
         var fs = InMemoryFileSystem(files: ["/system/bin/toolbox": "xxx"])
-        XCTAssertEqual(Platform.android, Platform._findCurrentPlatformLinux(fs))
+        XCTAssertEqual(Platform.android, Platform.findCurrentPlatformLinux(fs))
 
         fs = InMemoryFileSystem(files: ["/system/bin/toybox": "xxx"])
-        XCTAssertEqual(Platform.android, Platform._findCurrentPlatformLinux(fs))
+        XCTAssertEqual(Platform.android, Platform.findCurrentPlatformLinux(fs))
     }
 
     func testFindCurrentPlatformFedora() {
         var fs = InMemoryFileSystem(files: ["/etc/fedora-release": "xxx"])
-        XCTAssertEqual(Platform.linux(.fedora), Platform._findCurrentPlatformLinux(fs))
+        XCTAssertEqual(Platform.linux(.fedora), Platform.findCurrentPlatformLinux(fs))
 
         fs = InMemoryFileSystem(files: ["/etc/redhat-release": "xxx"])
-        XCTAssertEqual(Platform.linux(.fedora), Platform._findCurrentPlatformLinux(fs))
+        XCTAssertEqual(Platform.linux(.fedora), Platform.findCurrentPlatformLinux(fs))
 
         fs = InMemoryFileSystem(files: ["/etc/centos-release": "xxx"])
-        XCTAssertEqual(Platform.linux(.fedora), Platform._findCurrentPlatformLinux(fs))
+        XCTAssertEqual(Platform.linux(.fedora), Platform.findCurrentPlatformLinux(fs))
 
         fs = InMemoryFileSystem(files: ["/etc/system-release": "Amazon Linux release 2 (Karoo)"])
-        XCTAssertEqual(Platform.linux(.fedora), Platform._findCurrentPlatformLinux(fs))
+        XCTAssertEqual(Platform.linux(.fedora), Platform.findCurrentPlatformLinux(fs))
     }
 }


### PR DESCRIPTION
motivation: clients like swift-pm use Platform::darwinCacheDirectories in concurrent settings

changes:
* add lock around the internal caching of darwinCacheDirectories
* make several public functions internal since they are only supposed to be exposed for tests
* format code