### PR TITLE
Add TSCBasic as a separate product w/o TSCUtility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,9 @@ let package = Package(
     ],
     products: [
         .library(
+            name: "TSCBasic",
+            targets: ["TSCBasic"]),
+        .library(
             name: "SwiftToolsSupport",
             type: .dynamic,
             targets: ["TSCBasic", "TSCUtility"]),


### PR DESCRIPTION
Currently, targets such as `SwiftToolsSupport` and `SwiftToolsSupport-auto` can't be built with SwiftPM alone if SQLite is not preinstalled. Also, `SwiftToolsSupport` depends on `TSCUtility`, while `TSCBasic` is enough in a lot of use cases for libraries that rely on TSC.

This PR allows building `TSCBasic` alone with SwiftPM via new `SwiftToolsSupportBasic` product, and without having SQLite preinstalled.

The change is purely additive and doesn't touch any of the existing targets or products.