### PR TITLE
Fix compiling for 32-bit ARM platforms

### DIFF
--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -472,6 +472,24 @@ private func FD_SET(_ fd: Int32, _ set: inout fd_set) {
         case 13: fd_bits.13 = fd_bits.13 | mask
         case 14: fd_bits.14 = fd_bits.14 | mask
         case 15: fd_bits.15 = fd_bits.15 | mask
+	#if arch(arm)
+        case 16: fd_bits.16 = fd_bits.16 | mask
+        case 17: fd_bits.17 = fd_bits.17 | mask
+        case 18: fd_bits.18 = fd_bits.18 | mask
+        case 19: fd_bits.19 = fd_bits.19 | mask
+        case 20: fd_bits.20 = fd_bits.20 | mask
+        case 21: fd_bits.21 = fd_bits.21 | mask
+        case 22: fd_bits.22 = fd_bits.22 | mask
+        case 23: fd_bits.23 = fd_bits.23 | mask
+        case 24: fd_bits.24 = fd_bits.24 | mask
+        case 25: fd_bits.25 = fd_bits.25 | mask
+        case 26: fd_bits.26 = fd_bits.26 | mask
+        case 27: fd_bits.27 = fd_bits.27 | mask
+        case 28: fd_bits.28 = fd_bits.28 | mask
+        case 29: fd_bits.29 = fd_bits.29 | mask
+        case 30: fd_bits.30 = fd_bits.30 | mask
+        case 31: fd_bits.31 = fd_bits.31 | mask
+	#endif
         default: break
     }
   #if os(Android)
@@ -508,6 +526,24 @@ private func FD_ISSET(_ fd: Int32, _ set: inout fd_set) -> Bool {
         case 13: return fd_bits.13 & mask != 0
         case 14: return fd_bits.14 & mask != 0
         case 15: return fd_bits.15 & mask != 0
+	#if arch(arm)
+        case 16: return fd_bits.16 & mask != 0
+        case 17: return fd_bits.17 & mask != 0
+        case 18: return fd_bits.18 & mask != 0
+        case 19: return fd_bits.19 & mask != 0
+        case 20: return fd_bits.20 & mask != 0
+        case 21: return fd_bits.21 & mask != 0
+        case 22: return fd_bits.22 & mask != 0
+        case 23: return fd_bits.23 & mask != 0
+        case 24: return fd_bits.24 & mask != 0
+        case 25: return fd_bits.25 & mask != 0
+        case 26: return fd_bits.26 & mask != 0
+        case 27: return fd_bits.27 & mask != 0
+        case 28: return fd_bits.28 & mask != 0
+        case 29: return fd_bits.29 & mask != 0
+        case 30: return fd_bits.30 & mask != 0
+        case 31: return fd_bits.31 & mask != 0
+	#endif
         default: return false
     }
 }

--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -428,11 +428,21 @@ public final class Inotify {
 // FIXME: <rdar://problem/45794219> Swift should provide shims for FD_ macros
 
 private func FD_ZERO(_ set: inout fd_set) {
-      #if os(Android)
-	set.fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-      #else
-	set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-      #endif
+    #if os(Android)
+        #if arch(arm)
+            set.fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        #else
+            set.fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        #endif
+    #else
+        #if arch(arm)
+            set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        #else
+            set.__fds_bits = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        #endif
+    #endif
 }
 
 private func FD_SET(_ fd: Int32, _ set: inout fd_set) {


### PR DESCRIPTION
I came up with the Android portion of this pull when getting [the Swift toolchain cross-compiled to run on Android armv7](https://github.com/termux/termux-packages/pull/5843/files#diff-7eb40cefea92ea04df3500a5e92271b5446626784891e1fee04cc4b8f431c8d9R69), then found later that [@uraimo had patched it similarly earlier for linux armv7, as part of broader changes](https://github.com/uraimo/buildSwiftOnARM/blob/master/swiftpm.diffs/aarch32/fd_set.diff). I have only taken the analogous part to Android from his patch, as that's all I needed to successfully build. I don't think this feature works without further changes though, perhaps as he added.

@uraimo, could you sign off on upstreaming the non-Android part of this pull, which I got from your patch? If there's any other changes to this repo worth adding now, let me know.

@KittyMac, if you turned up any more patches in [your recent linux armv7 work](https://github.com/uraimo/buildSwiftOnARM/issues/66#issuecomment-800594395), let us know.