### PR TITLE
TSCBasic: FILE is an opaque struct since Android 7

### DIFF
--- a/Sources/TSCBasic/WritableByteStream.swift
+++ b/Sources/TSCBasic/WritableByteStream.swift
@@ -66,6 +66,12 @@ public extension WritableByteStream {
 // Public alias to the old name to not introduce API compatibility.
 public typealias OutputByteStream = WritableByteStream
 
+#if os(Android)
+public typealias FILEPointer = OpaquePointer
+#else
+public typealias FILEPointer = UnsafeMutablePointer<FILE>
+#endif
+
 extension WritableByteStream {
     /// Write a sequence of bytes to the buffer.
     public func write<S: Sequence>(sequence: S) where S.Iterator.Element == UInt8 {
@@ -670,7 +676,7 @@ public class FileOutputByteStream: _WritableByteStreamBase {
 public final class LocalFileOutputByteStream: FileOutputByteStream {
 
     /// The pointer to the file.
-    let filePointer: UnsafeMutablePointer<FILE>
+    let filePointer: FILEPointer
 
     /// Set to an error value if there were any IO error during writing.
     private var error: FileSystemError?
@@ -682,7 +688,7 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     private let path: AbsolutePath?
 
     /// Instantiate using the file pointer.
-    public init(filePointer: UnsafeMutablePointer<FILE>, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
+    public init(filePointer: FILEPointer, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
         self.filePointer = filePointer
         self.closeOnDeinit = closeOnDeinit
         self.path = nil


### PR DESCRIPTION
I've been working around this for awhile by passing in `-Xcc -D__ANDROID_API__=23` when cross-compiling SPM for Android with this file. Otherwise, I would get these errors:
```
/home/butta/src/swift-tools-support-core/Sources/TSCBasic/WritableByteStream.swift:685:51: error: cannot find type 'FILE' in scope
    public init(filePointer: UnsafeMutablePointer<FILE>, closeOnDeinit: Bool = true, buffered: Bool = true) throws {
/home/butta/src/swift-tools-support-core/Sources/TSCBasic/Process.swift:546:70: error: cannot convert value of type 'OpaquePointer?' to expected argument type 'AbsolutePath'
        let stdinStream = try LocalFileOutputByteStream(filePointer: fdopen(stdinPipe[1], "wb"), closeOnDeinit: true)
```
This is because a definition was added for Android 6, ie API 23, and below, but it's an opaque struct for all recent Android APIs, aosp-mirror/platform_bionic@3037ea4. This pull gets this Swift file to compile without having to force the Android API to 23 with the above flags.