### PR TITLE
enable netrc on non-darwin platforms

### DIFF
--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -13,15 +13,6 @@ extension AuthorizationProviding {
     }
 }
 
-#if os(Windows)
-// FIXME: - add support for Windows when regex function available
-#endif
-
-#if os(Linux)
-// FIXME: - add support for Linux when regex function available
-#endif
-
-#if os(macOS)
 /*
  Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
  which is only available in macOS 10.13+ at this time.
@@ -168,4 +159,3 @@ fileprivate enum RegexUtil {
         return #"\s*\#(string)\s+(?<\#(prefix + string)>\S++)"#
     }
 }
-#endif

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import TSCUtility
 
-#if os(macOS)
 @available(macOS 10.13, *)
 /// Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
 /// which is only available in macOS 10.13+ at this time.
@@ -445,4 +444,4 @@ class NetrcTests: XCTestCase {
         XCTAssertEqual(netrc.machines[1].password, "sunshine4ever")
     }
 }
-#endif
+


### PR DESCRIPTION
motivation:
* netrc functionality is useful on all platforms, the regex functionality was added to non-darwin foundation
* see https://github.com/apple/swift-corelibs-foundation/pull/1522

changes: remove platforms restructions where appropriate