### PR TITLE
better integration with NSError

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -12,7 +12,7 @@ import TSCLibc
 import Foundation
 import Dispatch
 
-public struct FileSystemError: Swift.Error, Equatable {
+public struct FileSystemError: Error, Equatable {
     public enum Kind: Equatable {
         /// Access to the path is denied.
         ///
@@ -77,6 +77,12 @@ public struct FileSystemError: Swift.Error, Equatable {
     public init(_ kind: Kind, _ path: AbsolutePath? = nil) {
         self.kind = kind
         self.path = path
+    }
+}
+
+extension FileSystemError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: "\(self)"]
     }
 }
 

--- a/Sources/TSCBasic/GraphAlgorithms.swift
+++ b/Sources/TSCBasic/GraphAlgorithms.swift
@@ -8,7 +8,7 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-public enum GraphError: Swift.Error {
+public enum GraphError: Error {
     /// A cycle was detected in the input.
     case unexpectedCycle
 }

--- a/Sources/TSCBasic/JSON.swift
+++ b/Sources/TSCBasic/JSON.swift
@@ -169,9 +169,15 @@ extension JSON: ByteStreamable {
 
 import Foundation
 
-enum JSONDecodingError: Swift.Error {
+enum JSONDecodingError: Error {
     /// The input byte string is malformed.
     case malformed
+}
+
+extension JSONDecodingError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: "\(self)"]
+    }
 }
 
 // NOTE: This implementation is carefully crafted to work correctly on both

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -35,10 +35,15 @@ public struct Lock {
     }
 }
 
-enum ProcessLockError: Swift.Error {
+enum ProcessLockError: Error {
     case unableToAquireLock(errno: Int32)
 }
 
+extension ProcessLockError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: "\(self)"]
+    }
+}
 /// Provides functionality to aquire a lock on a file via POSIX's flock() method.
 /// It can be used for things like serializing concurrent mutations on a shared resource
 /// by mutiple instances of a process. The `FileLock` is not thread-safe.

--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -18,6 +18,9 @@ private typealias PathImpl = UNIXPath
 private typealias PathImpl = UNIXPath
 #endif
 
+import protocol Foundation.CustomNSError
+import var Foundation.NSLocalizedDescriptionKey
+
 /// Represents an absolute file system path, independently of what (or whether
 /// anything at all) exists at that path in the file system at any given time.
 /// An absolute path always starts with a `/` character, and holds a normalized
@@ -911,6 +914,12 @@ extension AbsolutePath {
         return self.components.starts(with: other.components)
     }
 
+}
+
+extension PathValidationError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: self.description]
+    }
 }
 
 // FIXME: We should consider whether to merge the two `normalize()` functions.

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -9,6 +9,8 @@
 */
 
 import class Foundation.ProcessInfo
+import protocol Foundation.CustomNSError
+import var Foundation.NSLocalizedDescriptionKey
 
 #if os(Windows)
 import Foundation
@@ -755,6 +757,13 @@ extension Process.Error: CustomStringConvertible {
         }
     }
 }
+
+extension Process.Error: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: self.description]
+    }
+}
+
 #endif
 
 extension ProcessResult.Error: CustomStringConvertible {
@@ -793,5 +802,11 @@ extension ProcessResult.Error: CustomStringConvertible {
 
             return stream.bytes.description
         }
+    }
+}
+
+extension ProcessResult.Error: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: self.description]
     }
 }

--- a/Sources/TSCBasic/Result.swift
+++ b/Sources/TSCBasic/Result.swift
@@ -8,6 +8,9 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import protocol Foundation.CustomNSError
+import var Foundation.NSLocalizedDescriptionKey
+
 extension Result where Failure == Error {
     public func tryMap<NewSuccess>(_ closure: (Success) throws -> NewSuccess) -> Result<NewSuccess, Error> {
         flatMap({ value in
@@ -27,6 +30,12 @@ public struct StringError: Equatable, Codable, CustomStringConvertible, Error {
     /// Create an instance of StringError.
     public init(_ description: String) {
         self.description = description
+    }
+}
+
+extension StringError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: self.description]
     }
 }
 

--- a/Sources/TSCBasic/TemporaryFile.swift
+++ b/Sources/TSCBasic/TemporaryFile.swift
@@ -12,8 +12,10 @@ import TSCLibc
 import class Foundation.FileHandle
 import class Foundation.FileManager
 import func Foundation.NSTemporaryDirectory
+import protocol Foundation.CustomNSError
+import var Foundation.NSLocalizedDescriptionKey
 
-public enum TempFileError: Swift.Error {
+public enum TempFileError: Error {
     /// Could not create a unique temporary filename.
     case couldNotCreateUniqueName
 
@@ -24,6 +26,12 @@ public enum TempFileError: Swift.Error {
 
     /// Couldn't find a temporary directory.
     case couldNotFindTmpDir
+}
+
+extension TempFileError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: "\(self)"]
+    }
 }
 
 private extension TempFileError {
@@ -150,7 +158,7 @@ public func withTemporaryFile<Result>(
 // FIXME: This isn't right place to declare this, probably POSIX or merge with FileSystemError?
 //
 /// Contains the error which can be thrown while creating a directory using POSIX's mkdir.
-public enum MakeDirectoryError: Swift.Error {
+public enum MakeDirectoryError: Error {
     /// The given path already exists as a directory, file or symbolic link.
     case pathExists
     /// The path provided was too long.
@@ -186,6 +194,12 @@ private extension MakeDirectoryError {
         default:
             self = .other(errno)
         }
+    }
+}
+
+extension MakeDirectoryError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: "\(self)"]
     }
 }
 

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -157,7 +157,7 @@ extension AbsolutePath {
 }
 
 // FIXME: Eliminate or find a proper place for this.
