### PR TITLE
[5.5] TSCBasic: correct a use-after-free on Windows

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -730,13 +730,14 @@ private struct UNIXPath: Path {
 
     func suffix(withDot: Bool) -> String? {
 #if os(Windows)
-        let ext = self.string.withCString(encodedAs: UTF16.self) {
-            PathFindExtensionW($0)
+        return self.string.withCString(encodedAs: UTF16.self) {
+          if let pointer = PathFindExtensionW($0) {
+            let substring = String(decodingCString: pointer, as: UTF16.self)
+            guard substring.length > 0 else { return nil }
+            return withDot ? substring : String(substring.dropFirst(1))
+          }
+          return nil
         }
-        var result = String(decodingCString: ext!, as: UTF16.self)
-        guard result.length > 0 else { return nil }
-        if !withDot { result.removeFirst(1) }
-        return result
 #else
         // FIXME: This method seems too complicated; it should be simplified,
         //        if possible, and certainly optimized (using UTF8View).


### PR DESCRIPTION
This corrects a use-after-free caused by a pointer escape.  The lifetime
of the pointer is not guaranteed, and the OS may free the pointer
early, particularly with OSSA.  Push the handling into the closure to
ensure that the lifetime is extended for the duration.