### PR TITLE
Add async version of `Process.popen()`

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -613,7 +613,7 @@ public final class Process {
 
             // Close the local write end of the output pipe.
             try close(fd: outputPipe[1])
-            
+
             // Create a thread and start reading the output on it.
             group.enter()
             let stdoutThread = Thread { [weak self] in
@@ -628,7 +628,7 @@ public final class Process {
                         }
                     }
                     group.leave()
-               } else if let stderrResult = (pendingLock.withLock { pending }) {
+                } else if let stderrResult = (pendingLock.withLock { pending }) {
                     // TODO: this is more of an error
                     self?.stateLock.withLock {
                         self?.state = .outputReady(stdout: .success([]), stderr: stderrResult)

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -396,13 +396,14 @@ public final class Process {
         }
 
     #if os(Windows)
-        _process = Foundation.Process()
-        _process?.arguments = Array(arguments.dropFirst()) // Avoid including the executable URL twice.
-        _process?.executableURL = executablePath.asURL
-        _process?.environment = environment
+        let process = Foundation.Process()
+        _process = process
+        process.arguments = Array(arguments.dropFirst()) // Avoid including the executable URL twice.
+        process.executableURL = executablePath.asURL
+        process.environment = environment
 
         let stdinPipe = Pipe()
-        _process?.standardInput = stdinPipe
+        process.standardInput = stdinPipe
 
         let group = DispatchGroup()
 
@@ -446,8 +447,8 @@ public final class Process {
                 }
             }
 
-            _process?.standardOutput = stdoutPipe
-            _process?.standardError = stderrPipe
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
         }
 
         // first set state then start reading threads
@@ -464,7 +465,7 @@ public final class Process {
             sync.leave()
         }
 
-        try _process?.run()
+        try process.run()
         return stdinPipe.fileHandleForWriting
     #elseif (!canImport(Darwin) || os(macOS))
         // Initialize the spawn attributes.

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -697,12 +697,7 @@ public final class Process {
             group.leave()
         }
         group.wait()
