### PR TITLE
Link `XCTest` explicitly in test support target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,10 @@ let package = Package(
         .target(
             /** Generic test support library */
             name: "TSCTestSupport",
-            dependencies: ["TSCBasic", "TSCUtility"]),
+            dependencies: ["TSCBasic", "TSCUtility"],
+            linkerSettings: [
+                .linkedFramework("XCTest", .when(platforms: [.iOS, .macOS, .tvOS, .watchOS])),
+            ]),
         
         
         // MARK: Tools support core tests


### PR DESCRIPTION
If a target wants to use `XCTest`, it should do so explicitly.

rdar://75455829