### PR TITLE
OpenBSD support

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -418,7 +418,7 @@ public final class Process: ObjectIdentifierProtocol {
         return stdinPipe.fileHandleForWriting
       #else
         // Initialize the spawn attributes.
-      #if canImport(Darwin) || os(Android)
+      #if canImport(Darwin) || os(Android) || os(OpenBSD)
         var attributes: posix_spawnattr_t? = nil
       #else
         var attributes = posix_spawnattr_t()
@@ -463,7 +463,7 @@ public final class Process: ObjectIdentifierProtocol {
         posix_spawnattr_setflags(&attributes, Int16(flags))
 
         // Setup the file actions.
-      #if canImport(Darwin) || os(Android)
+      #if canImport(Darwin) || os(Android) || os(OpenBSD)
         var fileActions: posix_spawn_file_actions_t? = nil
       #else
         var fileActions = posix_spawn_file_actions_t()

--- a/Sources/TSCBasic/TerminalController.swift
+++ b/Sources/TSCBasic/TerminalController.swift
@@ -144,7 +144,13 @@ public final class TerminalController {
         // a temporary arrangement and needs to be fixed.
 #if !arch(powerpc64le)
         var ws = winsize()
-        if ioctl(1, UInt(TIOCGWINSZ), &ws) == 0 {
+#if os(OpenBSD)
+        let tiocgwinsz = 0x40087468
+        let err = ioctl(1, UInt(tiocgwinsz), &ws)
+#else
+        let err = ioctl(1, UInt(TIOCGWINSZ), &ws)
+#endif
+        if err == 0 {
             return Int(ws.ws_col)
         }
 #endif

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -53,6 +53,9 @@ target_link_libraries(TSCUtility PRIVATE
   Threads::Threads)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  if(CMAKE_SYSTEM_NAME STREQUAL OpenBSD)
+    target_link_directories(TSCUtility PRIVATE /usr/local/lib)
+  endif()
   target_link_libraries(TSCUtility PRIVATE
     SQLite::SQLite3)
   if(Foundation_FOUND)

--- a/Sources/TSCUtility/IndexStore.swift
+++ b/Sources/TSCUtility/IndexStore.swift
@@ -223,8 +223,6 @@ private final class IndexStoreAPIImpl {
         self.path = path
 #if os(Windows)
         let flags: DLOpenFlags = []
-#elseif os(Android)
-        let flags: DLOpenFlags = [.lazy, .local, .first]
 #else
         let flags: DLOpenFlags = [.lazy, .local, .first, .deepBind]
 #endif

--- a/Sources/TSCUtility/InterruptHandler.swift
+++ b/Sources/TSCUtility/InterruptHandler.swift
@@ -63,7 +63,7 @@ public final class InterruptHandler {
         }
       #else
         var action = sigaction()
-      #if canImport(Darwin)
+      #if canImport(Darwin) || os(OpenBSD)
         action.__sigaction_u.__sa_handler = signalHandler
       #elseif os(Android)
         action.sa_handler = signalHandler

--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -41,6 +41,7 @@ public struct Triple: Encodable, Equatable {
         case powerpc64le
         case s390x
         case aarch64
+        case amd64
         case armv7
         case arm
         case arm64
@@ -59,6 +60,7 @@ public struct Triple: Encodable, Equatable {
         case linux
         case windows
         case wasi
+        case openbsd
     }
 
     public enum ABI: String, Encodable {
@@ -127,6 +129,10 @@ public struct Triple: Encodable, Equatable {
         return os == .wasi
     }
 
+    public func isOpenBSD() -> Bool {
+        return os == .openbsd
+    }
+
     /// Returns the triple string for the given platform version.
     ///
     /// This is currently meant for Apple platforms only.
@@ -173,7 +179,7 @@ extension Triple {
         switch os {
         case .darwin, .macOS:
             return ".dylib"
-        case .linux:
+        case .linux, .openbsd:
             return ".so"
         case .windows:
             return ".dll"
@@ -186,7 +192,7 @@ extension Triple {
       switch os {
       case .darwin, .macOS:
         return ""
-      case .linux:
+      case .linux, .openbsd:
         return ""
       case .wasi:
         return ".wasm"

--- a/Sources/TSCUtility/dlopen.swift
+++ b/Sources/TSCUtility/dlopen.swift
@@ -62,8 +62,10 @@ public struct DLOpenFlags: RawRepresentable, OptionSet {
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #else
     public static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
-  #if !os(Android)
+  #if os(Linux)
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: RTLD_DEEPBIND)
+  #else
+    public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #endif
   #endif
   #endif


### PR DESCRIPTION
Preliminary OpenBSD support. Some particular notes:

*   Of note is the changes to FSWatch. inotify is only available on Linux,
    so do not condition on `canImport(Glibc)` but restrict to operating
    systems using the Linux kernel only.

    Naturally, OpenBSD does not have FSEventStream either, so for now,
    create a no-op delegate for this platform. It is possible that this
    particular functionality might be provided by some creative use of
    kevent, but we defer that here: such behavior would be important for
    platforms that do not have support for monitoring filesystem events.

*   On this platform, SQLite resides in /usr/local/lib, so make the
    necessary cmake changes as well, while we are here.

*   We do still need to do something about the `unversionedTriple`
    inference: this will be handled separately.

*   Flatten TIOCGWINSZ on OpenBSD.

    On this platform, the TIOCGWINSZ ioctl identifier is a complex macro.
    Compare #291 in swift-argument-parser.