### PR TITLE
TSCBasic: remove `close` overload in extension

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -1016,9 +1016,5 @@ extension FileHandle: WritableByteStream {
     public func flush() {
         synchronizeFile()
     }
-
-    public func close() throws {
-        closeFile()
-    }
 }
 #endif


### PR DESCRIPTION
The `FileHandle` extension added an overloaded `close` that causes
ambiguity when using `close` on a `FileHandle`.  This manifested as a
build failure with apple/swift-package-manager#3888.  Remove the
function as swift-driver, swift-package-manager, and sourcekit-lsp are
able to build without this function (relying on Foundation to provide
it).