### PR TITLE
Improve `removeFileTree`

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -440,8 +440,13 @@ private class LocalFileSystem: FileSystem {
     }
 
     func removeFileTree(_ path: AbsolutePath) throws {
-        if self.exists(path, followSymlink: false) {
+        do {
             try FileManager.default.removeItem(atPath: path.pathString)
+        } catch let error as NSError {
+            // If we failed because the directory doesn't actually exist anymore, ignore the error.
+            if !(error.domain == NSCocoaErrorDomain && error.code == NSFileNoSuchFileError) {
+                throw error
+            }
         }
     }
 

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -955,4 +955,8 @@ private func removeFileTreeTester(fs: FileSystem, basePath path: AbsolutePath, f
     XCTAssert(fs.exists(filePath), file: file, line: line)
     try fs.removeFileTree(filePath)
     XCTAssertFalse(fs.exists(filePath), file: file, line: line)
+
+    // Test removing non-existent path.
+    let nonExistingPath = folders.appending(component: "does-not-exist")
+    XCTAssertNoThrow(try fs.removeFileTree(nonExistingPath))
 }


### PR DESCRIPTION
There is a potential race of the given directory being deleted between the `exists` call and the actual deletion. If this happens, we can ignore the error.