### PR TITLE
make testSignals more robust

### DIFF
--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -180,7 +180,7 @@ class ProcessTests: XCTestCase {
             }
         }
 
-        if case .timedOut = group.wait(timeout: .now() + 1) {
+        if case .timedOut = group.wait(timeout: .now() + 10) {
             XCTFail("timeout waiting for signals to be processed")
         }
     }


### PR DESCRIPTION
motivation: #196 introduces a timeout for testSignals, but its too low in some cases

changes: increase timeout


rdar://74356445