### PR TITLE
Bring back Sergio's "Add support for Process stdin stream"

### DIFF
--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -216,6 +216,23 @@ class ProcessTests: XCTestCase {
         XCTAssertEqual(result2, "hello\n")
     }
 
+    func testStdin() throws {
+        var stdout = [UInt8]()
+        let process = Process(args: script("in-to-out"), outputRedirection: .stream(stdout: { stdoutBytes in
+            stdout += stdoutBytes
+        }, stderr: { _ in }))
+        let stdinStream = try process.launch()
+
+        stdinStream.write("hello\n")
+        stdinStream.flush()
+
+        try stdinStream.close()
+
+        try process.waitUntilExit()
+
+        XCTAssertEqual(String(decoding: stdout, as: UTF8.self), "hello\n")
+    }
+
     func testStdoutStdErr() throws {
         // A simple script to check that stdout and stderr are captured separatly.
         do {

--- a/Tests/TSCBasicTests/processInputs/in-to-out
+++ b/Tests/TSCBasicTests/processInputs/in-to-out
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+import sys
+
+sys.stdout.write(sys.stdin.readline())


### PR DESCRIPTION
This PR resurrects @sergiocampama's https://github.com/apple/swift-tools-support-core/pull/122, which we required in order to be able to forward standard input in the new swift-driver to the compile jobs it spawns (https://github.com/apple/swift-driver/pull/595).

The change was previously reverted in https://github.com/apple/swift-tools-support-core/pull/143, due to an error seen on Linux. 