### PR TITLE
[5.4] Change the current SwiftPM version from 5.3.0 to 5.4.0

### DIFF
--- a/Sources/TSCUtility/Versioning.swift
+++ b/Sources/TSCUtility/Versioning.swift
@@ -74,7 +74,7 @@ public struct Versioning {
 
     /// The current version of the package manager.
     public static let currentVersion = SwiftVersion(
-        version: (5, 3, 0),
+        version: (5, 4, 0),
         isDevelopment: true,
         buildIdentifier: getBuildIdentifier())
 


### PR DESCRIPTION
For historical reasons the SwiftPM version number is still contained in ToolsSupportCore (which should be fixed).  This increments it to 5.4.0, but leaves the `dev` flag true for now so that the 999.0 tools version is still accepted until the change has propagated through.  The `dev` flag will then be set to false before 5.4 is released.

This affects what `swift package --version` shows and also allows v5.4 package manifests to be used in SwiftPM.

rdar://73206582