### PR TITLE
Improve path normalization and judgment on Windows

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -458,8 +458,8 @@ private struct UNIXPath: Path {
             PathCchRemoveFileSpec(data, path.count)
             return String(decodingCString: data, as: UTF16.self)
         }
-        // These two expressions represent for the current directory.
-        if dir == "\\" || dir == "" {
+        // Blank path represents for the current directory.
+        if dir == "" {
             return "."
         }
         return dir

--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -449,12 +449,15 @@ private struct UNIXPath: Path {
 
     var dirname: String {
 #if os(Windows)
+        guard string != "" else {
+            return "."
+        }
         let fsr: UnsafePointer<Int8> = string.fileSystemRepresentation
         defer { fsr.deallocate() }
 
         let path: String = String(cString: fsr)
         return path.withCString(encodedAs: UTF16.self) {
-            let data = UnsafeMutablePointer(mutating: $0)
+            let data = UnsafeMutaßlePointer(mutating: $0)
             PathCchRemoveFileSpec(data, path.count)
             return String(decodingCString: data, as: UTF16.self)
         }
@@ -685,6 +688,9 @@ private struct UNIXPath: Path {
 
     init(validatingAbsolutePath path: String) throws {
       #if os(Windows)
+        guard path != "" else {
+            throw PathValidationError.invalidAbsolutePath(path)
+        }
         let fsr: UnsafePointer<Int8> = path.fileSystemRepresentation
         defer { fsr.deallocate() }
 
@@ -707,6 +713,9 @@ private struct UNIXPath: Path {
 
     init(validatingRelativePath path: String) throws {
       #if os(Windows)
+        guard path != "" else {
+            self.init(normalizingRelativePath: path)
+        }
         let fsr: UnsafePointer<Int8> = path.fileSystemRepresentation
         defer { fsr.deallocate() }
 

--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -431,7 +431,11 @@ extension Path {
 private struct UNIXPath: Path {
     let string: String
 
+#if os(Windows)
+    static let root = UNIXPath(string: "\\")
+#else
     static let root = UNIXPath(string: "/")
+#endif
 
     static func isValidComponent(_ name: String) -> Bool {
 #if os(Windows)
@@ -550,7 +554,7 @@ private struct UNIXPath: Path {
         var result: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(MAX_PATH + 1))
 
         _ = path.standardizingPathSeparator().withCString(encodedAs: UTF16.self) {
-            PathCchCanonicalize($0, result.length, $0)
+            PathCchCanonicalize(&result, result.count, $0)
         }
         self.init(string: String(decodingCString: result, as: UTF16.self))
       #else

--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -444,7 +444,8 @@ private struct UNIXPath: Path {
 
 #if os(Windows)
     static func isAbsolutePath(_ path: String) -> Bool {
-        return !path.prenormalized().withCString(encodedAs: UTF16.self, PathIsRelativeW)
+        return !path.standardizingPathSeparator()
+                    .withCString(encodedAs: UTF16.self, PathIsRelativeW)
     }
 #endif
 
@@ -547,9 +548,8 @@ private struct UNIXPath: Path {
     init(normalizingAbsolutePath path: String) {
       #if os(Windows)
         var result: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(MAX_PATH + 1))
-        defer { LocalFree(result) }
 
-        _ = path.prenormalized().withCString(encodedAs: UTF16.self) {
+        _ = path.standardizingPathSeparator().withCString(encodedAs: UTF16.self) {
             PathCchCanonicalize($0, result.length, $0)
         }
         self.init(string: String(decodingCString: result, as: UTF16.self))
@@ -620,7 +620,7 @@ private struct UNIXPath: Path {
         let pathSeparator: Character
 #if os(Windows)
         pathSeparator = "\\"
-        let path = path.prenormalized()
+        let path = path.standardizingPathSeparator()
 #else
         pathSeparator = "/"
 #endif
@@ -958,7 +958,7 @@ private func mayNeedNormalization(absolute string: String) -> Bool {
 
 #if os(Windows)
 fileprivate extension String {
-    func prenormalized() -> String {
+    func standardizingPathSeparator() -> String {
         return self.replacingOccurrences(of: "/", with: "\\")
     }
 }

--- a/Sources/TSCBasic/PathShims.swift
+++ b/Sources/TSCBasic/PathShims.swift
@@ -26,6 +26,8 @@ public func resolveSymlinks(_ path: AbsolutePath) -> AbsolutePath {
     var resolved: URL = URL(fileURLWithPath: path.pathString)
     if let destination = try? FileManager.default.destinationOfSymbolicLink(atPath: path.pathString) {
         resolved = URL(fileURLWithPath: destination, relativeTo: URL(fileURLWithPath: path.pathString))
+    } else {
+        return try! AbsolutePath(validating: path.pathString)
     }
 
     return resolved.standardized.withUnsafeFileSystemRepresentation {


### PR DESCRIPTION
- Fixes the problem of `..` being ignored during normalizing;
- Avoids crash when validating an empty path.