### PR TITLE
Switch BitstreamReader Entrypoints to Use ByteString

### DIFF
--- a/Sources/TSCUtility/SerializedDiagnostics.swift
+++ b/Sources/TSCUtility/SerializedDiagnostics.swift
@@ -8,6 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 import Foundation
+import TSCBasic
 
 /// Represents diagnostics serialized in a .dia file by the Swift compiler or Clang.
 public struct SerializedDiagnostics {
@@ -42,9 +43,18 @@ public struct SerializedDiagnostics {
   /// Serialized diagnostics.
   public var diagnostics: [Diagnostic]
 
+  @available(*, deprecated, message: "Use SerializedDiagnostics.init(bytes:) instead")
   public init(data: Data) throws {
     var reader = Reader()
     try Bitcode.read(stream: data, using: &reader)
+    guard let version = reader.versionNumber else { throw Error.noMetadataBlock }
+    self.versionNumber = version
+    self.diagnostics = reader.diagnostics
+  }
+
+  public init(bytes: ByteString) throws {
+    var reader = Reader()
+    try Bitcode.read(bytes: bytes, using: &reader)
     guard let version = reader.versionNumber else { throw Error.noMetadataBlock }
     self.versionNumber = version
     self.diagnostics = reader.diagnostics

--- a/Tests/TSCUtilityTests/BitstreamTests.swift
+++ b/Tests/TSCUtilityTests/BitstreamTests.swift
@@ -37,7 +37,7 @@ final class BitstreamTests: XCTestCase {
             .appending(components: "Inputs", "serialized.dia")
         let contents = try localFileSystem.readFileContents(bitstreamPath)
         var visitor = LoggingVisitor()
-        try Bitcode.read(stream: Data(contents.contents), using: &visitor)
+        try Bitcode.read(bytes: contents, using: &visitor)
         XCTAssertEqual(visitor.log, [
             "entering block: 8",
             "Record (id: 1, fields: [1], payload: none",
@@ -130,7 +130,7 @@ final class BitstreamTests: XCTestCase {
             .appending(components: "Inputs", "serialized.dia")
         let contents = try localFileSystem.readFileContents(bitstreamPath)
         var visitor = LoggingVisitor()
-        try Bitcode.read(stream: Data(contents.contents), using: &visitor)
+        try Bitcode.read(bytes: contents, using: &visitor)
         XCTAssertEqual(visitor.log, ["skipping block: 8",
                                      "skipping block: 9",
                                      "skipping block: 9",
@@ -155,7 +155,7 @@ final class BitstreamTests: XCTestCase {
         let bitstreamPath = AbsolutePath(#file).parentDirectory
             .appending(components: "Inputs", "serialized.dia")
         let contents = try localFileSystem.readFileContents(bitstreamPath)
-        let bitcode = try Bitcode(data: Data(contents.contents))
+        let bitcode = try Bitcode(bytes: contents)
         XCTAssertEqual(bitcode.signature, .init(string: "DIAG"))
         XCTAssertEqual(bitcode.elements.count, 18)
         guard case .block(let metadataBlock) = bitcode.elements.first else {
@@ -381,7 +381,7 @@ final class BitstreamTests: XCTestCase {
         }
 
         var visitor = RoundTripVisitor()
-        try Bitcode.read(stream: Data(writer.data), using: &visitor)
+        try Bitcode.read(bytes: ByteString(writer.data), using: &visitor)
     }
 
     func testSimpleRecordWrite() {

--- a/Tests/TSCUtilityTests/SerializedDiagnosticsTests.swift
+++ b/Tests/TSCUtilityTests/SerializedDiagnosticsTests.swift
@@ -18,7 +18,7 @@ final class SerializedDiagnosticsTests: XCTestCase {
     let serializedDiagnosticsPath = AbsolutePath(#file).parentDirectory
         .appending(components: "Inputs", "serialized.dia")
     let contents = try localFileSystem.readFileContents(serializedDiagnosticsPath)
-    let serializedDiags = try SerializedDiagnostics(data: Data(contents.contents))
+    let serializedDiags = try SerializedDiagnostics(bytes: contents)
 
     XCTAssertEqual(serializedDiags.versionNumber, 1)
     XCTAssertEqual(serializedDiags.diagnostics.count, 17)
@@ -66,7 +66,7 @@ final class SerializedDiagnosticsTests: XCTestCase {
     let serializedDiagnosticsPath = AbsolutePath(#file).parentDirectory
         .appending(components: "Inputs", "clang.dia")
     let contents = try localFileSystem.readFileContents(serializedDiagnosticsPath)
-    let serializedDiags = try SerializedDiagnostics(data: Data(contents.contents))
+    let serializedDiags = try SerializedDiagnostics(bytes: contents)
 
     XCTAssertEqual(serializedDiags.versionNumber, 1)
     XCTAssertEqual(serializedDiags.diagnostics.count, 4)


### PR DESCRIPTION
ByteString is a more appropriate vocabulary type than Data to use for
these entrypoints. TSCBasic traffics in ByteString values, and its
representation as an array means that there are reasonable indexing
invariants we can rely on with respect to subsequences.

This should also enable some clean up in the swift-driver.