### PR TITLE
Add a BitstreamWriter Abstraction

### DIFF
--- a/Sources/TSCUtility/Bitstream.swift
+++ b/Sources/TSCUtility/Bitstream.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2020-2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -9,6 +9,14 @@
 */
 
 import Foundation
+
+/// Represents the contents of a file encoded using the
+/// [LLVM bitstream container format](https://llvm.org/docs/BitCodeFormat.html#bitstream-container-format)
+public struct Bitcode {
+  public let signature: Signature
+  public let elements: [BitcodeElement]
+  public let blockInfo: [UInt64: BlockInfo]
+}
 
 public enum BitcodeElement {
   public struct Block {
@@ -58,309 +66,6 @@ extension Bitcode {
   }
 }
 
-/// Represents the contents of a file encoded using the
-/// [LLVM bitstream container format](https://llvm.org/docs/BitCodeFormat.html#bitstream-container-format)
-public struct Bitcode {
-  public let signature: Signature
-  public let elements: [BitcodeElement]
-  public let blockInfo: [UInt64: BlockInfo]
-}
-
-private extension Bits.Cursor {
-  enum BitcodeError: Swift.Error {
-    case vbrOverflow
-  }
-
-  mutating func readVBR(_ width: Int) throws -> UInt64 {
-    precondition(width > 1)
-    let testBit = UInt64(1 << (width &- 1))
-    let mask = testBit &- 1
-
-    var result: UInt64 = 0
-    var offset: UInt64 = 0
-    var next: UInt64
-    repeat {
-      next = try self.read(width)
-      result |= (next & mask) << offset
-      offset += UInt64(width &- 1)
-      if offset > 64 { throw BitcodeError.vbrOverflow }
-    } while next & testBit != 0
-
-    return result
-  }
-}
-
-private struct BitstreamReader {
-  struct Abbrev {
-    enum Operand {
-      case literal(UInt64)
-      case fixed(Int)
-      case vbr(Int)
-      indirect case array(Operand)
-      case char6
-      case blob
-
-      var isPayload: Bool {
-        switch self {
-        case .array, .blob: return true
-        case .literal, .fixed, .vbr, .char6: return false
-        }
-      }
-    }
-
-    var operands: [Operand] = []
-  }
-
-  enum Error: Swift.Error {
-    case invalidAbbrev
-    case nestedBlockInBlockInfo
-    case missingSETBID
-    case invalidBlockInfoRecord(recordID: UInt64)
-    case abbrevWidthTooSmall(width: Int)
-    case noSuchAbbrev(blockID: UInt64, abbrevID: Int)
-    case missingEndBlock(blockID: UInt64)
-  }
-
-  var cursor: Bits.Cursor
-  var blockInfo: [UInt64: BlockInfo] = [:]
-  var globalAbbrevs: [UInt64: [Abbrev]] = [:]
-
-  init(buffer: Data) {
-    cursor = Bits.Cursor(buffer: buffer)
-  }
-
-  mutating func readAbbrevOp() throws -> Abbrev.Operand {
-    let isLiteralFlag = try cursor.read(1)
-    if isLiteralFlag == 1 {
-      return .literal(try cursor.readVBR(8))
-    }
-
-    switch try cursor.read(3) {
-    case 0:
-      throw Error.invalidAbbrev
-    case 1:
-      return .fixed(Int(try cursor.readVBR(5)))
-    case 2:
-      return .vbr(Int(try cursor.readVBR(5)))
-    case 3:
-      return .array(try readAbbrevOp())
-    case 4:
-      return .char6
-    case 5:
-      return .blob
-    case 6, 7:
-      throw Error.invalidAbbrev
-    default:
-      fatalError()
-    }
-  }
-
-  mutating func readAbbrev(numOps: Int) throws -> Abbrev {
-    guard numOps > 0 else { throw Error.invalidAbbrev }
-
-    var operands: [Abbrev.Operand] = []
-    for i in 0..<numOps {
-      operands.append(try readAbbrevOp())
-
-      if case .array = operands.last! {
-        guard i == numOps - 2 else { throw Error.invalidAbbrev }
-        break
-      } else if case .blob = operands.last! {
-        guard i == numOps - 1 else { throw Error.invalidAbbrev }
-      }
-    }
-
-    return Abbrev(operands: operands)
-  }
-
-  mutating func readSingleAbbreviatedRecordOperand(_ operand: Abbrev.Operand) throws -> UInt64 {
-    switch operand {
-    case .char6:
-      let value = try cursor.read(6)
-      switch value {
-      case 0...25:
-        return value + UInt64(("a" as UnicodeScalar).value)
-      case 26...51:
-        return value + UInt64(("A" as UnicodeScalar).value) - 26
-      case 52...61:
-        return value + UInt64(("0" as UnicodeScalar).value) - 52
-      case 62:
-        return UInt64(("." as UnicodeScalar).value)
-      case 63:
-        return UInt64(("_" as UnicodeScalar).value)
-      default:
-        fatalError()
-      }
-    case .literal(let value):
-      return value
-    case .fixed(let width):
-      return try cursor.read(width)
-    case .vbr(let width):
-      return try cursor.readVBR(width)
-    case .array, .blob:
-      fatalError()
-    }
-  }
-
-  mutating func readAbbreviatedRecord(_ abbrev: Abbrev) throws -> BitcodeElement.Record {
-    let code = try readSingleAbbreviatedRecordOperand(abbrev.operands.first!)
-
-    let lastOperand = abbrev.operands.last!
-    let lastRegularOperandIndex: Int = abbrev.operands.endIndex - (lastOperand.isPayload ? 1 : 0)
-
-    var fields = [UInt64]()
-    for op in abbrev.operands[1..<lastRegularOperandIndex] {
-      fields.append(try readSingleAbbreviatedRecordOperand(op))
-    }
-
-    let payload: BitcodeElement.Record.Payload
-    if !lastOperand.isPayload {
-      payload = .none
-    } else {
-      switch lastOperand {
-      case .array(let element):
-        let length = try cursor.readVBR(6)
-        var elements = [UInt64]()
-        for _ in 0..<length {
-          elements.append(try readSingleAbbreviatedRecordOperand(element))
-        }
-        if case .char6 = element {
-          payload = .char6String(String(String.UnicodeScalarView(elements.map { UnicodeScalar(UInt8($0)) })))
-        } else {
-          payload = .array(elements)
-        }
-      case .blob:
-        let length = Int(try cursor.readVBR(6))
-        try cursor.advance(toBitAlignment: 32)
-        payload = .blob(try cursor.read(bytes: length))
-        try cursor.advance(toBitAlignment: 32)
-      default:
-        fatalError()
-      }
-    }
-
-    return .init(id: code, fields: fields, payload: payload)
-  }
-
-  mutating func readBlockInfoBlock(abbrevWidth: Int) throws {
-    var currentBlockID: UInt64?
-    while true {
-      switch try cursor.read(abbrevWidth) {
-      case 0: // END_BLOCK
-        try cursor.advance(toBitAlignment: 32)
-        // FIXME: check expected length
-        return
-
-      case 1: // ENTER_BLOCK
-        throw Error.nestedBlockInBlockInfo
-
-      case 2: // DEFINE_ABBREV
-        guard let blockID = currentBlockID else {
-          throw Error.missingSETBID
-        }
-        let numOps = Int(try cursor.readVBR(5))
-        if globalAbbrevs[blockID] == nil { globalAbbrevs[blockID] = [] }
-        globalAbbrevs[blockID]!.append(try readAbbrev(numOps: numOps))
-
-      case 3: // UNABBREV_RECORD
-        let code = try cursor.readVBR(6)
-        let numOps = try cursor.readVBR(6)
-        var operands = [UInt64]()
-        for _ in 0..<numOps {
-          operands.append(try cursor.readVBR(6))
-        }
-
-        switch code {
-        case 1:
-          guard operands.count == 1 else { throw Error.invalidBlockInfoRecord(recordID: code) }
-          currentBlockID = operands.first
-        case 2:
-          guard let blockID = currentBlockID else {
-            throw Error.missingSETBID
-          }
-          if blockInfo[blockID] == nil { blockInfo[blockID] = BlockInfo() }
-          blockInfo[blockID]!.name = String(bytes: operands.map { UInt8($0) }, encoding: .utf8) ?? "<invalid>"
-        case 3:
-          guard let blockID = currentBlockID else {
-            throw Error.missingSETBID
-          }
-          if blockInfo[blockID] == nil { blockInfo[blockID] = BlockInfo() }
-          guard let recordID = operands.first else {
-            throw Error.invalidBlockInfoRecord(recordID: code)
-          }
-          blockInfo[blockID]!.recordNames[recordID] = String(bytes: operands.dropFirst().map { UInt8($0) }, encoding: .utf8) ?? "<invalid>"
-        default:
-          throw Error.invalidBlockInfoRecord(recordID: code)
-        }
-
-      case let abbrevID:
-        throw Error.noSuchAbbrev(blockID: 0, abbrevID: Int(abbrevID))
-      }
-    }
-  }
-
-  mutating func readBlock<Visitor: BitstreamVisitor>(id: UInt64, abbrevWidth: Int, abbrevInfo: [Abbrev], visitor: inout Visitor) throws {
-    var abbrevInfo = abbrevInfo
-
-    while !cursor.isAtEnd {
-      switch try cursor.read(abbrevWidth) {
-      case 0: // END_BLOCK
-        try cursor.advance(toBitAlignment: 32)
-        // FIXME: check expected length
-        try visitor.didExitBlock()
-        return
-
-      case 1: // ENTER_SUBBLOCK
-        let blockID = try cursor.readVBR(8)
-        let newAbbrevWidth = Int(try cursor.readVBR(4))
-        try cursor.advance(toBitAlignment: 32)
-        let blockLength = try cursor.read(32) * 4
-
-        switch blockID {
-        case 0:
-          try readBlockInfoBlock(abbrevWidth: newAbbrevWidth)
-        case 1...7:
-          // Metadata blocks we don't understand yet
-          fallthrough
-        default:
-          guard try visitor.shouldEnterBlock(id: blockID) else {
-            try cursor.skip(bytes: Int(blockLength))
-            break
-          }
-          try readBlock(
-            id: blockID, abbrevWidth: newAbbrevWidth,
-            abbrevInfo: globalAbbrevs[blockID] ?? [], visitor: &visitor)
-        }
-
-      case 2: // DEFINE_ABBREV
-        let numOps = Int(try cursor.readVBR(5))
-        abbrevInfo.append(try readAbbrev(numOps: numOps))
-
-      case 3: // UNABBREV_RECORD
-        let code = try cursor.readVBR(6)
-        let numOps = try cursor.readVBR(6)
-        var operands = [UInt64]()
-        for _ in 0..<numOps {
-          operands.append(try cursor.readVBR(6))
-        }
-        try visitor.visit(record: .init(id: code, fields: operands, payload: .none))
-
-      case let abbrevID:
-        guard Int(abbrevID) - 4 < abbrevInfo.count else {
-          throw Error.noSuchAbbrev(blockID: id, abbrevID: Int(abbrevID))
-        }
-        try visitor.visit(record: try readAbbreviatedRecord(abbrevInfo[Int(abbrevID) - 4]))
-      }
-    }
-
-    guard id == Self.fakeTopLevelBlockID else {
-      throw Error.missingEndBlock(blockID: id)
-    }
-  }
-
-  static let fakeTopLevelBlockID: UInt64 = ~0
-}
-
 /// A visitor which receives callbacks while reading a bitstream.
 public protocol BitstreamVisitor {
   /// Customization point to validate a bitstream's signature or "magic number".
@@ -374,66 +79,121 @@ public protocol BitstreamVisitor {
   mutating func visit(record: BitcodeElement.Record) throws
 }
 
-/// A basic visitor that collects all the blocks and records in a stream.
-private struct CollectingVisitor: BitstreamVisitor {
-  var stack: [(UInt64, [BitcodeElement])] = [(BitstreamReader.fakeTopLevelBlockID, [])]
+/// A top-level namespace for all bitstream
+public enum Bitstream {}
 
-  func validate(signature: Bitcode.Signature) throws {}
+extension Bitstream {
+  public struct Abbreviation {
+    public enum Operand {
+      /// A literal value (emitted as a VBR8 field).
+      case literal(UInt64)
 
-  mutating func shouldEnterBlock(id: UInt64) throws -> Bool {
-    stack.append((id, []))
-    return true
-  }
+      /// A fixed-width field.
+      case fixed(bitWidth: UInt8)
 
-  mutating func didExitBlock() throws {
-    guard let (id, elements) = stack.popLast() else {
-      fatalError("Unbalanced calls to shouldEnterBlock/didExitBlock")
+      /// A VBR-encoded value with the provided chunk width.
+      case vbr(chunkBitWidth: UInt8)
+
+      /// An array of values. This expects another operand encoded
+      /// directly after indicating the element type.
+      /// The array will begin with a vbr6 value indicating the length of
+      /// the following array.
+      indirect case array(Operand)
+
+      /// A char6-encoded ASCII character.
+      case char6
+
+      /// Emitted as a vbr6 value, padded to a 32-bit boundary and then
+      /// an array of 8-bit objects.
+      case blob
+
+      var isPayload: Bool {
+        switch self {
+        case .array, .blob: return true
+        case .literal, .fixed, .vbr, .char6: return false
+        }
+      }
+
+      /// Whether this case is the `literal` case.
+      var isLiteral: Bool {
+        if case .literal = self { return true }
+        return false
+      }
+
+      /// The llvm::BitCodeAbbrevOp::Encoding value this
+      /// enum case represents.
+      /// - note: Must match the encoding in
+      ///         http://llvm.org/docs/BitCodeFormat.html#define-abbrev-encoding
+      var encodedKind: UInt8 {
+        switch self {
+        case .literal(_): return 0
+        case .fixed(_): return 1
+        case .vbr(_): return 2
+        case .array: return 3
+        case .char6: return 4
+        case .blob: return 5
+        }
+      }
     }
 
-    let block = BitcodeElement.Block(id: id, elements: elements)
-    stack[stack.endIndex-1].1.append(.block(block))
-  }
+    public var operands: [Operand] = []
 
-  mutating func visit(record: BitcodeElement.Record) throws {
-    stack[stack.endIndex-1].1.append(.record(record))
-  }
-
-  func finalizeTopLevelElements() -> [BitcodeElement] {
-    assert(stack.count == 1)
-    return stack[0].1
+    public init(_ operands: [Operand]) {
+      self.operands = operands
+    }
   }
 }
 
-extension Bitcode {
-  /// Parse a bitstream from data.
-  public init(data: Data) throws {
-    precondition(data.count > 4)
-    let signatureValue = UInt32(Bits(buffer: data).readBits(atOffset: 0, count: 32))
-    let bitstreamData = data[4..<data.count]
+extension Bitstream {
+  public struct BlockID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
+    public var rawValue: UInt8
 
-    var reader = BitstreamReader(buffer: bitstreamData)
-    var visitor = CollectingVisitor()
-    try reader.readBlock(id: BitstreamReader.fakeTopLevelBlockID,
-                         abbrevWidth: 2,
-                         abbrevInfo: [],
-                         visitor: &visitor)
-    self.init(signature: .init(value: signatureValue),
-              elements: visitor.finalizeTopLevelElements(),
-              blockInfo: reader.blockInfo)
+    public init(rawValue: UInt8) {
+      self.rawValue = rawValue
+    }
+
+    public static let blockInfo = Self(rawValue: 0)
+    public static let firstApplicationID = Self(rawValue: 8)
+
+    public var id: UInt8 {
+      self.rawValue
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      lhs.rawValue < rhs.rawValue
+    }
+
+    public static func + (lhs: Self, rhs: UInt8) -> Self {
+      return BlockID(rawValue: lhs.rawValue + rhs)
+    }
   }
+}
 
-  /// Traverse a bitstream using the specified `visitor`, which will receive
-  /// callbacks when blocks and records are encountered.
-  public static func read<Visitor: BitstreamVisitor>(stream data: Data, using visitor: inout Visitor) throws {
-    precondition(data.count > 4)
-    let signatureValue = UInt32(Bits(buffer: data).readBits(atOffset: 0, count: 32))
-    try visitor.validate(signature: .init(value: signatureValue))
+extension Bitstream {
+  public struct AbbreviationID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
+    public var rawValue: UInt64
 
-    let bitstreamData = data[4..<data.count]
-    var reader = BitstreamReader(buffer: bitstreamData)
-    try reader.readBlock(id: BitstreamReader.fakeTopLevelBlockID,
-                         abbrevWidth: 2,
-                         abbrevInfo: [],
-                         visitor: &visitor)
+    public init(rawValue: UInt64) {
+      self.rawValue = rawValue
+    }
+
+    public static let endBlock = Self(rawValue: 0)
+    public static let enterSubblock = Self(rawValue: 1)
+    public static let defineAbbreviation = Self(rawValue: 2)
+    public static let unabbreviatedRecord = Self(rawValue: 3)
+    /// The first application-defined abbreviation ID.
+    public static let firstApplicationID = Self(rawValue: 4)
+
+    public var id: UInt64 {
+      self.rawValue
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+      lhs.rawValue < rhs.rawValue
+    }
+
+    public static func + (lhs: Self, rhs: UInt64) -> Self {
+      return AbbreviationID(rawValue: lhs.rawValue + rhs)
+    }
   }
 }

--- a/Sources/TSCUtility/Bitstream.swift
+++ b/Sources/TSCUtility/Bitstream.swift
@@ -148,6 +148,24 @@ extension Bitstream {
 }
 
 extension Bitstream {
+    /// A `BlockInfoCode` enumerates the bits that occur in the metadata for
+    /// a block or record. Of these bits, only `setBID` is required. If
+    /// a name is given to a block or record with `blockName` or
+    /// `setRecordName`, debugging tools like `llvm-bcanalyzer` can be used to
+    /// introspect the structure of blocks and records in the bitstream file.
+    public enum BlockInfoCode: UInt8 {
+        /// Indicates which block ID is being described.
+        case setBID = 1
+        /// An optional element that records which bytes of the record are the
+        /// name of the block.
+        case blockName = 2
+        /// An optional element that records the record ID number and the bytes
+        /// for the name of the corresponding record.
+        case setRecordName = 3
+    }
+}
+
+extension Bitstream {
   /// A `BlockID` is a fixed-width field that occurs at the start of all blocks.
   ///
   /// Bistream reserves the first 7 block IDs for its own bookkeeping. User

--- a/Sources/TSCUtility/BitstreamReader.swift
+++ b/Sources/TSCUtility/BitstreamReader.swift
@@ -1,0 +1,350 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+extension Bitcode {
+  /// Parse a bitstream from data.
+  public init(data: Data) throws {
+    precondition(data.count > 4)
+    let signatureValue = UInt32(Bits(buffer: data).readBits(atOffset: 0, count: 32))
+    let bitstreamData = data[4..<data.count]
+
+    var reader = BitstreamReader(buffer: bitstreamData)
+    var visitor = CollectingVisitor()
+    try reader.readBlock(id: BitstreamReader.fakeTopLevelBlockID,
+                         abbrevWidth: 2,
+                         abbrevInfo: [],
+                         visitor: &visitor)
+    self.init(signature: .init(value: signatureValue),
+              elements: visitor.finalizeTopLevelElements(),
+              blockInfo: reader.blockInfo)
+  }
+
+  /// Traverse a bitstream using the specified `visitor`, which will receive
+  /// callbacks when blocks and records are encountered.
+  public static func read<Visitor: BitstreamVisitor>(stream data: Data, using visitor: inout Visitor) throws {
+    precondition(data.count > 4)
+    let signatureValue = UInt32(Bits(buffer: data).readBits(atOffset: 0, count: 32))
+    try visitor.validate(signature: .init(value: signatureValue))
+
+    let bitstreamData = data[4..<data.count]
+    var reader = BitstreamReader(buffer: bitstreamData)
+    try reader.readBlock(id: BitstreamReader.fakeTopLevelBlockID,
+                         abbrevWidth: 2,
+                         abbrevInfo: [],
+                         visitor: &visitor)
+  }
+}
+
+/// A basic visitor that collects all the blocks and records in a stream.
+private struct CollectingVisitor: BitstreamVisitor {
+  var stack: [(UInt64, [BitcodeElement])] = [(BitstreamReader.fakeTopLevelBlockID, [])]
+
+  func validate(signature: Bitcode.Signature) throws {}
+
+  mutating func shouldEnterBlock(id: UInt64) throws -> Bool {
+    stack.append((id, []))
+    return true
+  }
+
+  mutating func didExitBlock() throws {
+    guard let (id, elements) = stack.popLast() else {
+      fatalError("Unbalanced calls to shouldEnterBlock/didExitBlock")
+    }
+
+    let block = BitcodeElement.Block(id: id, elements: elements)
+    stack[stack.endIndex-1].1.append(.block(block))
+  }
+
+  mutating func visit(record: BitcodeElement.Record) throws {
+    stack[stack.endIndex-1].1.append(.record(record))
+  }
+
+  func finalizeTopLevelElements() -> [BitcodeElement] {
+    assert(stack.count == 1)
+    return stack[0].1
+  }
+}
+
+private extension Bits.Cursor {
+  enum BitcodeError: Swift.Error {
+    case vbrOverflow
+  }
+
+  mutating func readVBR(_ width: Int) throws -> UInt64 {
+    precondition(width > 1)
+    let testBit = UInt64(1 << (width &- 1))
+    let mask = testBit &- 1
+
+    var result: UInt64 = 0
+    var offset: UInt64 = 0
+    var next: UInt64
+    repeat {
+      next = try self.read(width)
+      result |= (next & mask) << offset
+      offset += UInt64(width &- 1)
+      if offset > 64 { throw BitcodeError.vbrOverflow }
+    } while next & testBit != 0
+
+    return result
+  }
+}
+
+private struct BitstreamReader {
+  enum Error: Swift.Error {
+    case invalidAbbrev
+    case nestedBlockInBlockInfo
+    case missingSETBID
+    case invalidBlockInfoRecord(recordID: UInt64)
+    case abbrevWidthTooSmall(width: Int)
+    case noSuchAbbrev(blockID: UInt64, abbrevID: Int)
+    case missingEndBlock(blockID: UInt64)
+  }
+
+  var cursor: Bits.Cursor
+  var blockInfo: [UInt64: BlockInfo] = [:]
+  var globalAbbrevs: [UInt64: [Bitstream.Abbreviation]] = [:]
+
+  init(buffer: Data) {
+    cursor = Bits.Cursor(buffer: buffer)
+  }
+
+  mutating func readAbbrevOp() throws -> Bitstream.Abbreviation.Operand {
+    let isLiteralFlag = try cursor.read(1)
+    if isLiteralFlag == 1 {
+      return .literal(try cursor.readVBR(8))
+    }
+
+    switch try cursor.read(3) {
+    case 0:
+      throw Error.invalidAbbrev
+    case 1:
+      return .fixed(bitWidth: UInt8(try cursor.readVBR(5)))
+    case 2:
+      return .vbr(chunkBitWidth: UInt8(try cursor.readVBR(5)))
+    case 3:
+      return .array(try readAbbrevOp())
+    case 4:
+      return .char6
+    case 5:
+      return .blob
+    case 6, 7:
+      throw Error.invalidAbbrev
+    default:
+      fatalError()
+    }
+  }
+
+  mutating func readAbbrev(numOps: Int) throws -> Bitstream.Abbreviation {
+    guard numOps > 0 else { throw Error.invalidAbbrev }
+
+    var operands: [Bitstream.Abbreviation.Operand] = []
+    for i in 0..<numOps {
+      operands.append(try readAbbrevOp())
+
+      if case .array = operands.last! {
+        guard i == numOps - 2 else { throw Error.invalidAbbrev }
+        break
+      } else if case .blob = operands.last! {
+        guard i == numOps - 1 else { throw Error.invalidAbbrev }
+      }
+    }
+
+    return Bitstream.Abbreviation(operands)
+  }
+
+  mutating func readSingleAbbreviatedRecordOperand(_ operand: Bitstream.Abbreviation.Operand) throws -> UInt64 {
+    switch operand {
+    case .char6:
+      let value = try cursor.read(6)
+      switch value {
+      case 0...25:
+        return value + UInt64(("a" as UnicodeScalar).value)
+      case 26...51:
+        return value + UInt64(("A" as UnicodeScalar).value) - 26
+      case 52...61:
+        return value + UInt64(("0" as UnicodeScalar).value) - 52
+      case 62:
+        return UInt64(("." as UnicodeScalar).value)
+      case 63:
+        return UInt64(("_" as UnicodeScalar).value)
+      default:
+        fatalError()
+      }
+    case .literal(let value):
+      return value
+    case .fixed(let width):
+      return try cursor.read(Int(width))
+    case .vbr(let width):
+      return try cursor.readVBR(Int(width))
+    case .array, .blob:
+      fatalError()
+    }
+  }
+
+  mutating func readAbbreviatedRecord(_ abbrev: Bitstream.Abbreviation) throws -> BitcodeElement.Record {
+    let code = try readSingleAbbreviatedRecordOperand(abbrev.operands.first!)
+
+    let lastOperand = abbrev.operands.last!
+    let lastRegularOperandIndex: Int = abbrev.operands.endIndex - (lastOperand.isPayload ? 1 : 0)
+
+    var fields = [UInt64]()
+    for op in abbrev.operands[1..<lastRegularOperandIndex] {
+      fields.append(try readSingleAbbreviatedRecordOperand(op))
+    }
+
+    let payload: BitcodeElement.Record.Payload
+    if !lastOperand.isPayload {
+      payload = .none
+    } else {
+      switch lastOperand {
+      case .array(let element):
+        let length = try cursor.readVBR(6)
+        var elements = [UInt64]()
+        for _ in 0..<length {
+          elements.append(try readSingleAbbreviatedRecordOperand(element))
+        }
+        if case .char6 = element {
+          payload = .char6String(String(String.UnicodeScalarView(elements.map { UnicodeScalar(UInt8($0)) })))
+        } else {
+          payload = .array(elements)
+        }
+      case .blob:
+        let length = Int(try cursor.readVBR(6))
+        try cursor.advance(toBitAlignment: 32)
+        payload = .blob(try cursor.read(bytes: length))
+        try cursor.advance(toBitAlignment: 32)
+      default:
+        fatalError()
+      }
+    }
+
+    return .init(id: code, fields: fields, payload: payload)
+  }
+
+  mutating func readBlockInfoBlock(abbrevWidth: Int) throws {
+    var currentBlockID: UInt64?
+    while true {
+      switch try cursor.read(abbrevWidth) {
+      case Bitstream.AbbreviationID.endBlock.rawValue:
+        try cursor.advance(toBitAlignment: 32)
+        // FIXME: check expected length
+        return
+
+      case Bitstream.AbbreviationID.enterSubblock.rawValue:
+        throw Error.nestedBlockInBlockInfo
+
+      case Bitstream.AbbreviationID.defineAbbreviation.rawValue:
+        guard let blockID = currentBlockID else {
+          throw Error.missingSETBID
+        }
+        let numOps = Int(try cursor.readVBR(5))
+        if globalAbbrevs[blockID] == nil { globalAbbrevs[blockID] = [] }
+        globalAbbrevs[blockID]!.append(try readAbbrev(numOps: numOps))
+
+      case Bitstream.AbbreviationID.unabbreviatedRecord.rawValue:
+        let code = try cursor.readVBR(6)
+        let numOps = try cursor.readVBR(6)
+        var operands = [UInt64]()
+        for _ in 0..<numOps {
+          operands.append(try cursor.readVBR(6))
+        }
+
+        switch code {
+        case 1:
+          guard operands.count == 1 else { throw Error.invalidBlockInfoRecord(recordID: code) }
+          currentBlockID = operands.first
+        case 2:
+          guard let blockID = currentBlockID else {
+            throw Error.missingSETBID
+          }
+          if blockInfo[blockID] == nil { blockInfo[blockID] = BlockInfo() }
+          blockInfo[blockID]!.name = String(bytes: operands.map { UInt8($0) }, encoding: .utf8) ?? "<invalid>"
+        case 3:
+          guard let blockID = currentBlockID else {
+            throw Error.missingSETBID
+          }
+          if blockInfo[blockID] == nil { blockInfo[blockID] = BlockInfo() }
+          guard let recordID = operands.first else {
+            throw Error.invalidBlockInfoRecord(recordID: code)
+          }
+          blockInfo[blockID]!.recordNames[recordID] = String(bytes: operands.dropFirst().map { UInt8($0) }, encoding: .utf8) ?? "<invalid>"
+        default:
+          throw Error.invalidBlockInfoRecord(recordID: code)
+        }
+
+      case let abbrevID:
+        throw Error.noSuchAbbrev(blockID: 0, abbrevID: Int(abbrevID))
+      }
+    }
+  }
+
+  mutating func readBlock<Visitor: BitstreamVisitor>(id: UInt64, abbrevWidth: Int, abbrevInfo: [Bitstream.Abbreviation], visitor: inout Visitor) throws {
+    var abbrevInfo = abbrevInfo
+
+    while !cursor.isAtEnd {
+      switch try cursor.read(abbrevWidth) {
+      case Bitstream.AbbreviationID.endBlock.rawValue:
+        try cursor.advance(toBitAlignment: 32)
+        // FIXME: check expected length
+        try visitor.didExitBlock()
+        return
+
+      case Bitstream.AbbreviationID.enterSubblock.rawValue:
+        let blockID = try cursor.readVBR(8)
+        let newAbbrevWidth = Int(try cursor.readVBR(4))
+        try cursor.advance(toBitAlignment: 32)
+        let blockLength = try cursor.read(32) * 4
+
+        switch blockID {
+        case 0:
+          try readBlockInfoBlock(abbrevWidth: newAbbrevWidth)
+        case 1...7:
+          // Metadata blocks we don't understand yet
+          fallthrough
+        default:
+          guard try visitor.shouldEnterBlock(id: blockID) else {
+            try cursor.skip(bytes: Int(blockLength))
+            break
+          }
+          try readBlock(
+            id: blockID, abbrevWidth: newAbbrevWidth,
+            abbrevInfo: globalAbbrevs[blockID] ?? [], visitor: &visitor)
+        }
+
+      case Bitstream.AbbreviationID.defineAbbreviation.rawValue:
+        let numOps = Int(try cursor.readVBR(5))
+        abbrevInfo.append(try readAbbrev(numOps: numOps))
+
+      case Bitstream.AbbreviationID.unabbreviatedRecord.rawValue:
+        let code = try cursor.readVBR(6)
+        let numOps = try cursor.readVBR(6)
+        var operands = [UInt64]()
+        for _ in 0..<numOps {
+          operands.append(try cursor.readVBR(6))
+        }
+        try visitor.visit(record: .init(id: code, fields: operands, payload: .none))
+
+      case let abbrevID:
+        guard Int(abbrevID) - 4 < abbrevInfo.count else {
+          throw Error.noSuchAbbrev(blockID: id, abbrevID: Int(abbrevID))
+        }
+        try visitor.visit(record: try readAbbreviatedRecord(abbrevInfo[Int(abbrevID) - 4]))
+      }
+    }
+
+    guard id == Self.fakeTopLevelBlockID else {
+      throw Error.missingEndBlock(blockID: id)
+    }
+  }
+
+  static let fakeTopLevelBlockID: UInt64 = ~0
+}

--- a/Sources/TSCUtility/BitstreamReader.swift
+++ b/Sources/TSCUtility/BitstreamReader.swift
@@ -259,16 +259,16 @@ private struct BitstreamReader {
         }
 
         switch code {
-        case 1:
+        case UInt64(Bitstream.BlockInfoCode.setBID.rawValue):
           guard operands.count == 1 else { throw Error.invalidBlockInfoRecord(recordID: code) }
           currentBlockID = operands.first
-        case 2:
+        case UInt64(Bitstream.BlockInfoCode.blockName.rawValue):
           guard let blockID = currentBlockID else {
             throw Error.missingSETBID
           }
           if blockInfo[blockID] == nil { blockInfo[blockID] = BlockInfo() }
           blockInfo[blockID]!.name = String(bytes: operands.map { UInt8($0) }, encoding: .utf8) ?? "<invalid>"
-        case 3:
+        case UInt64(Bitstream.BlockInfoCode.setRecordName.rawValue):
           guard let blockID = currentBlockID else {
             throw Error.missingSETBID
           }

--- a/Sources/TSCUtility/BitstreamWriter.swift
+++ b/Sources/TSCUtility/BitstreamWriter.swift
@@ -1,0 +1,566 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import Foundation
+
+public final class BitstreamWriter {
+    public enum BlockInfoCode: UInt8 {
+        case setBID = 1
+        case blockName = 2
+        case setRecordName = 3
+    }
+
+    /// The buffer of data being written to.
+    private(set) public var data: [UInt8]
+
+    /// The current value. Only bits < currentBit are valid.
+    private var currentValue: UInt32 = 0
+
+    /// Always between 0 and 31 inclusive, specifies the next bit to use.
+    private var currentBit: UInt8 = 0
+
+    /// The bit width used for abbreviated codes.
+    private var codeBitWidth: UInt8
+
+    /// The list of defined abbreviations.
+    private var currentAbbreviations = [Bitstream.Abbreviation]()
+
+    /// Represents an in-flight block currently being emitted.
+    struct Block {
+        /// The code width before we started emitting this block.
+        let previousCodeWidth: UInt8
+
+        /// The index into the data buffer where this block's length placeholder
+        /// lives.
+        let lengthPlaceholderByteIndex: Int
+
+        /// The previous set of abbreviations registered.
+        let previousAbbrevs: [Bitstream.Abbreviation]
+    }
+
+    /// This keeps track of the blocks that are being emitted.
+    private var blockScope = [Block]()
+
+    /// This contains information emitted to BLOCKINFO_BLOCK blocks.
+    /// These describe abbreviations that all blocks of the specified ID inherit.
+    final class BlockInfo {
+        var abbrevs = [Bitstream.Abbreviation]()
+    }
+    /// This maps BlockInfo IDs to their corresponding values.
+    private var blockInfoRecords = [UInt8: BlockInfo]()
+
+    /// When emitting blockinfo, this is the ID of the current block being
+    /// emitted.
+    private var currentBlockID: Bitstream.BlockID?
+
+    /// Creates a new BitstreamWriter with the provided data stream.
+    public init(data: [UInt8] = []) {
+        self.data = data
+        self.codeBitWidth = 2
+    }
+
+
+    public var bufferOffset: Int {
+        return data.count
+    }
+
+    /// \brief Retrieve the current position in the stream, in bits.
+    public var bitNumber: Int {
+        return bufferOffset * 8 + Int(currentBit)
+    }
+
+    public var isEmpty: Bool {
+        return self.data.isEmpty
+    }
+}
+
+// MARK: Data Writing Primitives
+
+extension BitstreamWriter {
+    /// Writes the provided UInt32 to the data stream directly.
+    public func write(_ int: UInt32) {
+        let index = data.count
+
+        // Add 4 bytes of zeroes to be overwritten.
+        data.append(0)
+        data.append(0)
+        data.append(0)
+        data.append(0)
+
+        overwriteBytes(int, byteIndex: index)
+    }
+
+    /// Writes the provided number of bits to the buffer.
+    ///
+    /// - Parameters:
+    ///   - int: The integer containing the bits you'd like to write
+    ///   - width: The number of low-bits of the integer you're writing to the
+    ///            buffer
+    public func writeVBR<IntType>(_ int: IntType, width: UInt8)
+        where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        let threshold = UInt64(1) << (UInt64(width) - 1)
+        var value = UInt64(int)
+
+        // Emit the bits with VBR encoding, (width - 1) bits at a time.
+        while value >= threshold {
+            let masked = (value & (threshold - 1)) | threshold
+            write(masked, width: width)
+            value >>= width - 1
+        }
+
+        write(value, width: width)
+    }
+
+    /// Writes the provided number of bits to the buffer.
+    ///
+    /// - Parameters:
+    ///   - int: The integer containing the bits you'd like to write
+    ///   - width: The number of low-bits of the integer you're writing to the
+    ///            buffer
+    public func write<IntType>(_ int: IntType, width: UInt8)
+        where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        precondition(width > 0, "cannot emit 0 bits")
+        precondition(width <= 32, "can only write at most 32 bits")
+
+        let intPattern = UInt32(int)
+
+        precondition(intPattern & ~(~(0 as UInt32) >> (32 - width)) == 0,
+                     "High bits set!")
+
+        // Mask the bits of the argument over the current bit we're tracking
+        let intMask = intPattern << currentBit
+        currentValue |= intMask
+
+        // If we haven't spilled past the temp buffer, just update the
+        // current bit.
+        if currentBit + width < 32 {
+            currentBit += width
+            return
+        }
+
+        // Otherwise, write the current value.
+        write(currentValue)
+
+        if currentBit > 0 {
+            // If we still have bits leftover, replace the current buffer with
+            // the low bits of the input, offset by the current bit.
+            // For example, when we're adding:
+            // 0b00000000_00000000_00000000_00000011
+            // to
+            // 0b01111111_11111111_11111111_11111111
+            //    ^ currentBit (31)
+            // We've already taken 1 bit off the end of the first number,
+            // leaving an extra 1 bit that needs to be represented for the next
+            // write.
+            // Subtract the currentBit from 32 to get the number of bits
+            // leftover and then shift to get rid of the already-recorded bits.
+            currentValue = UInt32(int) >> (32 - UInt32(currentBit))
+        } else {
+            // Otherwise, reset our buffer.
+            currentValue = 0
+        }
+        currentBit = (currentBit + width) & 31
+    }
+
+    public func alignIfNeeded() {
+        guard currentBit > 0 else { return }
+        write(currentValue)
+        assert(bufferOffset % 4 == 0, "buffer must be 32-bit aligned")
+        currentValue = 0
+        currentBit = 0
+    }
+
+    /// Writes a Bool as a 1-bit integer value.
+    public func write(_ bool: Bool) {
+        write(bool ? 1 as UInt : 0, width: 1)
+    }
+
+    /// Writes the provided BitCode Abbrev operand to the stream.
+    public func write(_ abbrevOp: Bitstream.Abbreviation.Operand) {
+        write(abbrevOp.isLiteral) // the Literal bit.
+        switch abbrevOp {
+        case .literal(let value):
+            // Literal values are 1 (for the Literal bit) and then a vbr8
+            // encoded literal.
+            writeVBR(value, width: 8)
+        case .fixed(let bitWidth):
+            // Fixed values are the encoding kind then the bitWidth as a vbr5
+            // value.
+            write(abbrevOp.encodedKind, width: 3)
+            writeVBR(bitWidth, width: 5)
+        case .vbr(let chunkBitWidth):
+            // VBR values are the encoding kind then the chunk width as a
+            // vbr5 value.
+            write(abbrevOp.encodedKind, width: 3)
+            writeVBR(chunkBitWidth, width: 5)
+        case .array(let eltOp):
+            // Arrays are encoded as the Array kind, then the element type
+            // directly after.
+            write(abbrevOp.encodedKind, width: 3)
+            write(eltOp)
+        case .char6, .blob:
+            // Blobs and Char6 are just their encoding kind.
+            write(abbrevOp.encodedKind, width: 3)
+        }
+    }
+
+    /// Writes the specified abbreviaion value to the stream, as a 32-bit quantity.
+    public func writeCode(_ code: Bitstream.AbbreviationID) {
+        writeCode(code.rawValue)
+    }
+
+    /// Writes the specified Code value to the stream, as a 32-bit quantity.
+    public func writeCode<IntType>(_ code: IntType)
+        where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        write(code, width: codeBitWidth)
+    }
+
+    /// Writes an ASCII character to the stream, as an 8-bit ascii value.
+    public func writeASCII(_ character: Character) {
+        precondition(character.unicodeScalars.count == 1, "character is not ASCII")
+        let c = UInt8(ascii: character.unicodeScalars.first!)
+        write(c, width: 8)
+    }
+}
+
+// MARK: Abbreviations
+
+extension BitstreamWriter {
+    /// Defines an abbreviation and returns the unique identifier for that
+    /// abbreviation.
+    public func defineAbbreviation(_ abbrev: Bitstream.Abbreviation) -> Bitstream.AbbreviationID {
+        encodeAbbreviation(abbrev)
+        currentAbbreviations.append(abbrev)
+        let rawValue = UInt64(currentAbbreviations.count - 1) +
+                                Bitstream.AbbreviationID.firstApplicationID.rawValue
+        return Bitstream.AbbreviationID(rawValue: rawValue)
+    }
+
+    /// Encodes the definition of an abbreviation to the stream.
+    private func encodeAbbreviation(_ abbrev: Bitstream.Abbreviation) {
+        writeCode(.defineAbbreviation)
+        writeVBR(UInt(abbrev.operands.count), width: 5)
+        for op in abbrev.operands {
+            write(op)
+        }
+    }
+}
+
+// MARK: Writing Records
+
+extension BitstreamWriter {
+    public struct RecordBuffer {
+        private(set) var values = [UInt32]()
+
+        fileprivate init() {
+            self.values = []
+        }
+
+        fileprivate init<CodeType>(recordID: CodeType)
+            where CodeType: RawRepresentable, CodeType.RawValue: UnsignedInteger & ExpressibleByIntegerLiteral
+        {
+            self.values = [ UInt32(recordID.rawValue) ]
+        }
+
+        fileprivate init(block: Bitstream.BlockID) {
+            self.values = [ UInt32(block.rawValue) ]
+        }
+
+        fileprivate init(abbreviation: Bitstream.AbbreviationID) {
+            self.values = [ UInt32(abbreviation.rawValue) ]
+        }
+
+        public mutating func append<CodeType>(_ code: CodeType)
+            where CodeType: RawRepresentable, CodeType.RawValue: UnsignedInteger & ExpressibleByIntegerLiteral
+        {
+            values.append(UInt32(code.rawValue))
+        }
+
+        public mutating func append<IntType>(_ int: IntType)
+            where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+        {
+            values.append(UInt32(int))
+        }
+
+        public mutating func append(_ string: String) {
+            for byte in string.utf8 {
+                values.append(UInt32(byte))
+            }
+        }
+    }
+
+    /// Writes an unabbreviated record to the stream.
+    public func writeRecord<CodeType>(_ code: CodeType, _ composeRecord: (inout RecordBuffer) -> Void)
+        where CodeType: RawRepresentable, CodeType.RawValue == UInt8
+    {
+        writeCode(.unabbreviatedRecord)
+        writeVBR(code.rawValue, width: 6)
+        var record = RecordBuffer()
+        composeRecord(&record)
+        writeVBR(UInt(record.values.count), width: 6)
+        for value in record.values {
+            writeVBR(value, width: 6)
+        }
+    }
+
+    /// Writes a record with the provided abbreviation ID and record contents.
+    /// Optionally, emits the provided blob if the abbreviation referenced
+    /// by that ID requires it.
+    public func writeRecord(
+        _ abbrevID: Bitstream.AbbreviationID,
+        _ composeRecord: (inout RecordBuffer) -> Void,
+        blob: String? = nil
+    ) {
+        let index = Bitstream.AbbreviationID.firstApplicationID.rawValue.distance(to: abbrevID.rawValue)
+        guard index < currentAbbreviations.count else {
+            fatalError("unregistered abbreviation \(index)")
+        }
+
+        let abbrev = currentAbbreviations[Int(index)]
+        var record = RecordBuffer()
+        composeRecord(&record)
+        let values = record.values
+        var valueIndex = 0
+        writeCode(abbrevID)
+        for op in abbrev.operands {
+            switch op {
+            case .array(let eltOp):
+                // First, emit the length as a VBR6
+                let length = UInt(values.count - valueIndex)
+                writeVBR(length, width: 6)
+
+                // Emit the remaining values using that encoding.
+                for idx in valueIndex..<values.count {
+                    writeAbbrevField(eltOp, value: values[idx])
+                }
+            case .blob:
+                guard let blob = blob else { fatalError("expected blob") }
+                // Blobs are encoded as a VBR6 length, then a sequence of
+                // 8-bit values.
+                let length = UInt(blob.utf8.count)
+                writeVBR(length, width: 6)
+                alignIfNeeded()
+
+                for char in blob.utf8 {
+                    write(char, width: 8)
+                }
+
+                // Ensure total length of the blob is a multiple of 4 by
+                // writing zeroes.
+                alignIfNeeded()
+            default:
+                // Otherwise, write this value using its encoding directly and
+                // increment the value index.
+                writeAbbrevField(op, value: values[valueIndex])
+                valueIndex += 1
+            }
+        }
+    }
+}
+
+// MARK: Writing Data
+
+extension BitstreamWriter {
+    /// Char6 is encoded using a special encoding that uses 0 to 64 to encode
+    /// English alphanumeric identifiers.
+    /// The ranges are specified as:
+    /// 'a' .. 'z' ---  0 .. 25
+    /// 'A' .. 'Z' --- 26 .. 51
+    /// '0' .. '9' --- 52 .. 61
+    ///        '.' --- 62
+    ///        '_' --- 63
+    private static let char6Map =
+        Array(zip("abcdefghijklmnopqrstuvwxyz" +
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+                    "0123456789._", (0 as UInt)...))
+
+    /// Writes a char6-encoded value.
+    public func writeChar6<IntType>(_ value: IntType)
+        where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        guard (0..<64).contains(value) else {
+            fatalError("invalid char6 value")
+        }
+        let v = BitstreamWriter.char6Map[Int(value)].1
+        write(v, width: 6)
+    }
+
+    /// Writes a value with the provided abbreviation encoding.
+    public func writeAbbrevField(_ op: Bitstream.Abbreviation.Operand, value: UInt32) {
+        switch op {
+        case .literal(let literalValue):
+            // Do not write anything
+            precondition(value == literalValue,
+                         "literal value must match abbreviated literal " +
+                            "(expected \(literalValue), got \(value))")
+        case .fixed(let bitWidth):
+            write(value, width: UInt8(bitWidth))
+        case .vbr(let chunkBitWidth):
+            writeVBR(value, width: UInt8(chunkBitWidth))
+        case .char6:
+            writeChar6(value)
+        case .blob, .array:
+            fatalError("cannot emit a field as array or blob")
+        }
+    }
+
+    /// Writes a block, beginning with the provided block code and the
+    /// abbreviation width
+    public func writeBlock(
+        _ blockID: Bitstream.BlockID,
+        newAbbrevWidth: UInt8? = nil,
+        emitRecords: () -> Void
+    ) {
+        enterSubblock(blockID, abbreviationBitWidth: newAbbrevWidth)
+        emitRecords()
+        endBlock()
+    }
+
+    public func writeBlob<S>(_ bytes: S, includeSize: Bool = true)
+        where S: Collection, S.Element == UInt8
+    {
+        if includeSize {
+            // Emit a vbr6 to indicate the number of elements present.
+            self.writeVBR(UInt8(bytes.count), width: 6)
+        }
+
+        // Flush to a 32-bit alignment boundary.
+        self.alignIfNeeded()
+
+        // Emit literal bytes.
+        for byte in bytes {
+            self.write(byte, width: 8)
+        }
+
+        // Align end to 32-bits.
+        while (self.bufferOffset & 3) != 0 {
+            self.write(0 as UInt8, width: 8)
+        }
+    }
+    
+
+    /// Writes the blockinfo block and allows emitting abbreviations
+    /// and records in it.
+    public func writeBlockInfoBlock(emitRecords: () -> Void) {
+        writeBlock(.blockInfo, newAbbrevWidth: 2) {
+            currentBlockID = nil
+            blockInfoRecords = [:]
+            emitRecords()
+        }
+    }
+}
+
+// MARK: Block Management
+
+extension BitstreamWriter {
+    public func `switch`(to blockID: Bitstream.BlockID) {
+        if currentBlockID == blockID { return }
+        writeRecord(BlockInfoCode.setBID) {
+            $0.append(blockID)
+        }
+        currentBlockID = blockID
+    }
+
+    public func withSubBlock(
+        _ blockID: Bitstream.BlockID,
+        abbreviationBitWidth: UInt8? = nil,
+        defineSubBlock: () -> Void
+    ) {
+        self.enterSubblock(blockID, abbreviationBitWidth: abbreviationBitWidth)
+        defineSubBlock()
+        self.endBlock()
+    }
+
+    public func enterSubblock(
+        _ blockID: Bitstream.BlockID,
+        abbreviationBitWidth: UInt8? = nil
+    ) {
+        // [ENTER_SUBBLOCK, blockid(vbr8), newabbrevlen(vbr4),
+        //                  <align32bits>, blocklen_32]
+        writeCode(.enterSubblock)
+
+        let newWidth = abbreviationBitWidth ?? codeBitWidth
+
+        writeVBR(blockID.rawValue,  width: 8)
+
+        writeVBR(newWidth, width: 4)
+        alignIfNeeded()
+
+        // Caller is responsible for filling in the blocklen_32 value
+        // after emitting the contents of the block.
+        let byteOffset = bufferOffset
+        write(0 as UInt, width: 32)
+
+        let block = Block(previousCodeWidth: codeBitWidth,
+                          lengthPlaceholderByteIndex: byteOffset,
+                          previousAbbrevs: currentAbbreviations)
+
+        codeBitWidth = newWidth
+        currentAbbreviations = []
+        blockScope.append(block)
+        if let blockInfo = blockInfoRecords[blockID.rawValue] {
+            currentAbbreviations.append(contentsOf: blockInfo.abbrevs)
+        }
+    }
+
+    public func endBlock() {
+        guard let block = blockScope.popLast() else {
+            fatalError("endBlock() called with no block registered")
+        }
+
+        let blockLengthInBytes = data.count - block.lengthPlaceholderByteIndex
+        let blockLengthIn32BitWords = UInt32(blockLengthInBytes / 4)
+
+        writeCode(.endBlock)
+        alignIfNeeded()
+
+        // Backpatch the block length now that we've finished it
+        overwriteBytes(blockLengthIn32BitWords,
+                       byteIndex: block.lengthPlaceholderByteIndex)
+
+        // Restore the inner block's code size and abbrev table.
+        codeBitWidth = block.previousCodeWidth
+        currentAbbreviations = block.previousAbbrevs
+    }
+
+    /// Defines an abbreviation within the blockinfo block for the provided
+    /// block ID.
+    public func defineBlockInfoAbbreviation(
+        _ blockID: Bitstream.BlockID,
+        _ abbrev: Bitstream.Abbreviation
+    ) -> Bitstream.AbbreviationID {
+        self.switch(to: blockID)
+        encodeAbbreviation(abbrev)
+        let info = getOrCreateBlockInfo(blockID.rawValue)
+        info.abbrevs.append(abbrev)
+        let rawValue = UInt64(info.abbrevs.count - 1) + Bitstream.AbbreviationID.firstApplicationID.rawValue
+        return Bitstream.AbbreviationID(rawValue: rawValue)
+    }
+
+
+    private func overwriteBytes(_ int: UInt32, byteIndex: Int) {
+        let i = int.littleEndian
+        data.withUnsafeMutableBytes { ptr in
+            ptr.storeBytes(of: i, toByteOffset: byteIndex, as: UInt32.self)
+        }
+    }
+
+    /// Gets the BlockInfo for the provided ID or creates it if it hasn't been
+    /// created already.
+    private func getOrCreateBlockInfo(_ id: UInt8) -> BlockInfo {
+        if let blockInfo = blockInfoRecords[id] { return blockInfo }
+        let info = BlockInfo()
+        blockInfoRecords[id] = info
+        return info
+    }
+}

--- a/Sources/TSCUtility/BitstreamWriter.swift
+++ b/Sources/TSCUtility/BitstreamWriter.swift
@@ -8,8 +8,6 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import Foundation
-
 /// A `BitstreamWriter` is an object that is capable of emitting data in the
 /// [LLVM Bitstream](https://llvm.org/docs/BitCodeFormat.html#bitstream-format)
 /// format.
@@ -33,6 +31,7 @@ import Foundation
 ///
 /// Next, identify the kinds of records needed in the format and assign them
 /// unique, stable identifiers. For example:
+/// 
 /// ```
 /// enum DiagnosticRecordID: UInt8 {
 ///     case version        = 1
@@ -69,7 +68,7 @@ import Foundation
 ///     }
 ///
 ///     versionAbbrev = recordWriter.defineBlockInfoAbbreviation(.metadata, .init([
-///         .literalCode(RoundTripRecordID.version),
+///         .literalCode(DiagnosticRecordID.version),
 ///         .fixed(bitWidth: 32)
 ///     ]))
 ///
@@ -83,7 +82,7 @@ import Foundation
 /// ```
 /// recordWriter.writeBlock(.metadata, newAbbrevWidth: 3) {
 ///     recordWriter.writeRecord(versionAbbrev!) {
-///         $0.append(RoundTripRecordID.version)
+///         $0.append(DiagnosticRecordID.version)
 ///         $0.append(25 as UInt32)
 ///     }
 /// }
@@ -92,12 +91,6 @@ import Foundation
 /// The higher-level APIs will automatically ensure that `BitstreamWriter.data`
 /// is valid. Once serialization has completed, simply emit this data to a file.
 public final class BitstreamWriter {
-    public enum BlockInfoCode: UInt8 {
-        case setBID = 1
-        case blockName = 2
-        case setRecordName = 3
-    }
-
     /// The buffer of data being written to.
     private(set) public var data: [UInt8]
 
@@ -657,7 +650,7 @@ extension BitstreamWriter {
 
     private func `switch`(to blockID: Bitstream.BlockID) {
         if currentBlockID == blockID { return }
-        writeRecord(BlockInfoCode.setBID) {
+        writeRecord(Bitstream.BlockInfoCode.setBID) {
             $0.append(blockID)
         }
         currentBlockID = blockID

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(TSCUtility
   ArgumentParserShellCompletion.swift
   Bits.swift
   Bitstream.swift
+  BitstreamReader.swift
   BuildFlags.swift
   CollectionExtensions.swift
   Diagnostics.swift

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(TSCUtility
   Bits.swift
   Bitstream.swift
   BitstreamReader.swift
+  BitstreamWriter.swift
   BuildFlags.swift
   CollectionExtensions.swift
   Diagnostics.swift

--- a/Tests/TSCUtilityTests/BitstreamTests.swift
+++ b/Tests/TSCUtilityTests/BitstreamTests.swift
@@ -183,4 +183,410 @@ final class BitstreamTests: XCTestCase {
         XCTAssertEqual(lastRecord.id, 3)
         XCTAssertEqual(lastRecord.fields, [5, 34, 13, 0, 5, 34, 26, 0])
     }
+
+    func testBufferedWriter() {
+        let writer = BitstreamWriter()
+
+        // Make sure we only blit 32 bits at a time.
+        XCTAssertTrue(writer.isEmpty)
+        XCTAssertEqual(writer.bufferOffset, 0)
+        XCTAssertEqual(writer.bitNumber, 0)
+        writer.writeASCII("B")
+        XCTAssertEqual(writer.bufferOffset, 0)
+        XCTAssertEqual(writer.bitNumber, 8)
+        writer.writeASCII("I")
+        XCTAssertEqual(writer.bufferOffset, 0)
+        XCTAssertEqual(writer.bitNumber, 16)
+        writer.writeASCII("T")
+        XCTAssertEqual(writer.bufferOffset, 0)
+        XCTAssertEqual(writer.bitNumber, 24)
+        writer.writeASCII("S")
+        XCTAssertEqual(writer.bufferOffset, 4)
+        XCTAssertEqual(writer.bitNumber, 32)
+    }
+
+    func testWriteEquivalence() {
+        let literalWriter = BitstreamWriter()
+        XCTAssertTrue(literalWriter.isEmpty)
+        literalWriter.writeBlob([], includeSize: false)
+        XCTAssertTrue(literalWriter.isEmpty)
+
+        do {
+            literalWriter.writeASCII("B")
+            literalWriter.writeASCII("I")
+            literalWriter.writeASCII("T")
+            literalWriter.writeASCII("S")
+        }
+
+        let stringWriter = BitstreamWriter()
+        do {
+            stringWriter.writeBlob("BITS".map { $0.asciiValue! }, includeSize: false)
+        }
+
+        XCTAssertEqual(literalWriter.data, stringWriter.data)
+    }
+
+    func testWriteAlignment() {
+        do {
+            let writer = BitstreamWriter()
+            XCTAssertTrue(writer.isEmpty)
+            writer.alignIfNeeded()
+            XCTAssertTrue(writer.isEmpty)
+        }
+
+        do {
+            let writer = BitstreamWriter()
+            XCTAssertTrue(writer.isEmpty)
+            writer.writeASCII("B")
+            writer.alignIfNeeded()
+            XCTAssertEqual(writer.data, [
+                ("B" as Character).asciiValue!,
+                0, 0, 0
+            ])
+        }
+
+        do {
+            let writer = BitstreamWriter()
+            XCTAssertTrue(writer.isEmpty)
+            writer.writeASCII("B")
+            writer.writeASCII("I")
+            writer.alignIfNeeded()
+            XCTAssertEqual(writer.data, [
+                ("B" as Character).asciiValue!,
+                ("I" as Character).asciiValue!,
+                0, 0
+            ])
+        }
+
+        do {
+            let writer = BitstreamWriter()
+            XCTAssertTrue(writer.isEmpty)
+            writer.writeASCII("B")
+            writer.writeASCII("I")
+            writer.writeASCII("T")
+            writer.alignIfNeeded()
+            XCTAssertEqual(writer.data, [
+                ("B" as Character).asciiValue!,
+                ("I" as Character).asciiValue!,
+                ("T" as Character).asciiValue!,
+                0
+            ])
+        }
+
+        do {
+            let writer = BitstreamWriter()
+            XCTAssertTrue(writer.isEmpty)
+            writer.writeASCII("B")
+            writer.writeASCII("I")
+            writer.writeASCII("T")
+            writer.writeASCII("S")
+            writer.alignIfNeeded()
+            XCTAssertEqual(writer.data, [
+                ("B" as Character).asciiValue!,
+                ("I" as Character).asciiValue!,
+                ("T" as Character).asciiValue!,
+                ("S" as Character).asciiValue!,
+            ])
+        }
+    }
+
+    func testRoundTrip() throws {
+        enum RoundTripRecordID: UInt8 {
+            case version = 1
+            case blob    = 2
+        }
+
+        struct RoundTripVisitor: BitstreamVisitor {
+            var log: [String] = []
+
+            func validate(signature: Bitcode.Signature) throws {
+                XCTAssertEqual(signature, Bitcode.Signature(string: "BITS"))
+            }
+
+            mutating func shouldEnterBlock(id: UInt64) throws -> Bool {
+                return true
+            }
+
+            mutating func didExitBlock() throws {}
+
+            mutating func visit(record: BitcodeElement.Record) throws {
+                switch record.id {
+                case UInt64(RoundTripRecordID.version.rawValue):
+                    XCTAssertEqual(record.fields, [ 25 ]) // version
+                    guard case .none = record.payload else {
+                        XCTFail("Unexpected payload in metadata record!")
+                        return
+                    }
+                case UInt64(RoundTripRecordID.blob.rawValue):
+                    XCTAssertEqual(record.fields, [
+                        42,
+                        43,
+                        44,
+                        45,
+                    ])
+                    guard case .none = record.payload else {
+                        XCTFail("Unexpected payload in blob record!")
+                        return
+                    }
+                default:
+                    XCTFail("Unexpected record ID \(record.id)")
+                }
+            }
+        }
+
+        let writer = BitstreamWriter()
+        writer.writeASCII("B")
+        writer.writeASCII("I")
+        writer.writeASCII("T")
+        writer.writeASCII("S")
+
+        var versionAbbrev: Bitstream.AbbreviationID? = nil
+        var dataBlobAbbrev: Bitstream.AbbreviationID? = nil
+        writer.writeBlockInfoBlock {
+            self.emitBlockID(.metadata, named: "Meta", to: writer)
+            self.emitRecordID(RoundTripRecordID.version, named: "Version", to: writer)
+
+            versionAbbrev = writer.defineBlockInfoAbbreviation(.metadata, .init([
+                .literalCode(RoundTripRecordID.version),
+                .fixed(bitWidth: 32)
+            ]))
+
+            emitBlockID(.data, named: "Data", to: writer)
+            emitRecordID(RoundTripRecordID.blob, named: "DataBlob", to: writer)
+
+            dataBlobAbbrev = writer.defineBlockInfoAbbreviation(.data, .init([
+                .literalCode(RoundTripRecordID.blob),
+                .fixed(bitWidth: 10), // File ID
+                .fixed(bitWidth: 32), // Line
+                .fixed(bitWidth: 32), // Column
+                .fixed(bitWidth: 32), // Offset
+            ]))
+        }
+
+        writer.writeBlock(.metadata, newAbbrevWidth: 3) {
+            writer.writeRecord(versionAbbrev!) {
+                $0.append(RoundTripRecordID.version)
+                $0.append(25 as UInt32)
+            }
+        }
+
+        writer.writeBlock(.data, newAbbrevWidth: 3) {
+            writer.writeRecord(dataBlobAbbrev!) {
+                $0.append(RoundTripRecordID.blob)
+                $0.append(42 as UInt32)
+                $0.append(43 as UInt32)
+                $0.append(44 as UInt32)
+                $0.append(45 as UInt32)
+            }
+        }
+
+        var visitor = RoundTripVisitor()
+        try Bitcode.read(stream: Data(writer.data), using: &visitor)
+    }
+
+    func testSimpleRecordWrite() {
+        let recordWriter = BitstreamWriter()
+        recordWriter.withSubBlock(.metadata, abbreviationBitWidth: 2) {
+            recordWriter.writeRecord(BitstreamWriter.BlockInfoCode.setRecordName) {
+                $0.append(Bitstream.AbbreviationID.mockAbbreviation)
+            }
+        }
+        XCTAssertEqual(recordWriter.data, [
+            UInt8(Bitstream.AbbreviationID.enterSubblock.rawValue) | (UInt8(Bitstream.BlockID.metadata.rawValue) << 2),
+            UInt8(2 << 2),
+            UInt8(0), UInt8(0),
+            // now 32-bit aligned, the length we back-patched comes up next
+            UInt8(1), UInt8(0), UInt8(0), UInt8(0),
+            // Still 32-bit aligned, now here's the record data
+            UInt8(Bitstream.AbbreviationID.unabbreviatedRecord.rawValue)
+                | UInt8(BitstreamWriter.BlockInfoCode.setRecordName.rawValue << 2),
+            UInt8(1), // record length of 1 - which is just the ID field
+            UInt8(1), // record ID itself - which is 0b00001000 but we're
+                      // 14 bits in by the time we get here and writing 6 bits,
+                      // so we're going to mush in the end marker (0b00)
+            UInt8(0), // Then align to 32 bits.
+        ])
+    }
+
+    func emitBlockID(_ id: Bitstream.BlockID, named name: String, to stream: BitstreamWriter) {
+        stream.writeRecord(BitstreamWriter.BlockInfoCode.setBID) {
+            $0.append(id)
+        }
+
+        stream.writeRecord(BitstreamWriter.BlockInfoCode.blockName) {
+            $0.append(name)
+        }
+    }
+
+    func emitRecordID<CodeType>(_ id: CodeType, named name: String, to stream: BitstreamWriter)
+        where CodeType: RawRepresentable, CodeType.RawValue: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        stream.writeRecord(BitstreamWriter.BlockInfoCode.setRecordName) {
+            $0.append(id)
+            $0.append(name)
+        }
+    }
+
+    func testComplexRecordWrite() {
+        enum DiagnosticRecordID: UInt8 {
+            case version        = 1
+            case diagnostic     = 2
+            case sourceRange    = 3
+            case diagnosticFlag = 4
+            case category       = 5
+            case filename       = 6
+            case fixIt          = 7
+        }
+
+
+        var abbreviations = [Bitstream.AbbreviationID]()
+
+        let recordWriter = BitstreamWriter()
+        recordWriter.writeASCII("D")
+        recordWriter.writeASCII("I")
+        recordWriter.writeASCII("A")
+        recordWriter.writeASCII("G")
+        recordWriter.writeBlockInfoBlock {
+            self.emitBlockID(.metadata, named: "Meta", to: recordWriter)
+            self.emitRecordID(DiagnosticRecordID.version, named: "Version", to: recordWriter)
+
+            abbreviations.append(recordWriter.defineBlockInfoAbbreviation(.metadata, .init([
+                .literalCode(DiagnosticRecordID.version),
+                .fixed(bitWidth: 32)
+            ])))
+
+            emitBlockID(.diagnostics, named: "Diag", to: recordWriter)
+            emitRecordID(DiagnosticRecordID.diagnostic, named: "DiagInfo", to: recordWriter)
+            emitRecordID(DiagnosticRecordID.sourceRange, named: "SrcRange", to: recordWriter)
+            emitRecordID(DiagnosticRecordID.category, named: "CatName", to: recordWriter)
+            emitRecordID(DiagnosticRecordID.diagnosticFlag, named: "DiagFlag", to: recordWriter)
+            emitRecordID(DiagnosticRecordID.filename, named: "FileName", to: recordWriter)
+            emitRecordID(DiagnosticRecordID.fixIt, named: "FixIt", to: recordWriter)
+
+            let sourceLocationOperands: [Bitstream.Abbreviation.Operand] = [
+                .fixed(bitWidth: 10), // File ID
+                .fixed(bitWidth: 32), // Line
+                .fixed(bitWidth: 32), // Column
+                .fixed(bitWidth: 32), // Offset
+            ]
+
+            abbreviations.append(recordWriter.defineBlockInfoAbbreviation(.diagnostics, .init([
+                .literalCode(DiagnosticRecordID.diagnostic),
+                .fixed(bitWidth: 3)   // Diag level.
+            ] + sourceLocationOperands + [
+                .fixed(bitWidth: 10), // Category.
+                .fixed(bitWidth: 10), // Mapped Diag ID.
+                .fixed(bitWidth: 16), // Text size.
+                .blob                 // Diagnostic text.
+            ])))
+
+            abbreviations.append(recordWriter.defineBlockInfoAbbreviation(.diagnostics, .init([
+                .literalCode(DiagnosticRecordID.category),
+                .fixed(bitWidth: 16), // Category ID
+                .fixed(bitWidth: 8),  // Text size
+                .blob                 // Category text
+            ])))
+
+            abbreviations.append(recordWriter.defineBlockInfoAbbreviation(.diagnostics, .init([
+                .literalCode(DiagnosticRecordID.sourceRange)
+            ] + sourceLocationOperands + sourceLocationOperands)))
+
+            abbreviations.append(recordWriter.defineBlockInfoAbbreviation(.diagnostics, .init([
+              .literalCode(DiagnosticRecordID.diagnosticFlag),
+              .fixed(bitWidth: 10), // Mapped Diag ID
+              .fixed(bitWidth: 16), // Text size
+              .blob                 // Flag name text
+            ])))
+
+            abbreviations.append(recordWriter.defineBlockInfoAbbreviation(.diagnostics, .init([
+              .literalCode(DiagnosticRecordID.filename),
+              .fixed(bitWidth: 10), // Mapped File ID
+              .fixed(bitWidth: 32), // Size
+              .fixed(bitWidth: 32), // Modification time.
+              .fixed(bitWidth: 16), // Text size.
+              .blob                 // File name text
+            ])))
+
+            abbreviations.append(recordWriter.defineBlockInfoAbbreviation(.diagnostics, .init([
+                .literalCode(DiagnosticRecordID.fixIt)
+            ] + sourceLocationOperands + sourceLocationOperands + [
+                .fixed(bitWidth: 16), // Text size
+                .blob                // FixIt Text
+            ])))
+        }
+
+        XCTAssertEqual(recordWriter.data, [
+                        68, 73, 65, 71, // 'DIAG'
+                        1, 8, 0, 0,
+                        48, 0, 0, 0,
+                        7, 1, 178, 64,
+                        180, 66, 57, 208,
+                        67, 56, 60, 32,
+                        129, 45, 148, 131,
+                        60, 204, 67, 58,
+                        188, 131, 59, 28,
+                        4, 136, 98, 128,
+                        64, 113, 16, 36,
+                        11, 4, 41, 164,
+                        67, 56, 156, 195,
+                        67, 34, 144, 66,
+                        58, 132, 195, 57,
+                        164, 130, 59, 152,
+                        195, 59, 60, 36,
+                        195, 44, 200, 195,
+                        56, 200, 66, 56,
+                        184, 195, 57, 148,
+                        195, 3, 82, 140,
+                        66, 56, 208, 131,
+                        43, 132, 67, 59,
+                        148, 195, 67, 66,
+                        144, 66, 58, 132,
+                        195, 57, 152, 2,
+                        59, 132, 195, 57,
+                        60, 36, 134, 41,
+                        164, 3, 59, 148,
+                        131, 43, 132, 67,
+                        59, 148, 195, 131,
+                        113, 152, 66, 58,
+                        224, 67, 42, 208,
+                        195, 65, 144, 168,
+                        10, 200, 16, 37,
+                        80, 8, 20, 2,
+                        133, 40, 81, 2,
+                        131, 74, 22, 8,
+                        12, 130, 212, 116,
+                        64, 148, 64, 33,
+                        80, 8, 20, 162,
+                        4, 10, 129, 66,
+                        160, 144, 36, 16,
+                        37, 48, 168, 166,
+                        129, 40, 129, 66,
+                        160, 16, 24, 212,
+                        245, 64, 148, 64,
+                        33, 80, 8, 20,
+                        162, 4, 10, 129,
+                        66, 160, 16, 24,
+                        20, 0, 0, 0])
+    }
+}
+
+extension Bitstream.BlockID {
+    static let metadata     = Self.firstApplicationID
+    static let diagnostics  = Self.firstApplicationID + 1
+    static let data         = Self.firstApplicationID + 2
+}
+
+extension Bitstream.AbbreviationID {
+    static let mockAbbreviation          = Self.firstApplicationID
+}
+
+extension Bitstream.Abbreviation.Operand {
+    /// Turns a literal value of a RawRepresentable type into a literal abbrev.
+    static func literalCode<CodeType>(
+        _ code: CodeType
+    ) -> Bitstream.Abbreviation.Operand
+        where CodeType: RawRepresentable, CodeType.RawValue: UnsignedInteger & ExpressibleByIntegerLiteral
+    {
+        return .literal(numericCast(code.rawValue))
+    }
 }

--- a/Tests/TSCUtilityTests/BitstreamTests.swift
+++ b/Tests/TSCUtilityTests/BitstreamTests.swift
@@ -387,7 +387,7 @@ final class BitstreamTests: XCTestCase {
     func testSimpleRecordWrite() {
         let recordWriter = BitstreamWriter()
         recordWriter.withSubBlock(.metadata, abbreviationBitWidth: 2) {
-            recordWriter.writeRecord(BitstreamWriter.BlockInfoCode.setRecordName) {
+            recordWriter.writeRecord(Bitstream.BlockInfoCode.setRecordName) {
                 $0.append(Bitstream.AbbreviationID.mockAbbreviation)
             }
         }
@@ -399,7 +399,7 @@ final class BitstreamTests: XCTestCase {
             UInt8(1), UInt8(0), UInt8(0), UInt8(0),
             // Still 32-bit aligned, now here's the record data
             UInt8(Bitstream.AbbreviationID.unabbreviatedRecord.rawValue)
-                | UInt8(BitstreamWriter.BlockInfoCode.setRecordName.rawValue << 2),
+                | UInt8(Bitstream.BlockInfoCode.setRecordName.rawValue << 2),
             UInt8(1), // record length of 1 - which is just the ID field
             UInt8(1), // record ID itself - which is 0b00001000 but we're
                       // 14 bits in by the time we get here and writing 6 bits,
@@ -409,11 +409,11 @@ final class BitstreamTests: XCTestCase {
     }
 
     func emitBlockID(_ id: Bitstream.BlockID, named name: String, to stream: BitstreamWriter) {
-        stream.writeRecord(BitstreamWriter.BlockInfoCode.setBID) {
+        stream.writeRecord(Bitstream.BlockInfoCode.setBID) {
             $0.append(id)
         }
 
-        stream.writeRecord(BitstreamWriter.BlockInfoCode.blockName) {
+        stream.writeRecord(Bitstream.BlockInfoCode.blockName) {
             $0.append(name)
         }
     }
@@ -421,7 +421,7 @@ final class BitstreamTests: XCTestCase {
     func emitRecordID<CodeType>(_ id: CodeType, named name: String, to stream: BitstreamWriter)
         where CodeType: RawRepresentable, CodeType.RawValue: UnsignedInteger & ExpressibleByIntegerLiteral
     {
-        stream.writeRecord(BitstreamWriter.BlockInfoCode.setRecordName) {
+        stream.writeRecord(Bitstream.BlockInfoCode.setRecordName) {
             $0.append(id)
             $0.append(name)
         }


### PR DESCRIPTION
Add a counterpart to `BitstreamReader` and shuffle the deck chairs a bit so the different abstractions are well separated and their shared infrastructure is in one place. The first commit largely does the shuffling parts, the latter two commits contain the juicy bitstream writer bits.

rdar://73517080