### PR TITLE
Require macOS 10.15 and iOS 13 or later on Darwin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,17 +14,11 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-let macOSPlatform: SupportedPlatform
-if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFT_TOOLCHAIN_MACOS_DEPLOYMENT_TARGET"] {
-    macOSPlatform = .macOS(deploymentTarget)
-} else {
-    macOSPlatform = .macOS(.v10_10)
-}
-
 let package = Package(
     name: "swift-tools-support-core",
     platforms: [
-        macOSPlatform,
+        .macOS(.v10_15),
+        .iOS(.v13)
     ],
     products: [
         .library(


### PR DESCRIPTION
Increase the minimum deployment target to macOS 10.15 and iOS 13 or later.  This is required in order to take advantage the APIs required for Netrc support etc.  Note that non-Darwin platforms are unaffected.

This also removes the environment variable introduced in https://github.com/apple/swift-tools-support-core/pull/220.