### PR TITLE
Add lenient mode to Version string parsing that doesn't require patch version

### DIFF
--- a/Sources/TSCUtility/Version.swift
+++ b/Sources/TSCUtility/Version.swift
@@ -48,22 +48,29 @@ public struct Version {
 /// An error that occurs during the creation of a version.
 public enum VersionError: Error, CustomStringConvertible {
     /// The version string contains non-ASCII characters.
+    /// - Parameter versionString: The version string.
     case nonASCIIVersionString(_ versionString: String)
     /// The version core contains an invalid number of Identifiers.
-    case invalidVersionCoreIdentifiersCount(_ identifiers: [String])
+    /// - Parameters:
+    ///   - identifiers: The version core identifiers in the version string.
+    ///   - usesLenientParsing: A Boolean value indicating whether or not the lenient parsing mode was enabled when this error occurred.
+    case invalidVersionCoreIdentifiersCount(_ identifiers: [String], usesLenientParsing: Bool)
     /// Some or all of the version core identifiers contain non-numerical characters or are empty.
+    /// - Parameter identifiers: The version core identifiers in the version string.
     case nonNumericalOrEmptyVersionCoreIdentifiers(_ identifiers: [String])
     /// Some or all of the pre-release identifiers contain characters other than alpha-numerics and hyphens.
+    /// - Parameter identifiers: The pre-release identifiers in the version string.
     case nonAlphaNumerHyphenalPrereleaseIdentifiers(_ identifiers: [String])
     /// Some or all of the build metadata identifiers contain characters other than alpha-numerics and hyphens.
+    /// - Parameter identifiers: The build metadata identifiers in the version string.
     case nonAlphaNumerHyphenalBuildMetadataIdentifiers(_ identifiers: [String])
 
     public var description: String {
         switch self {
         case let .nonASCIIVersionString(versionString):
             return "non-ASCII characters in version string '\(versionString)'"
-        case let .invalidVersionCoreIdentifiersCount(identifiers):
-            return "\(identifiers.count < 3 ? "fewer" : "more") than 3 identifiers in version core '\(identifiers.joined(separator: "."))'"
+        case let .invalidVersionCoreIdentifiersCount(identifiers, usesLenientParsing):
+            return "\(identifiers.count > 3 ? "more than 3" : "fewer than \(usesLenientParsing ? 2 : 3)") identifiers in version core '\(identifiers.joined(separator: "."))'"
         case let .nonNumericalOrEmptyVersionCoreIdentifiers(identifiers):
             if !identifiers.allSatisfy( { !$0.isEmpty } ) {
                 return "empty identifiers in version core '\(identifiers.joined(separator: "."))'"
@@ -85,15 +92,17 @@ public enum VersionError: Error, CustomStringConvertible {
 }
 
 extension Version {
-    // TODO: Rename this function to `init(string: String) throws`, after `init?(string: String)` is removed.
+    // TODO: Rename this function to `init(string:usesLenientParsing:) throws`, after `init?(string: String)` is removed.
     // TODO: Find a better error-checking order.
     // Currently, if a version string is "forty-two", this initializer throws an error that says "forty" is only 1 version core identifier, which is not enough.
     // But this is misleading the user to consider "forty" as a valid version core identifier.
     // We should find a way to check for (or throw) "wrong characters used" errors first, but without overly-complicating the logic.
     /// Creates a version from the given string.
-    /// - Parameter versionString: The string to create the version from.
+    /// - Parameters:
+    ///   - versionString: The string to create the version from.
+    ///   - usesLenientParsing: A Boolean value indicating whether or not the version string should be parsed leniently. If `true`, then the patch version is assumed to be `0` if it's not provided in the version string; otherwise, the parsing strictly follows the Semantic Versioning 2.0.0 rules. This value defaults to `false`.
     /// - Throws: A `VersionError` instance if the `versionString` doesn't follow [SemVer 2.0.0](https://semver.org).
-    public init(versionString: String) throws {
+    public init(versionString: String, usesLenientParsing: Bool = false) throws {
         // SemVer 2.0.0 allows only ASCII alphanumerical characters and "-" in the version string, except for "." and "+" as delimiters. ("-" is used as a delimiter between the version core and pre-release identifiers, but it's allowed within pre-release and metadata identifiers as well.)
         // Alphanumerics check will come later, after each identifier is split out (i.e. after the delimiters are removed).
         guard versionString.allSatisfy(\.isASCII) else {
@@ -107,8 +116,8 @@ extension Version {
         let versionCore = versionString[..<(prereleaseDelimiterIndex ?? metadataDelimiterIndex ?? versionString.endIndex)]
         let versionCoreIdentifiers = versionCore.split(separator: ".", omittingEmptySubsequences: false)
 
-        guard versionCoreIdentifiers.count == 3 else {
-            throw VersionError.invalidVersionCoreIdentifiersCount(versionCoreIdentifiers.map { String($0) })
+        guard versionCoreIdentifiers.count == 3 || (usesLenientParsing && versionCoreIdentifiers.count == 2) else {
+            throw VersionError.invalidVersionCoreIdentifiersCount(versionCoreIdentifiers.map { String($0) }, usesLenientParsing: usesLenientParsing)
         }
 
         guard
@@ -116,7 +125,7 @@ extension Version {
             // Converting each identifier from a substring to an integer doubles as checking if the identifiers have non-numeric characters.
             let major = Int(versionCoreIdentifiers[0]),
             let minor = Int(versionCoreIdentifiers[1]),
-            let patch = Int(versionCoreIdentifiers[2])
+            let patch = usesLenientParsing && versionCoreIdentifiers.count == 2 ? 0 : Int(versionCoreIdentifiers[2])
         else {
             throw VersionError.nonNumericalOrEmptyVersionCoreIdentifiers(versionCoreIdentifiers.map { String($0) })
         }


### PR DESCRIPTION
Git repos are commonly leaving off the patch segments of version strings in tags. This practice is also commonly repeated in guides on Git tagging. This commit makes the patch version optional to improve compatibility with these Git repositories in SPM.

Because of the possible downstream effects, I've made the lenient version parsing optional, and it defaults to off. Right now it only allows the patch version to be left off.

I considered trying to keep changes entirely in SPM without touching the Version type. This seemed like the most maintainable and performant option.