### PR TITLE
Disable LockTests.testReadWriteFileLock

### DIFF
--- a/Tests/TSCBasicTests/LockTests.swift
+++ b/Tests/TSCBasicTests/LockTests.swift
@@ -61,6 +61,7 @@ class LockTests: XCTestCase {
     }
 
     func testReadWriteFileLock() throws {
+        try XCTSkipIf(true, "fails spuriously if reader thread beats first writer rdar://78461378")
         try withTemporaryDirectory { tempDir in
             let fileA = tempDir.appending(component: "fileA")
             let fileB = tempDir.appending(component: "fileB")


### PR DESCRIPTION
This test may fail spuriously if a reader thread runs before any writers
were able to write the initial value to the file. Disable the test until
it can be fixed. We saw the same issue with FileSystemTests in the past.

rdar://78461378