### PR TITLE
Default to macOS 10.10 minimum deployment target again but allow it to be overridden

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,17 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
+let macOSPlatform: SupportedPlatform
+if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTTSC_MACOS_DEPLOYMENT_TARGET"] {
+    macOSPlatform = .macOS(deploymentTarget)
+} else {
+    macOSPlatform = .macOS(.v10_10)
+}
+
 let package = Package(
     name: "swift-tools-support-core",
     platforms: [
-        .macOS(.v10_15),
+        macOSPlatform,
         .iOS(.v13)
     ],
     products: [


### PR DESCRIPTION
This reverts the main part of the https://github.com/apple/swift-tools-support-core/pull/225 change.

This reverts commit 5e968d4b3bb92e4cd39efdaac56f0a05de122f1e since it caused breakage, but keeps the iOS 13 minimum deployment target.