### PR TITLE
[PkgConfig] Add checks for circular dependencies

### DIFF
--- a/Sources/TSCUtility/PkgConfig.swift
+++ b/Sources/TSCUtility/PkgConfig.swift
@@ -174,9 +174,7 @@ public struct PkgConfig {
             var libs = [String]()
             
             for dep in dependencies {
-                let firstOccurrence = loadingContext.pkgConfigStack.firstIndex(of: dep)
-
-                if let index = firstOccurrence {
+                if let index = loadingContext.pkgConfigStack.firstIndex(of: dep) {
                     diagnostics.emit(warning: "circular dependency detected while parsing \(loadingContext.pkgConfigStack[0]): \(loadingContext.pkgConfigStack[index..<loadingContext.pkgConfigStack.count].joined(separator: " -> ")) -> \(dep)")
                     continue
                 }

--- a/Sources/TSCUtility/PkgConfig.swift
+++ b/Sources/TSCUtility/PkgConfig.swift
@@ -104,6 +104,15 @@ public struct PCFileFinder {
     }
 }
 
+/// Informations to track circular dependencies and other PkgConfig issues
+public class LoadingContext {
+    public init() {
+        pkgConfigStack = [String]()
+    }
+
+    public var pkgConfigStack: [String]
+}
+
 /// Information on an individual `pkg-config` supported package.
 public struct PkgConfig {
     /// The name of the package.
@@ -138,8 +147,10 @@ public struct PkgConfig {
         additionalSearchPaths: [AbsolutePath] = [],
         diagnostics: DiagnosticsEngine,
         fileSystem: FileSystem = localFileSystem,
-        brewPrefix: AbsolutePath?
+        brewPrefix: AbsolutePath?,
+        loadingContext: LoadingContext = LoadingContext()
     ) throws {
+        loadingContext.pkgConfigStack.append(name)
 
         if let path = try? AbsolutePath(validating: name) {
             guard fileSystem.isFile(path) else { throw PkgConfigError.couldNotFindConfigFile(name: name) }
@@ -163,13 +174,21 @@ public struct PkgConfig {
             var libs = [String]()
             
             for dep in dependencies {
+                let firstOccurrence = loadingContext.pkgConfigStack.firstIndex(of: dep)
+
+                if let index = firstOccurrence {
+                    diagnostics.emit(warning: "circular dependency detected while parsing \(loadingContext.pkgConfigStack[0]): \(loadingContext.pkgConfigStack[index..<loadingContext.pkgConfigStack.count].joined(separator: " -> ")) -> \(dep)")
+                    continue
+                }
+
                 // FIXME: This is wasteful, we should be caching the PkgConfig result.
                 let pkg = try PkgConfig(
-                    name: dep, 
+                    name: dep,
                     additionalSearchPaths: additionalSearchPaths,
                     diagnostics: diagnostics,
                     fileSystem: fileSystem,
-                    brewPrefix: brewPrefix
+                    brewPrefix: brewPrefix,
+                    loadingContext: loadingContext
                 )
 
                 cFlags += pkg.cFlags
@@ -184,6 +203,8 @@ public struct PkgConfig {
 
         self.cFlags = parser.cFlags + dependencyFlags.cFlags + privateDependencyFlags.cFlags
         self.libs = parser.libs + dependencyFlags.libs
+
+        loadingContext.pkgConfigStack.removeLast();
     }
 
     private static var envSearchPaths: [AbsolutePath] {
@@ -408,3 +429,4 @@ public struct PkgConfigParser {
         return splits
     }
 }
+

--- a/Tests/TSCUtilityTests/PkgConfigParserTests.swift
+++ b/Tests/TSCUtilityTests/PkgConfigParserTests.swift
@@ -16,7 +16,7 @@ import TSCTestSupport
 
 final class PkgConfigParserTests: XCTestCase {
     func testCircularPCFile() throws {
-        XCTAssertTrue(try PkgConfig(name: "harfbuzz", additionalSearchPaths: [pcFilePath("harfbuzz.pc")], diagnostics: DiagnosticsEngine(), brewPrefix: nil).diagnostics.diagnostics.contains { diagnostic in
+        XCTAssertTrue(try PkgConfig(name: "harfbuzz", additionalSearchPaths: [AbsolutePath("/custom")], diagnostics: DiagnosticsEngine(), brewPrefix: nil).diagnostics.diagnostics.contains { diagnostic in
             diagnostic.message.text == "circular dependency detected while parsing harfbuzz: harfbuzz -> freetype2 -> harfbuzz"
         })
     }

--- a/Tests/TSCUtilityTests/PkgConfigParserTests.swift
+++ b/Tests/TSCUtilityTests/PkgConfigParserTests.swift
@@ -16,7 +16,7 @@ import TSCTestSupport
 
 final class PkgConfigParserTests: XCTestCase {
     func testCircularPCFile() throws {
-        XCTAssertTrue(try PkgConfig(name: "harfbuzz", additionalSearchPaths: [AbsolutePath("/custom")], diagnostics: DiagnosticsEngine(), brewPrefix: nil).diagnostics.diagnostics.contains { diagnostic in
+        XCTAssertTrue(try PkgConfig(name: "harfbuzz", additionalSearchPaths: [AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs")], diagnostics: DiagnosticsEngine(), brewPrefix: nil).diagnostics.diagnostics.contains { diagnostic in
             diagnostic.message.text == "circular dependency detected while parsing harfbuzz: harfbuzz -> freetype2 -> harfbuzz"
         })
     }

--- a/Tests/TSCUtilityTests/PkgConfigParserTests.swift
+++ b/Tests/TSCUtilityTests/PkgConfigParserTests.swift
@@ -15,6 +15,11 @@ import TSCTestSupport
 @testable import TSCUtility
 
 final class PkgConfigParserTests: XCTestCase {
+    func testCircularPCFile() throws {
+        XCTAssertTrue(try PkgConfig(name: "harfbuzz", additionalSearchPaths: [pcFilePath("harfbuzz.pc")], diagnostics: DiagnosticsEngine(), brewPrefix: nil).diagnostics.diagnostics.contains { diagnostic in
+            diagnostic.message.text == "circular dependency detected while parsing harfbuzz: harfbuzz -> freetype2 -> harfbuzz"
+        })
+    }
 
     func testGTK3PCFile() {
         try! loadPCFile("gtk+-3.0.pc") { parser in

--- a/Tests/TSCUtilityTests/pkgconfigInputs/freetype2.pc
+++ b/Tests/TSCUtilityTests/pkgconfigInputs/freetype2.pc
@@ -8,7 +8,7 @@ URL: https://freetype.org
 Description: A free, high-quality, and portable font engine.
 Version: 23.4.17
 Requires:
-Requires.private: zlib, libpng, harfbuzz >= 1.8.0
+Requires.private: harfbuzz
 Libs: -L${libdir} -lfreetype
 Libs.private: -lbz2
 Cflags: -I${includedir}/freetype2

--- a/Tests/TSCUtilityTests/pkgconfigInputs/freetype2.pc
+++ b/Tests/TSCUtilityTests/pkgconfigInputs/freetype2.pc
@@ -1,0 +1,14 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=/usr/lib
+includedir=/usr/include
+
+Name: FreeType 2
+URL: https://freetype.org
+Description: A free, high-quality, and portable font engine.
+Version: 23.4.17
+Requires:
+Requires.private: zlib, libpng, harfbuzz >= 1.8.0
+Libs: -L${libdir} -lfreetype
+Libs.private: -lbz2
+Cflags: -I${includedir}/freetype2

--- a/Tests/TSCUtilityTests/pkgconfigInputs/harfbuzz.pc
+++ b/Tests/TSCUtilityTests/pkgconfigInputs/harfbuzz.pc
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 Name: harfbuzz
 Description: HarfBuzz text shaping library
 Version: 2.7.4
-Requires.private: freetype2, graphite2, glib-2.0
+Requires.private: freetype2 
 Libs: -L${libdir} -lharfbuzz
 Libs.private: -pthread -lm
 Cflags: -I${includedir}/harfbuzz

--- a/Tests/TSCUtilityTests/pkgconfigInputs/harfbuzz.pc
+++ b/Tests/TSCUtilityTests/pkgconfigInputs/harfbuzz.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: harfbuzz
+Description: HarfBuzz text shaping library
+Version: 2.7.4
+Requires.private: freetype2, graphite2, glib-2.0
+Libs: -L${libdir} -lharfbuzz
+Libs.private: -pthread -lm
+Cflags: -I${includedir}/harfbuzz


### PR DESCRIPTION
Some libraries form dependency cycles such as `freetype` and `harfbuzz` on Arch Linux. This PR tries to avoid cycles by tracking pkg-config packages dependencies and detecting two occurences of a same library in the same branch.