### PR TITLE
TSCBasic: correct handling of normalizing relative paths

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -617,11 +617,15 @@ private struct UNIXPath: Path {
 
     init(normalizingRelativePath path: String) {
       #if os(Windows)
-        var buffer: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(MAX_PATH + 1))
-        _ = path.replacingOccurrences(of: "/", with: "\\").withCString(encodedAs: UTF16.self) {
-            PathCanonicalizeW(&buffer, $0)
+        if path.isEmpty || path == "." {
+            self.init(string: ".")
+        } else {
+            var buffer: [WCHAR] = Array<WCHAR>(repeating: 0, count: Int(MAX_PATH + 1))
+            _ = path.replacingOccurrences(of: "/", with: "\\").withCString(encodedAs: UTF16.self) {
+                PathCanonicalizeW(&buffer, $0)
+            }
+            self.init(string: String(decodingCString: buffer, as: UTF16.self))
         }
-        self.init(string: String(decodingCString: buffer, as: UTF16.self))
       #else
         precondition(path.first != "/")
 


### PR DESCRIPTION
Relative paths which are empty or `.` need to be handled as a special
case as PathCanonicalizeW is meant to canonicalize absolute paths, and
will convert these cases to the root of the current drive `\`.  This
enables a number of swift-driver tests to now pass on Windows.