### PR TITLE
TSCUtility: remove extraneous `)` in dispatch queue ids (NFC)

### DIFF
--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -233,10 +233,10 @@ public final class Inotify {
     private var wds: [Int32: AbsolutePath] = [:]
 
     /// The queue on which we read the events.
-    private let readQueue = DispatchQueue(label: "org.swift.swiftpm.\(Inotify.self).read)")
+    private let readQueue = DispatchQueue(label: "org.swift.swiftpm.\(Inotify.self).read")
 
     /// Callback queue for the delegate.
-    private let callbacksQueue = DispatchQueue(label: "org.swift.swiftpm.\(Inotify.self).callback)")
+    private let callbacksQueue = DispatchQueue(label: "org.swift.swiftpm.\(Inotify.self).callback")
 
     /// Condition for handling event reporting.
     private var reportCondition = Condition()
@@ -625,7 +625,7 @@ public final class FSEventStream {
     private var runLoop: CFRunLoop?
 
     /// Callback queue for the delegate.
-    fileprivate let callbacksQueue = DispatchQueue(label: "org.swift.swiftpm.\(FSEventStream.self).callback)")
+    fileprivate let callbacksQueue = DispatchQueue(label: "org.swift.swiftpm.\(FSEventStream.self).callback")
 
     public init(
         paths: [AbsolutePath],


### PR DESCRIPTION
This removes errant `)` in the dispatch queue names.