### PR TITLE
Propagate method `async`-ness during test discovery

### DIFF
--- a/Sources/TSCUtility/IndexStore.swift
+++ b/Sources/TSCUtility/IndexStore.swift
@@ -102,8 +102,8 @@ private final class IndexStoreImpl {
         class TestCaseBuilder {
             var classToMethods: [String: Set<TestCaseClass.TestMethod>] = [:]
 
-            func add(klass: String, method: TestCaseClass.TestMethod) {
-                classToMethods[klass, default: []].insert(method)
+            func add(className: String, method: TestCaseClass.TestMethod) {
+                classToMethods[className, default: []].insert(method)
             }
 
             func build() -> [TestCaseClass] {
@@ -153,7 +153,7 @@ private final class IndexStoreImpl {
             if !className.instance.isEmpty {
                 let methodName = fn.symbol_get_name(sym).str
                 let isAsync = symbolProperties & UInt64(INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ASYNC.rawValue) != 0
-                builder.instance.add(klass: className.instance, method: TestCaseClass.TestMethod(name: methodName, isAsync: isAsync))
+                builder.instance.add(className: className.instance, method: TestCaseClass.TestMethod(name: methodName, isAsync: isAsync))
             }
 
             return true

--- a/Sources/TSCUtility/IndexStore.swift
+++ b/Sources/TSCUtility/IndexStore.swift
@@ -14,17 +14,12 @@ import TSCBasic
 public final class IndexStore {
 
     public struct TestCaseClass {
-        public enum TestMethod: Hashable, Comparable {
-            case standard(String)
-            case async(String)
+        public struct TestMethod: Hashable, Comparable {
+            public let name: String
+            public let isAsync: Bool
 
-            public var name: String {
-                switch self {
-                case .standard(let name):
-                    return name
-                case .async(let name):
-                    return name
-                }
+            public static func < (lhs: IndexStore.TestCaseClass.TestMethod, rhs: IndexStore.TestCaseClass.TestMethod) -> Bool {
+                return lhs.name < rhs.name
             }
         }
 
@@ -158,7 +153,7 @@ private final class IndexStoreImpl {
             if !className.instance.isEmpty {
                 let methodName = fn.symbol_get_name(sym).str
                 let isAsync = symbolProperties & UInt64(INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ASYNC.rawValue) != 0
-                builder.instance.add(klass: className.instance, method: isAsync ? .async(methodName) : .standard(methodName))
+                builder.instance.add(klass: className.instance, method: TestCaseClass.TestMethod(name: methodName, isAsync: isAsync))
             }
 
             return true

--- a/Sources/TSCUtility/IndexStore.swift
+++ b/Sources/TSCUtility/IndexStore.swift
@@ -19,7 +19,7 @@ public final class IndexStore {
             public let isAsync: Bool
 
             public static func < (lhs: IndexStore.TestCaseClass.TestMethod, rhs: IndexStore.TestCaseClass.TestMethod) -> Bool {
-                return lhs.name < rhs.name
+                return (lhs.name, (lhs.isAsync ? 1 : 0)) < (rhs.name, (rhs.isAsync ? 1 : 0))
             }
         }
 

--- a/Sources/TSCclibc/include/indexstore_functions.h
+++ b/Sources/TSCclibc/include/indexstore_functions.h
@@ -168,6 +168,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_PROPERTY_GKINSPECTABLE                    = 1 << 6,
   INDEXSTORE_SYMBOL_PROPERTY_LOCAL                            = 1 << 7,
   INDEXSTORE_SYMBOL_PROPERTY_PROTOCOL_INTERFACE               = 1 << 8,
+  INDEXSTORE_SYMBOL_PROPERTY_SWIFT_ASYNC                      = 1 << 16,
 } indexstore_symbol_property_t;
 
 typedef enum {


### PR DESCRIPTION
Extend IndexStore.TestCaseClass to include information about `async` test methods.

This adopts the indexer enhancement from https://github.com/apple/llvm-project/pull/3452

This should be reviewed with a corresponding SwiftPM change, to be posted, which is also where a test is included.