### PR TITLE
Revert "OpenBSD support"

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -468,7 +468,7 @@ public final class Process: ObjectIdentifierProtocol {
         return stdinPipe.fileHandleForWriting
     #else
         // Initialize the spawn attributes.
-      #if canImport(Darwin) || os(Android) || os(OpenBSD)
+      #if canImport(Darwin) || os(Android)
         var attributes: posix_spawnattr_t? = nil
       #else
         var attributes = posix_spawnattr_t()
@@ -513,7 +513,7 @@ public final class Process: ObjectIdentifierProtocol {
         posix_spawnattr_setflags(&attributes, Int16(flags))
 
         // Setup the file actions.
-      #if canImport(Darwin) || os(Android) || os(OpenBSD)
+      #if canImport(Darwin) || os(Android)
         var fileActions: posix_spawn_file_actions_t? = nil
       #else
         var fileActions = posix_spawn_file_actions_t()

--- a/Sources/TSCBasic/TerminalController.swift
+++ b/Sources/TSCBasic/TerminalController.swift
@@ -147,13 +147,7 @@ public final class TerminalController {
         // a temporary arrangement and needs to be fixed.
 #if !arch(powerpc64le)
         var ws = winsize()
-#if os(OpenBSD)
-        let tiocgwinsz = 0x40087468
-        let err = ioctl(1, UInt(tiocgwinsz), &ws)
-#else
-        let err = ioctl(1, UInt(TIOCGWINSZ), &ws)
-#endif
-        if err == 0 {
+        if ioctl(1, UInt(TIOCGWINSZ), &ws) == 0 {
             return Int(ws.ws_col)
         }
 #endif

--- a/Sources/TSCUtility/CMakeLists.txt
+++ b/Sources/TSCUtility/CMakeLists.txt
@@ -53,9 +53,6 @@ target_link_libraries(TSCUtility PRIVATE
   Threads::Threads)
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  if(CMAKE_SYSTEM_NAME STREQUAL OpenBSD)
-    target_link_directories(TSCUtility PRIVATE /usr/local/lib)
-  endif()
   target_link_libraries(TSCUtility PRIVATE
     SQLite::SQLite3)
   if(Foundation_FOUND)

--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -47,9 +47,7 @@ public class FSWatch {
         self.paths = paths
         self.latency = latency
 
-      #if os(OpenBSD)
-        self._watcher = NoOpWatcher(paths: paths, latency: latency, delegate: _WatcherDelegate(block: block))
-      #elseif canImport(Glibc)
+      #if canImport(Glibc)
         var ipaths: [AbsolutePath: Inotify.WatchOptions] = [:]
 
         // FIXME: We need to recurse here.
@@ -95,37 +93,17 @@ private protocol _FileWatcher {
     func stop()
 }
 
-#if os(OpenBSD)
-extension FSWatch._WatcherDelegate: NoOpWatcherDelegate {}
-extension NoOpWatcher: _FileWatcher{}
-#elseif canImport(Glibc)
+#if canImport(Glibc)
 extension FSWatch._WatcherDelegate: InotifyDelegate {}
 extension Inotify: _FileWatcher{}
 #elseif os(macOS)
 extension FSWatch._WatcherDelegate: FSEventStreamDelegate {}
 extension FSEventStream: _FileWatcher{}
-#else
-#error("Implementation required")
 #endif
 
 // MARK:- inotify
 
-#if os(OpenBSD)
-
-public protocol NoOpWatcherDelegate {
-    func pathsDidReceiveEvent(_ paths: [AbsolutePath])
-}
-
-public final class NoOpWatcher {
-    public init(paths: [AbsolutePath], latency: Double, delegate: NoOpWatcherDelegate? = nil) {
-    }
-
-    public func start() throws {}
-
-    public func stop() {}
-}
-
-#elseif canImport(Glibc)
+#if canImport(Glibc)
 
 /// The delegate for receiving inotify events.
 public protocol InotifyDelegate {

--- a/Sources/TSCUtility/IndexStore.swift
+++ b/Sources/TSCUtility/IndexStore.swift
@@ -223,6 +223,8 @@ private final class IndexStoreAPIImpl {
         self.path = path
 #if os(Windows)
         let flags: DLOpenFlags = []
+#elseif os(Android)
+        let flags: DLOpenFlags = [.lazy, .local, .first]
 #else
         let flags: DLOpenFlags = [.lazy, .local, .first, .deepBind]
 #endif

--- a/Sources/TSCUtility/InterruptHandler.swift
+++ b/Sources/TSCUtility/InterruptHandler.swift
@@ -63,7 +63,7 @@ public final class InterruptHandler {
         }
       #else
         var action = sigaction()
-      #if canImport(Darwin) || os(OpenBSD)
+      #if canImport(Darwin)
         action.__sigaction_u.__sa_handler = signalHandler
       #elseif os(Android)
         action.sa_handler = signalHandler

--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -41,7 +41,6 @@ public struct Triple: Encodable, Equatable {
         case powerpc64le
         case s390x
         case aarch64
-        case amd64
         case armv7
         case arm
         case arm64
@@ -60,7 +59,6 @@ public struct Triple: Encodable, Equatable {
         case linux
         case windows
         case wasi
-        case openbsd
     }
 
     public enum ABI: String, Encodable {
@@ -129,10 +127,6 @@ public struct Triple: Encodable, Equatable {
         return os == .wasi
     }
 
-    public func isOpenBSD() -> Bool {
-        return os == .openbsd
-    }
-
     /// Returns the triple string for the given platform version.
     ///
     /// This is currently meant for Apple platforms only.
@@ -179,7 +173,7 @@ extension Triple {
         switch os {
         case .darwin, .macOS:
             return ".dylib"
-        case .linux, .openbsd:
+        case .linux:
             return ".so"
         case .windows:
             return ".dll"
@@ -192,7 +186,7 @@ extension Triple {
       switch os {
       case .darwin, .macOS:
         return ""
-      case .linux, .openbsd:
+      case .linux:
         return ""
       case .wasi:
         return ".wasm"

--- a/Sources/TSCUtility/dlopen.swift
+++ b/Sources/TSCUtility/dlopen.swift
@@ -62,10 +62,8 @@ public struct DLOpenFlags: RawRepresentable, OptionSet {
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #else
     public static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
-  #if os(Linux)
+  #if !os(Android)
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: RTLD_DEEPBIND)
-  #else
-    public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #endif
   #endif
   #endif


### PR DESCRIPTION
Reverts apple/swift-tools-support-core#228

This seems to have regressed the Windows build: https://dev.azure.com/compnerd/swift-build/_build/results?buildId=52599&view=logs&j=73ce2acc-4df7-56ec-1894-6d2e45aae46f&t=b5c3161b-bae5-527a-a0c5-e44be8cd66e3