### PR TITLE
Respect `SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET` if it is set in the environment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 /*
  This source file is part of the Swift.org open source project
  
- Copyright (c) 2019 - 2020 Apple Inc. and the Swift project authors
+ Copyright (c) 2019 - 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
  
  See http://swift.org/LICENSE.txt for license information
@@ -12,9 +12,20 @@
 
 
 import PackageDescription
+import class Foundation.ProcessInfo
+
+let macOSPlatform: SupportedPlatform
+if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET"] {
+    macOSPlatform = .macOS(deploymentTarget)
+} else {
+    macOSPlatform = .macOS(.v10_10)
+}
 
 let package = Package(
     name: "swift-tools-support-core",
+    platforms: [
+        macOSPlatform,
+    ],
     products: [
         .library(
             name: "SwiftToolsSupport",


### PR DESCRIPTION
Respect `SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET` if it is set in the environment, otherwise stay with the default minimum deployment target of 10.10 on macOS.

ToolsSupportCore has availability annotations to represent requirements on various versions of macOS.  Yet ToolsSupportCore itself doesn't specify a minimum deployment target for macOS, and so it always builds for macOS 10.10.

This aligns with both swift-package-manager and with swift-driver, and is important now that ToolSupportCore has started containing some code that is annotated with availability for Darwin platforms (Netrc support required 10.13 or later).  It does use the package-neutral name `SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET` and the expectation is that both SwiftDriver and SwiftPM will at some point switch to that name as well.