### PR TITLE
Remove iOS 13 deployment target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,6 @@ let package = Package(
     name: "swift-tools-support-core",
     platforms: [
         macOSPlatform,
-        .iOS(.v13)
     ],
     products: [
         .library(

--- a/Tests/TSCUtilityTests/NetrcTests.swift
+++ b/Tests/TSCUtilityTests/NetrcTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import TSCUtility
 
-@available(macOS 10.13, *)
+@available(macOS 10.13, iOS 11, tvOS 11, watchOS 4, *)
 /// Netrc feature depends upon `NSTextCheckingResult.range(withName name: String) -> NSRange`,
 /// which is only available in macOS 10.13+ at this time.
 class NetrcTests: XCTestCase {


### PR DESCRIPTION
swift-tsc can build just fine with an iOS 9 deployment target, so let it
continue defaulting to that. Add the required availability annotations
in the unit tests to let the build succeed against the subset of APIs
that do require iOS 13.