-        switch processResult! {
-        case .failure(let error):
-            throw error
-        case .success(let result):
-            return result
-        }
+        return try processResult.unsafelyUnwrapped.get()
     }
 
     /// Executes the process I/O state machine, calling completion block when finished.

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -230,7 +230,7 @@ public final class Process {
     // process execution mutable state
     private var state: State = .idle
     private let stateLock = Lock()
-    private static let sharedCompletionQueue = DispatchQueue(label: "Process.sharedCompletionQueue")
+    private static let sharedCompletionQueue = DispatchQueue(label: "org.swift.tools-support-core.process-completion")
     private var completionQueue = Process.sharedCompletionQueue
 
     /// The result of the process execution. Available after process is terminated.

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -180,10 +180,10 @@ public final class Process {
     // process execution mutable state
     private enum State {
         case idle
-        case readingOutputThread(stdout: Thread, stderr: Thread?)
         case readingOutputPipe(sync: DispatchGroup)
         case outputReady(stdout: Result<[UInt8], Swift.Error>, stderr: Result<[UInt8], Swift.Error>)
         case complete(ProcessResult)
+        case failed(Swift.Error)
     }
 
     /// Typealias for process id type.
@@ -230,6 +230,7 @@ public final class Process {
     // process execution mutable state
     private var state: State = .idle
     private let stateLock = Lock()
+    private static let stateQueue = DispatchQueue(label: "ProcessStateQueue")
 
     /// The result of the process execution. Available after process is terminated.
     /// This will block while the process is awaiting result
@@ -456,7 +457,7 @@ public final class Process {
             self.state = .readingOutputPipe(sync: sync)
         }
 
-        group.notify(queue: .global()) {
+        group.notify(queue: Self.stateQueue) {
             self.stateLock.withLock {
                 self.state = .outputReady(stdout: .success(stdout), stderr: .success(stderr))
             }
@@ -596,6 +597,7 @@ public final class Process {
         // Close the local read end of the input pipe.
         try close(fd: stdinPipe[0])
 
+        let group = DispatchGroup()
         if !outputRedirection.redirectsOutput {
             // no stdout or stderr in this case
             self.stateLock.withLock {
@@ -609,8 +611,9 @@ public final class Process {
 
             // Close the local write end of the output pipe.
             try close(fd: outputPipe[1])
-
+            
             // Create a thread and start reading the output on it.
+            group.enter()
             let stdoutThread = Thread { [weak self] in
                 if let readResult = self?.readOutput(onFD: outputPipe[0], outputClosure: outputClosures?.stdoutClosure) {
                     pendingLock.withLock {
@@ -622,11 +625,13 @@ public final class Process {
                             pending = readResult
                         }
                     }
-                } else if let stderrResult = (pendingLock.withLock { pending }) {
+                    group.leave()
+               } else if let stderrResult = (pendingLock.withLock { pending }) {
                     // TODO: this is more of an error
                     self?.stateLock.withLock {
                         self?.state = .outputReady(stdout: .success([]), stderr: stderrResult)
                     }
+                    group.leave()
                 }
             }
 
@@ -637,6 +642,7 @@ public final class Process {
                 try close(fd: stderrPipe[1])
 
                 // Create a thread and start reading the stderr output on it.
+                group.enter()
                 stderrThread = Thread { [weak self] in
                     if let readResult = self?.readOutput(onFD: stderrPipe[0], outputClosure: outputClosures?.stderrClosure) {
                         pendingLock.withLock {
@@ -648,11 +654,13 @@ public final class Process {
                                 pending = readResult
                             }
                         }
+                        group.leave()
                     } else if let stdoutResult = (pendingLock.withLock { pending }) {
                         // TODO: this is more of an error
                         self?.stateLock.withLock {
                             self?.state = .outputReady(stdout: stdoutResult, stderr: .success([]))
                         }
+                        group.leave()
                     }
                 }
             } else {
@@ -660,10 +668,12 @@ public final class Process {
                     pending = .success([])  // no stderr in this case
                 }
             }
+            
             // first set state then start reading threads
             self.stateLock.withLock {
-                self.state = .readingOutputThread(stdout: stdoutThread, stderr: stderrThread)
+                self.state = .readingOutputPipe(sync: group)
             }
+            
             stdoutThread.start()
             stderrThread?.start()
         }
@@ -677,6 +687,24 @@ public final class Process {
     /// Blocks the calling process until the subprocess finishes execution.
     @discardableResult
     public func waitUntilExit() throws -> ProcessResult {
+        let group = DispatchGroup()
+        group.enter()
+        var processResult : ProcessResult?
+        var processError : Swift.Error?
+        self.waitUntilExit() { result, error in
+            processResult = result
+            processError = error
+            group.leave()
+        }
+        group.wait()
+        if let error = processError {
+            throw error
+        }
+        return processResult.unsafelyUnwrapped
+    }
+
+    /// Executes the process I/O state machine, calling completion block when finished.
+    private func waitUntilExit(_ completion: @escaping (ProcessResult?, Swift.Error?) -> Void) {
         self.stateLock.lock()
         switch self.state {
         case .idle:
@@ -684,17 +712,15 @@ public final class Process {
             preconditionFailure("The process is not yet launched.")
         case .complete(let result):
             defer { self.stateLock.unlock() }
-            return result
-        case .readingOutputThread(let stdoutThread, let stderrThread):
-            self.stateLock.unlock() // unlock early since output read thread need to change state
-            // If we're reading output, make sure that is finished.
-            stdoutThread.join()
-            stderrThread?.join()
-            return try self.waitUntilExit()
+            completion(result, nil)
+        case .failed(let error):
+            defer { self.stateLock.unlock() }
+            completion(nil, error)
         case .readingOutputPipe(let sync):
-            self.stateLock.unlock() // unlock early since output read thread need to change state
-            sync.wait()
-            return try self.waitUntilExit()
+            defer { self.stateLock.unlock() }
+            sync.notify(queue: Self.stateQueue) {
+                self.waitUntilExit(completion)
+            }
         case .outputReady(let stdoutResult, let stderrResult):
             defer { self.stateLock.unlock() }
             // Wait until process finishes execution.
@@ -710,7 +736,7 @@ public final class Process {
                 result = waitpid(processID, &exitStatusCode, 0)
             }
             if result == -1 {
-                throw SystemError.waitpid(errno)
+                self.state = .failed(SystemError.waitpid(errno))
             }
           #endif
 
@@ -723,7 +749,9 @@ public final class Process {
                 stderrOutput: stderrResult
             )
             self.state = .complete(executionResult)
-            return executionResult
+            Self.stateQueue.async {
+                self.waitUntilExit(completion)
+            }
         }
     }
 
@@ -790,6 +818,20 @@ public final class Process {
 }
 
 extension Process {
+    /// Execute a subprocess and calls completion block when it finishes execution
+    ///
+    /// - Parameters:
+    ///   - arguments: The arguments for the subprocess.
+    ///   - environment: The environment to pass to subprocess. By default the current process environment
+    ///     will be inherited.
+    /// - Returns: The process result.
+    static public func popen(arguments: [String], environment: [String: String] = ProcessEnv.vars,
+                             completion: @escaping (ProcessResult?, Swift.Error?) -> Void) throws {
+        let process = Process(arguments: arguments, environment: environment, outputRedirection: .collect)
+        try process.launch()
+        process.waitUntilExit(completion)
+    }
+
     /// Execute a subprocess and block until it finishes execution
     ///
     /// - Parameters:

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -826,10 +826,14 @@ extension Process {
     ///     will be inherited.
     /// - Returns: The process result.
     static public func popen(arguments: [String], environment: [String: String] = ProcessEnv.vars,
-                             completion: @escaping (Result<ProcessResult, Swift.Error>) -> Void) throws {
-        let process = Process(arguments: arguments, environment: environment, outputRedirection: .collect)
-        try process.launch()
-        process.waitUntilExit(completion)
+                             completion: @escaping (Result<ProcessResult, Swift.Error>) -> Void) {
+        do {
+            let process = Process(arguments: arguments, environment: environment, outputRedirection: .collect)
+            try process.launch()
+            process.waitUntilExit(completion)
+        } catch {
+            completion(.failure(error))
+        }
     }
 
     /// Execute a subprocess and block until it finishes execution

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -712,13 +712,13 @@ public final class Process {
             defer { self.stateLock.unlock() }
             preconditionFailure("The process is not yet launched.")
         case .complete(let result):
-            defer { self.stateLock.unlock() }
+            self.stateLock.unlock()
             completion(.success(result))
         case .failed(let error):
-            defer { self.stateLock.unlock() }
+            self.stateLock.unlock()
             completion(.failure(error))
         case .readingOutput(let sync):
-            defer { self.stateLock.unlock() }
+            self.stateLock.unlock()
             sync.notify(queue: Self.stateQueue) {
                 self.waitUntilExit(completion)
             }

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -42,8 +42,13 @@ class ProcessTests: XCTestCase {
     }
 
     func testPopen() throws {
+        #if os(Windows)
+        let echo = "echo.exe"
+        #else
+        let echo = "echo"
+        #endif
         // Test basic echo.
-        XCTAssertEqual(try Process.popen(arguments: ["echo", "hello"]).utf8Output(), "hello\n")
+        XCTAssertEqual(try Process.popen(arguments: [echo, "hello"]).utf8Output(), "hello\n")
 
         // Test buffer larger than that allocated.
         try withTemporaryFile { file in
@@ -51,7 +56,12 @@ class ProcessTests: XCTestCase {
             let stream = BufferedOutputByteStream()
             stream <<< Format.asRepeating(string: "a", count: count)
             try localFileSystem.writeFileContents(file.path, bytes: stream.bytes)
-            let outputCount = try Process.popen(args: "cat", file.path.pathString).utf8Output().count
+            #if os(Windows)
+            let cat = "cat.exe"
+            #else
+            let cat = "cat"
+            #endif
+            let outputCount = try Process.popen(args: cat, file.path.pathString).utf8Output().count
             XCTAssert(outputCount == count)
         }
     }
@@ -64,15 +74,15 @@ class ProcessTests: XCTestCase {
         let args = ["whoami"]
         let answer = NSUserName()
         #endif
-        var whereResult : Result<ProcessResult, Error>?
+        var popenResult: Result<ProcessResult, Error>?
         let group = DispatchGroup()
         group.enter()
         Process.popen(arguments: args) { result in
-            whereResult = result
+            popenResult = result
             group.leave()
         }
         group.wait()
-        switch whereResult {
+        switch popenResult {
         case .success(let processResult):
             let output = try processResult.utf8Output()
             XCTAssertTrue(output.hasPrefix(answer))

--- a/Tests/TSCBasicTests/TemporaryFileTests.swift
+++ b/Tests/TSCBasicTests/TemporaryFileTests.swift
@@ -143,11 +143,13 @@ class TemporaryFileTests: XCTestCase {
         // sequence of creating and destroying TemporaryFile objects. I don't
         // believe that this is guaranteed by POSIX, but it is true on all
         // platforms I know of.
+        #if !os(Windows)
         let initialFD = try Int(withTemporaryFile { return $0.fileHandle.fileDescriptor })
         for _ in 0..<10 {
             _ = try withTemporaryFile { return $0.fileHandle }
         }
         let endFD = try Int(withTemporaryFile { return $0.fileHandle.fileDescriptor })
         XCTAssertEqual(initialFD, endFD)
+        #endif
     }
 }


### PR DESCRIPTION
This provides a new version of the `popen()` convenience method:

```swift
static public func popen(arguments: [String], environment: [String: String] = ProcessEnv.vars,
                             completion: @escaping (Result<ProcessResult, Swift.Error>) -> Void)
```

This allows the caller to asynchronously receive a `ProcessResult` or `Swift.Error`. This was implemented to reduce the number of active threads necessary to execute multiple sub-processes simultaneously. A new unit test is provided that tests the API. In addition, enhancements were made to the `withTemporaryDirectory()` and `withTemporaryFile()` APIs to make them easier to use from asynchronous contexts:

```swift
public func withTemporaryFile<Result>(
  dir: AbsolutePath? = nil, prefix: String = "TemporaryFile", suffix: String = "", _ body: (TemporaryFile, @escaping (TemporaryFile) -> Void) throws -> Result
) throws -> Result

public func withTemporaryDirectory<Result>(
    dir: AbsolutePath? = nil, prefix: String = "TemporaryDirectory" , _ body: (AbsolutePath, @escaping (AbsolutePath) -> Void) throws -> Result
) throws -> Result
```

Both of these new functions pass the callback block a `@escaping` reference to a cleanup block, to allow the cleanup to be deferred until a later time. The old API uses a Bool argument to disable cleanup, and makes it the caller's responsibility to delete the temporary resources. The cleanup block reduces code duplication.