### PR TITLE
Add conditionals to unbreak building ToolsSupportCore for iOS

### DIFF
--- a/Sources/TSCUtility/BitstreamReader.swift
+++ b/Sources/TSCUtility/BitstreamReader.swift
@@ -183,7 +183,7 @@ private struct BitstreamReader {
         if case .char6 = element {
           // FIXME: Once the minimum deployment target bumps to macOS 11, use
           // the more ergonomic stdlib API everywhere.
-          if #available(macOS 11.0, *) {
+          if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
             payload = try .char6String(String(unsafeUninitializedCapacity: Int(length)) { buffer in
               for i in 0..<Int(length) {
                 buffer[i] = try UInt8(readSingleAbbreviatedRecordOperand(element))

--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -95,7 +95,7 @@ private protocol _FileWatcher {
     func stop()
 }
 
-#if os(OpenBSD) || os(Windows)
+#if os(OpenBSD) || os(Windows) || os(iOS)
 extension FSWatch._WatcherDelegate: NoOpWatcherDelegate {}
 extension NoOpWatcher: _FileWatcher{}
 #elseif canImport(Glibc)
@@ -110,7 +110,7 @@ extension FSEventStream: _FileWatcher{}
 
 // MARK:- inotify
 
-#if os(OpenBSD) || os(Windows)
+#if os(OpenBSD) || os(Windows) || os(iOS)
 
 public protocol NoOpWatcherDelegate {
     func pathsDidReceiveEvent(_ paths: [AbsolutePath])


### PR DESCRIPTION
One availability conditional wasn't properly including the iOS platform, and another conditional caused an "implementation required" error.  This restores the ability to build on iOS after #228 and #236.