### PR TITLE
Remove LinuxMain.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 
 /*
  This source file is part of the Swift.org open source project

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,1 +1,0 @@
-fatalError("Use `swift test --enable-test-discovery` to run tests")


### PR DESCRIPTION
Swift 5.5+ Swift Package Manager warns that `--enable-test-discovery` is
enabled by default. I assume for this project that should mean this
isn't needed anymore on `main`.