-public enum SystemError: Swift.Error {
+public enum SystemError: Error {
     case chdir(Int32, String)
     case close(Int32)
     case exec(Int32, path: String, args: [String])
@@ -233,6 +233,12 @@ extension SystemError: CustomStringConvertible {
         case .waitpid(let errno):
             return "waitpid error: \(strerror(errno))"
         }
+    }
+}
+
+extension SystemError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: self.description]
     }
 }
 

--- a/Sources/TSCUtility/JSONMessageStreamingParser.swift
+++ b/Sources/TSCUtility/JSONMessageStreamingParser.swift
@@ -82,7 +82,14 @@ public final class JSONMessageStreamingParser<Delegate: JSONMessageStreamingPars
 private extension JSONMessageStreamingParser {
 
     /// Error corresponding to invalid Swift compiler output.
-    struct ParsingError: LocalizedError {
+    struct ParsingError: CustomStringConvertible, LocalizedError {
+        var description: String {
+            if let error = underlyingError {
+                return "\(reason): \(error)"
+            } else {
+                return reason
+            }
+        }
 
         /// Text describing the specific reason for the parsing failure.
         let reason: String
@@ -91,11 +98,7 @@ private extension JSONMessageStreamingParser {
         let underlyingError: Error?
 
         var errorDescription: String? {
-            if let error = underlyingError {
-                return "\(reason): \(error)"
-            } else {
-                return reason
-            }
+            self.description
         }
     }
 
@@ -171,3 +174,9 @@ private extension JSONMessageStreamingParser {
 }
 
 private let newline = UInt8(ascii: "\n")
+
+extension JSONMessageStreamingParser.ParsingError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: self.description]
+    }
+}

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -136,6 +136,13 @@ public extension Netrc {
 }
 
 @available (OSX 10.13, *)
+extension Netrc.Error: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: "\(self)"]
+    }
+}
+
+@available (OSX 10.13, *)
 fileprivate enum RegexUtil {
     @frozen fileprivate enum Token: String, CaseIterable {
         case machine, login, password, account, macdef, `default`

--- a/Sources/TSCUtility/SerializedDiagnostics.swift
+++ b/Sources/TSCUtility/SerializedDiagnostics.swift
@@ -61,6 +61,12 @@ public struct SerializedDiagnostics {
   }
 }
 
+extension SerializedDiagnostics.Error: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: "\(self)"]
+    }
+}
+
 extension SerializedDiagnostics {
   public struct Diagnostic {
 

--- a/Sources/TSCUtility/SimplePersistence.swift
+++ b/Sources/TSCUtility/SimplePersistence.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import protocol Foundation.CustomNSError
+import var Foundation.NSLocalizedDescriptionKey
 import TSCBasic
 
 /// A protocol which needs to be implemented by the objects which can be
@@ -33,6 +35,12 @@ extension SimplePersistence.Error: CustomStringConvertible {
         case let .restoreFailure(stateFile, error):
             return "unable to restore state from \(stateFile); \(error)"
         }
+    }
+}
+
+extension SimplePersistence.Error: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: self.description]
     }
 }
 

--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import protocol Foundation.CustomNSError
+import var Foundation.NSLocalizedDescriptionKey
 import TSCBasic
 
 /// Triple - Helper class for working with Destination.target values
@@ -207,5 +209,11 @@ extension Triple {
             // See: https://github.com/apple/swift-corelibs-foundation/blob/master/Docs/FHS%20Bundles.md
             return ".resources"
         }
+    }
+}
+
+extension Triple.Error: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: "\(self)"]
     }
 }

--- a/Sources/TSCUtility/dlopen.swift
+++ b/Sources/TSCUtility/dlopen.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import protocol Foundation.CustomNSError
+import var Foundation.NSLocalizedDescriptionKey
 import TSCLibc
 
 public final class DLHandle {
@@ -73,9 +75,15 @@ public struct DLOpenFlags: RawRepresentable, OptionSet {
     }
 }
 
-public enum DLError: Swift.Error {
+public enum DLError: Error {
     case `open`(String)
     case close(String)
+}
+
+extension DLError: CustomNSError {
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: "\(self)"]
+    }
 }
 
 public func dlopen(_ path: String?, mode: DLOpenFlags) throws -> DLHandle {


### PR DESCRIPTION
motivation: some of TSC errors go through Foundation layers and can loose information (the description specifically) when crossing the Error <> NSError boundries

changes: conform most Error types to CustomNSError and provide the description via NSLocalizedDescriptionKey

rdar://74712707