### PR TITLE
Mark 'release/5.4' as being a release build

### DIFF
--- a/Sources/TSCUtility/Versioning.swift
+++ b/Sources/TSCUtility/Versioning.swift
@@ -75,7 +75,7 @@ public struct Versioning {
     /// The current version of the package manager.
     public static let currentVersion = SwiftVersion(
         version: (5, 4, 0),
-        isDevelopment: true,
+        isDevelopment: false,
         buildIdentifier: getBuildIdentifier())
 
     /// The list of version specific "keys" to search when attempting to load


### PR DESCRIPTION
This makes the `--version` output not add a `-dev` suffix, and also makes the tools version no longer accept `999.0` (`.vNext`) as a valid version (that's the placeholder used during development until a version number is known).

<rdar://73433200>