### PR TITLE
Extend the availability annotations for the Netrc support to cover all the Darwin platforms

### DIFF
--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -15,9 +15,9 @@ extension AuthorizationProviding {
 
 /*
  Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
- which is only available in macOS 10.13+ at this time.
+ which is only available in macOS 10.13+, iOS 11+, etc at this time.
  */
-@available (OSX 10.13, *)
+@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 /// Container of parsed netrc connection settings
 public struct Netrc: AuthorizationProviding {
     /// Representation of `machine` connection settings & `default` connection settings.
@@ -88,7 +88,7 @@ public struct Netrc: AuthorizationProviding {
     }
 }
 
-@available (OSX 10.13, *)
+@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 public extension Netrc {
     enum Error: Swift.Error {
         case invalidFilePath
@@ -126,14 +126,14 @@ public extension Netrc {
     }
 }
 
-@available (OSX 10.13, *)
+@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 extension Netrc.Error: CustomNSError {
     public var errorUserInfo: [String : Any] {
         return [NSLocalizedDescriptionKey: "\(self)"]
     }
 }
 
-@available (OSX 10.13, *)
+@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 fileprivate enum RegexUtil {
     @frozen fileprivate enum Token: String, CaseIterable {
         case machine, login, password, account, macdef, `default`


### PR DESCRIPTION
This PR extends the availability annotation for the Netrc support to cover all the version numbers for the various Darwin platforms in the annotation for `NSTextCheckingResult.range(withName name: String) -> NSRange` in the SDK.  Otherwise, ToolsSupportCore can no longer build on non-macOS Darwin platforms such as iOS, because the default minimum deployment targets for the various platforms are really old (e.g. iOS 9).