### PR TITLE
deprecate unused and outdated code

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let macOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTTSC_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
-    macOSPlatform = .macOS(.v10_10)
+    macOSPlatform = .macOS(.v10_15)
 }
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let macOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTTSC_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
-    macOSPlatform = .macOS(.v10_15)
+    macOSPlatform = .macOS(.v10_10)
 }
 
 let package = Package(

--- a/Sources/TSCBasic/ObjectIdentifierProtocol.swift
+++ b/Sources/TSCBasic/ObjectIdentifierProtocol.swift
@@ -11,8 +11,10 @@
 /// A protocol which implements Hashable protocol using ObjectIdentifier.
 ///
 /// Classes can conform to this protocol to auto-conform to Hashable and Equatable.
+@available(*, deprecated, message: "user Identifiable instead")
 public protocol ObjectIdentifierProtocol: AnyObject, Hashable {}
 
+@available(*, deprecated)
 extension ObjectIdentifierProtocol {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(self))

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -119,8 +119,7 @@ public struct ProcessResult: CustomStringConvertible {
 /// Process allows spawning new subprocesses and working with them.
 ///
 /// Note: This class is thread safe.
-public final class Process: ObjectIdentifierProtocol {
-
+public final class Process {
     /// Errors when attempting to invoke a process
     public enum Error: Swift.Error {
         /// The program requested to be executed cannot be found on the existing search paths, or is not executable.
@@ -834,6 +833,16 @@ extension Process {
 
     public convenience init(args: String..., environment: [String: String] = ProcessEnv.vars, outputRedirection: OutputRedirection = .collect) {
         self.init(arguments: args, environment: environment, outputRedirection: outputRedirection)
+    }
+}
+
+extension Process: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: Process, rhs: Process) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
     }
 }
 

--- a/Sources/TSCUtility/Diagnostics.swift
+++ b/Sources/TSCUtility/Diagnostics.swift
@@ -186,6 +186,8 @@ extension Optional where Wrapped == DiagnosticsEngine {
 }
 
 /// Namespace for representing diagnostic location of a package.
+// deprecated 9/2021
+@available(*, deprecated)
 public enum PackageLocation {
 
     /// Represents location of a locally available package. This could be root

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -2,11 +2,16 @@ import Foundation
 import TSCBasic
 
 /// Supplies `Authorization` header, typically to be appended to `URLRequest`
+
+// deprecated 9/2021
+@available(*, deprecated)
 public protocol AuthorizationProviding {
     /// Optional `Authorization` header, likely added to `URLRequest`
     func authorization(for url: Foundation.URL) -> String?
 }
 
+// deprecated 9/2021
+@available(*, deprecated)
 extension AuthorizationProviding {
     public func authorization(for url: Foundation.URL) -> String? {
         return nil
@@ -17,9 +22,9 @@ extension AuthorizationProviding {
  Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
  which is only available in macOS 10.13+, iOS 11+, etc at this time.
  */
-@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 /// Container of parsed netrc connection settings
-public struct Netrc: AuthorizationProviding {
+@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+public struct Netrc {
     /// Representation of `machine` connection settings & `default` connection settings.
     /// If `default` connection settings present, they will be last element.
     public let machines: [Machine]
@@ -62,7 +67,7 @@ public struct Netrc: AuthorizationProviding {
         
         let machines: [Machine] = matches.compactMap {
             return Machine(for: $0, string: content, variant: "lp") ??
-                Machine(for: $0, string: content, variant: "pl")
+            Machine(for: $0, string: content, variant: "pl")
         }
         
         if let defIndex = machines.firstIndex(where: { $0.isDefault }) {
@@ -87,6 +92,11 @@ public struct Netrc: AuthorizationProviding {
         return trimmedCommentsText
     }
 }
+
+// deprecated 9/2021
+@available(*, deprecated)
+@available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
+extension Netrc: AuthorizationProviding {}
 
 @available (macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 public extension Netrc {
@@ -117,10 +127,10 @@ public extension Netrc {
         
         init?(for match: NSTextCheckingResult, string: String, variant: String = "") {
             guard let name = RegexUtil.Token.machine.capture(in: match, string: string) ?? RegexUtil.Token.default.capture(in: match, string: string),
-                let login = RegexUtil.Token.login.capture(prefix: variant, in: match, string: string),
-                let password = RegexUtil.Token.password.capture(prefix: variant, in: match, string: string) else {
-                    return nil
-            }
+                  let login = RegexUtil.Token.login.capture(prefix: variant, in: match, string: string),
+                  let password = RegexUtil.Token.password.capture(prefix: variant, in: match, string: string) else {
+                      return nil
+                  }
             self = Machine(name: name, login: login, password: password)
         }
     }

--- a/Sources/TSCUtility/URL.swift
+++ b/Sources/TSCUtility/URL.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+// deprecated 9/2021
+@available(*, deprecated, message: "use Foundation APIs instead")
 public struct URL {
 
     /// Parses the URL type of a git repository

--- a/Tests/TSCBasicTests/ObjectIdentifierProtocolTests.swift
+++ b/Tests/TSCBasicTests/ObjectIdentifierProtocolTests.swift
@@ -12,6 +12,7 @@ import XCTest
 
 import TSCBasic
 
+@available(*, deprecated)
 final class Person {
     let name: String
     init(_ name: String) {
@@ -19,8 +20,10 @@ final class Person {
     }
 }
 
+@available(*, deprecated)
 extension Person: ObjectIdentifierProtocol {}
 
+@available(*, deprecated)
 class ObjectIdentifierProtocolTests: XCTestCase {
 
     func testBasics() {

--- a/Tests/TSCUtilityTests/StringTests.swift
+++ b/Tests/TSCUtilityTests/StringTests.swift
@@ -57,6 +57,7 @@ class StringTests: XCTestCase {
 }
 
 class URLTests: XCTestCase {
+    @available(*, deprecated)
     func testSchema() {
         XCTAssertEqual(TSCUtility.URL.scheme("http://github.com/foo/bar"), "http")
         XCTAssertEqual(TSCUtility.URL.scheme("https://github.com/foo/bar"), "https")

--- a/Tests/TSCUtilityTests/VersionTests.swift
+++ b/Tests/TSCUtilityTests/VersionTests.swift
@@ -1454,15 +1454,15 @@ class VersionTests: XCTestCase {
             "-1.2.3", "1.-2.3", "1.2.-3", ".1.2.3", "v.1.2.3", "1.2..3", "v1.2.3",
         ]
         for str in badStrings {
-            XCTAssertNil(Version(string: str))
+            XCTAssertNil(Version(str))
         }
 
-        XCTAssertEqual(Version(1,2,3), Version(string: "1.2.3"))
-        XCTAssertEqual(Version(1,2,3), Version(string: "01.002.0003"))
-        XCTAssertEqual(Version(0,9,21), Version(string: "0.9.21"))
+        XCTAssertEqual(Version(1,2,3), Version("1.2.3"))
+        XCTAssertEqual(Version(1,2,3), Version("01.002.0003"))
+        XCTAssertEqual(Version(0,9,21), Version("0.9.21"))
         XCTAssertEqual(Version(0,9,21, prereleaseIdentifiers: ["alpha", "beta"], buildMetadataIdentifiers: ["1011"]),
-            Version(string: "0.9.21-alpha.beta+1011"))
-        XCTAssertEqual(Version(0,9,21, prereleaseIdentifiers: [], buildMetadataIdentifiers: ["1011"]), Version(string: "0.9.21+1011"))
+            Version("0.9.21-alpha.beta+1011"))
+        XCTAssertEqual(Version(0,9,21, prereleaseIdentifiers: [], buildMetadataIdentifiers: ["1011"]), Version("0.9.21+1011"))
     }
 
     func testRange() {

--- a/Tests/TSCUtilityTests/miscTests.swift
+++ b/Tests/TSCUtilityTests/miscTests.swift
@@ -30,17 +30,17 @@ class miscTests: XCTestCase {
 
     func testVersion() throws {
         // Valid.
-        XCTAssertEqual(Version(string: "0.9.21-alpha.beta+1011"),
+        XCTAssertEqual(Version("0.9.21-alpha.beta+1011"),
             Version(0,9,21, prereleaseIdentifiers: ["alpha", "beta"], buildMetadataIdentifiers: ["1011"]))
-        XCTAssertEqual(Version(string: "0.9.21+1011"),
+        XCTAssertEqual(Version("0.9.21+1011"),
             Version(0,9,21, prereleaseIdentifiers: [], buildMetadataIdentifiers: ["1011"]))
-        XCTAssertEqual(Version(string: "01.002.0003"), Version(1,2,3))
-        XCTAssertEqual(Version(string: "0.9.21"), Version(0,9,21))
+        XCTAssertEqual(Version("01.002.0003"), Version(1,2,3))
+        XCTAssertEqual(Version("0.9.21"), Version(0,9,21))
 
         // Invalid.
         let invalidVersions = ["foo", "1", "1.0", "1.0.", "1.0.0."]
         for v in invalidVersions {
-            XCTAssertTrue(Version(string: v) == nil)
+            XCTAssertTrue(Version(v) == nil)
         }
     }
 }


### PR DESCRIPTION
motivation: reduce API surface area when not needed

changes:
* deprecate ObjectIdentifierProtocol, since we have Identifiable now in the stdlib
* deprecate PackageLocation which is a SwiftPM diagnostics concern and name-squats a too general of a name
* deprecate AuthorizationProviding which is not in use and redundant
* deprecate TSCUtility.URL which is redundant and name-squats / conflict with Foundation.URL
* adjust call-sites / test