### PR TITLE
prepare to move Versionig back to SwiftPM

### DIFF
--- a/Sources/TSCUtility/Git.swift
+++ b/Sources/TSCUtility/Git.swift
@@ -12,9 +12,8 @@ import class Foundation.ProcessInfo
 import TSCBasic
 
 extension Version {
-    /// Try a version from a git tag.
-    ///
-    /// - Parameter tag: A version string possibly prepended with "v".
+    // FIXME: deprecate 2/2021 (used below), remove once clients transitioned
+    @available(*, deprecated, message: "moved to SwiftPM")
     init?(tag: String) {
         if tag.first == "v" {
             self.init(string: String(tag.dropFirst()))
@@ -24,8 +23,9 @@ extension Version {
     }
 }
 
-public class Git {
-    /// Compute the version -> tags mapping from a list of input `tags`.
+public enum Git {
+    // FIXME: deprecate 2/2021, remove once clients transitioned
+    @available(*, deprecated, message: "moved to SwiftPM")
     public static func convertTagsToVersionMap(_ tags: [String]) -> [Version: [String]] {
         // First, check if we need to restrict the tag set to version-specific tags.
         var knownVersions: [Version: [String]] = [:]

--- a/Sources/TSCUtility/Versioning.swift
+++ b/Sources/TSCUtility/Versioning.swift
@@ -10,9 +10,8 @@
 
 @_implementationOnly import TSCclibc
 
-/// A Swift version number.
-///
-/// Note that these are *NOT* semantically versioned numbers.
+// FIXME: deprecate 2/2021, remove once clients transitioned
+@available(*, deprecated, message: "moved to SwiftPM")
 public struct SwiftVersion {
     /// The version number.
     public var version: (major: Int, minor: Int, patch: Int)
@@ -69,7 +68,8 @@ private func getBuildIdentifier() -> String? {
     return buildIdentifier.isEmpty ? nil : buildIdentifier
 }
 
-/// Version support for the package manager.
+// FIXME: deprecate 2/2021, remove once clients transitioned
+@available(*, deprecated, message: "moved to SwiftPM")
 public struct Versioning {
 
     /// The current version of the package manager.


### PR DESCRIPTION
motivation: the logic in Versioning does not belong in TSC, its a SwiftPM concern

changes:
* mark Versioning as deprecated, this will move to SwiftPM
* mark convertTagsToVersionMap as deprecated, this will move to SwiftPM