### PR TITLE
Improve Deserialization Performance for Bitstream Files

### DIFF
--- a/Sources/TSCUtility/Bitstream.swift
+++ b/Sources/TSCUtility/Bitstream.swift
@@ -47,6 +47,21 @@ public enum BitcodeElement {
   case record(Record)
 }
 
+extension BitcodeElement.Record.Payload: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .none:
+      return "none"
+    case .array(let vals):
+      return "array(\(vals))"
+    case .char6String(let s):
+      return "char6String(\(s))"
+    case .blob(let s):
+      return "blob(\(s.count) bytes)"
+    }
+  }
+}
+
 public struct BlockInfo {
   public var name: String = ""
   public var recordNames: [UInt64: String] = [:]

--- a/Sources/TSCUtility/Bitstream.swift
+++ b/Sources/TSCUtility/Bitstream.swift
@@ -18,22 +18,28 @@ public struct Bitcode {
   public let blockInfo: [UInt64: BlockInfo]
 }
 
+/// A non-owning view of a bitcode element.
 public enum BitcodeElement {
   public struct Block {
     public var id: UInt64
     public var elements: [BitcodeElement]
   }
 
+  /// A record element.
+  ///
+  /// - Warning: A `Record` element's fields and payload only live as long as
+  ///            the `visit` function that provides them is called. To persist
+  ///            a record, always make a copy of it.
   public struct Record {
     public enum Payload {
       case none
       case array([UInt64])
       case char6String(String)
-      case blob(Data)
+      case blob(ArraySlice<UInt8>)
     }
 
     public var id: UInt64
-    public var fields: [UInt64]
+    public var fields: UnsafeBufferPointer<UInt64>
     public var payload: Payload
   }
 

--- a/Sources/TSCUtility/BitstreamReader.swift
+++ b/Sources/TSCUtility/BitstreamReader.swift
@@ -148,6 +148,10 @@ private struct BitstreamReader {
     }
   }
 
+  /// Computes a non-owning view of a `BitcodeElement.Record` that is valid for
+  /// the lifetime of the call to `body`.
+  ///
+  /// - Warning: If this function throws, the `body` block will not be called.
   mutating func withAbbreviatedRecord(
     _ abbrev: Bitstream.Abbreviation,
     body: (BitcodeElement.Record) throws -> Void

--- a/Sources/TSCUtility/BitstreamReader.swift
+++ b/Sources/TSCUtility/BitstreamReader.swift
@@ -25,36 +25,6 @@ extension Bitcode {
   }
 }
 
-/// A basic visitor that collects all the blocks and records in a stream.
-private struct CollectingVisitor: BitstreamVisitor {
-  var stack: [(UInt64, [BitcodeElement])] = [(BitstreamReader.fakeTopLevelBlockID, [])]
-
-  func validate(signature: Bitcode.Signature) throws {}
-
-  mutating func shouldEnterBlock(id: UInt64) throws -> Bool {
-    stack.append((id, []))
-    return true
-  }
-
-  mutating func didExitBlock() throws {
-    guard let (id, elements) = stack.popLast() else {
-      fatalError("Unbalanced calls to shouldEnterBlock/didExitBlock")
-    }
-
-    let block = BitcodeElement.Block(id: id, elements: elements)
-    stack[stack.endIndex-1].1.append(.block(block))
-  }
-
-  mutating func visit(record: BitcodeElement.Record) throws {
-    stack[stack.endIndex-1].1.append(.record(record))
-  }
-
-  func finalizeTopLevelElements() -> [BitcodeElement] {
-    assert(stack.count == 1)
-    return stack[0].1
-  }
-}
-
 private extension Bits.Cursor {
   enum BitcodeError: Swift.Error {
     case vbrOverflow

--- a/Sources/TSCUtility/BitstreamReader.swift
+++ b/Sources/TSCUtility/BitstreamReader.swift
@@ -104,6 +104,7 @@ private struct BitstreamReader {
     guard numOps > 0 else { throw Error.invalidAbbrev }
 
     var operands: [Bitstream.Abbreviation.Operand] = []
+    operands.reserveCapacity(numOps)
     for i in 0..<numOps {
       operands.append(try readAbbrevOp())
 
@@ -156,7 +157,11 @@ private struct BitstreamReader {
     let lastOperand = abbrev.operands.last!
     let lastRegularOperandIndex: Int = abbrev.operands.endIndex - (lastOperand.isPayload ? 1 : 0)
 
-    // Safety: `lastRegularOperandIndex` is always at least 1.
+    // Safety: `lastRegularOperandIndex` is always at least 1. An abbreviation
+    // is required by the format to contain at least one operand. If that last
+    // operand is a payload (and thus we subtracted one from the total number of
+    // operands above), then that must mean it is either a trailing array
+    // or trailing blob. Both of these are preceded by their length field.
     let fields = UnsafeMutableBufferPointer<UInt64>.allocate(capacity: lastRegularOperandIndex - 1)
     defer { fields.deallocate() }
 

--- a/Sources/TSCUtility/BitstreamWriter.swift
+++ b/Sources/TSCUtility/BitstreamWriter.swift
@@ -338,6 +338,7 @@ extension BitstreamWriter {
 
         fileprivate init() {
             self.values = []
+            self.values.reserveCapacity(8)
         }
 
         fileprivate init<CodeType>(recordID: CodeType)
@@ -367,6 +368,7 @@ extension BitstreamWriter {
         }
 
         public mutating func append(_ string: String) {
+            self.values.reserveCapacity(self.values.capacity + string.utf8.count)
             for byte in string.utf8 {
                 values.append(UInt32(byte))
             }

--- a/Sources/TSCUtility/SerializedDiagnostics.swift
+++ b/Sources/TSCUtility/SerializedDiagnostics.swift
@@ -43,15 +43,6 @@ public struct SerializedDiagnostics {
   /// Serialized diagnostics.
   public var diagnostics: [Diagnostic]
 
-  @available(*, deprecated, message: "Use SerializedDiagnostics.init(bytes:) instead")
-  public init(data: Data) throws {
-    var reader = Reader()
-    try Bitcode.read(stream: data, using: &reader)
-    guard let version = reader.versionNumber else { throw Error.noMetadataBlock }
-    self.versionNumber = version
-    self.diagnostics = reader.diagnostics
-  }
-
   public init(bytes: ByteString) throws {
     var reader = Reader()
     try Bitcode.read(bytes: bytes, using: &reader)

--- a/Sources/TSCUtility/SerializedDiagnostics.swift
+++ b/Sources/TSCUtility/SerializedDiagnostics.swift
@@ -98,7 +98,7 @@ extension SerializedDiagnostics {
                 case .blob(let diagnosticBlob) = record.payload
           else { throw Error.malformedRecord }
 
-          text = String(data: diagnosticBlob, encoding: .utf8)
+          text = String(decoding: diagnosticBlob, as: UTF8.self)
           level = Level(rawValue: record.fields[0])
           location = SourceLocation(fields: record.fields[1...4],
                                     filenameMap: filenameMap)
@@ -116,38 +116,38 @@ extension SerializedDiagnostics {
           }
         case .flag:
           guard record.fields.count == 2,
-                case .blob(let flagBlob) = record.payload,
-                let flagText = String(data: flagBlob, encoding: .utf8)
+                case .blob(let flagBlob) = record.payload
           else { throw Error.malformedRecord }
 
+          let flagText = String(decoding: flagBlob, as: UTF8.self)
           let diagnosticID = record.fields[0]
           flagMap[diagnosticID] = flagText
 
         case .category:
           guard record.fields.count == 2,
-                case .blob(let categoryBlob) = record.payload,
-                let categoryText = String(data: categoryBlob, encoding: .utf8)
+                case .blob(let categoryBlob) = record.payload
           else { throw Error.malformedRecord }
 
+          let categoryText = String(decoding: categoryBlob, as: UTF8.self)
           let categoryID = record.fields[0]
           categoryMap[categoryID] = categoryText
 
         case .filename:
           guard record.fields.count == 4,
-                case .blob(let filenameBlob) = record.payload,
-                let filenameText = String(data: filenameBlob, encoding: .utf8)
+                case .blob(let filenameBlob) = record.payload
           else { throw Error.malformedRecord }
 
+          let filenameText = String(decoding: filenameBlob, as: UTF8.self)
           let filenameID = record.fields[0]
           // record.fields[1] and record.fields[2] are no longer used.
           filenameMap[filenameID] = filenameText
 
         case .fixit:
           guard record.fields.count == 9,
-                case .blob(let fixItBlob) = record.payload,
-                let fixItText = String(data: fixItBlob, encoding: .utf8)
+                case .blob(let fixItBlob) = record.payload
           else { throw Error.malformedRecord }
 
+          let fixItText = String(decoding: fixItBlob, as: UTF8.self)
           if let start = SourceLocation(fields: record.fields[0...3],
                                         filenameMap: filenameMap),
              let end = SourceLocation(fields: record.fields[4...7],
@@ -184,7 +184,7 @@ extension SerializedDiagnostics {
     /// Clang includes this, it is set to 0 by Swift.
     public var offset: UInt64
 
-    fileprivate init?(fields: ArraySlice<UInt64>,
+    fileprivate init?(fields: Slice<UnsafeBufferPointer<UInt64>>,
                       filenameMap: [UInt64: String]) {
       guard let filename = filenameMap[fields[fields.startIndex]] else { return nil }
       self.filename = filename

--- a/Tests/TSCUtilityTests/BitstreamTests.swift
+++ b/Tests/TSCUtilityTests/BitstreamTests.swift
@@ -151,39 +151,6 @@ final class BitstreamTests: XCTestCase {
                                      "skipping block: 9"])
     }
 
-    func testStandardInit() throws {
-        let bitstreamPath = AbsolutePath(#file).parentDirectory
-            .appending(components: "Inputs", "serialized.dia")
-        let contents = try localFileSystem.readFileContents(bitstreamPath)
-        let bitcode = try Bitcode(bytes: contents)
-        XCTAssertEqual(bitcode.signature, .init(string: "DIAG"))
-        XCTAssertEqual(bitcode.elements.count, 18)
-        guard case .block(let metadataBlock) = bitcode.elements.first else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(metadataBlock.id, 8)
-        XCTAssertEqual(metadataBlock.elements.count, 1)
-        guard case .record(let versionRecord) = metadataBlock.elements[0] else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(versionRecord.id, 1)
-        XCTAssertEqual(versionRecord.fields, [1])
-        guard case .block(let lastBlock) = bitcode.elements.last else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(lastBlock.id, 9)
-        XCTAssertEqual(lastBlock.elements.count, 3)
-        guard case .record(let lastRecord) = lastBlock.elements[2] else {
-            XCTFail()
-            return
-        }
-        XCTAssertEqual(lastRecord.id, 3)
-        XCTAssertEqual(lastRecord.fields, [5, 34, 13, 0, 5, 34, 26, 0])
-    }
-
     func testBufferedWriter() {
         let writer = BitstreamWriter()
 
@@ -312,13 +279,13 @@ final class BitstreamTests: XCTestCase {
             mutating func visit(record: BitcodeElement.Record) throws {
                 switch record.id {
                 case UInt64(RoundTripRecordID.version.rawValue):
-                    XCTAssertEqual(record.fields, [ 25 ]) // version
+                    XCTAssertEqual(Array(record.fields), [ 25 ]) // version
                     guard case .none = record.payload else {
                         XCTFail("Unexpected payload in metadata record!")
                         return
                     }
                 case UInt64(RoundTripRecordID.blob.rawValue):
-                    XCTAssertEqual(record.fields, [
+                    XCTAssertEqual(Array(record.fields), [
                         42,
                         43,
                         44,

--- a/Tests/TSCUtilityTests/BitstreamTests.swift
+++ b/Tests/TSCUtilityTests/BitstreamTests.swift
@@ -29,7 +29,7 @@ final class BitstreamTests: XCTestCase {
             }
 
             mutating func visit(record: BitcodeElement.Record) throws {
-                log.append("Record (id: \(record.id), fields: \(record.fields), payload: \(record.payload)")
+                log.append("Record (id: \(record.id), fields: \(Array(record.fields)), payload: \(record.payload)")
             }
         }
 


### PR DESCRIPTION
Switch to a non-owning intermediate representation to allow the caller to perform the necessary copies when it reinterprets the raw data we provide to them in the visitor. This meant removing the remaining entry points that could possibly allow unowned data to escape - so the initializers on `Bitstream` that ran the `CollectingVisitor` have been struck - as well as the existing deprecated APIs here that we no longer need.

The combo of all of the changes here improves the performance of dependency graph deserialization in the Swift driver by 3-5x which translates to a 3-5 second wall time improvement for large projects (> 1000 files).