### PR TITLE
Change the current SwiftPM version from 5.3.0 to 5.4.0 (leaving the dev flag set to true)

### DIFF
--- a/Sources/TSCUtility/Versioning.swift
+++ b/Sources/TSCUtility/Versioning.swift
@@ -74,7 +74,7 @@ public struct Versioning {
 
     /// The current version of the package manager.
     public static let currentVersion = SwiftVersion(
-        version: (5, 3, 0),
+        version: (5, 4, 0),
         isDevelopment: true,
         buildIdentifier: getBuildIdentifier())
 


### PR DESCRIPTION
ToolsSupportCore used to be part of SwiftPM, and for historical reasons the SwiftPM version is still provided by ToolsSupportCore (this should also be fixed, separately).  In the `main` branch the `dev` flag is still true; this will be set to false in the release branch.