### PR TITLE
Fix SPM exclude warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTTSC_MACOS_DE
     macOSPlatform = .macOS(.v10_10)
 }
 
-let CMakeFiles = ["cmake_install.cmake", "CMakeLists.txt", "CMakeFiles"]
+let CMakeFiles = ["CMakeLists.txt"]
 
 let package = Package(
     name: "swift-tools-support-core",


### PR DESCRIPTION
Will get the following warning when building swift-driver or the repo itself.

<img width="765" alt="Screen Shot 2021-12-04 at 00 37 07" src="https://user-images.githubusercontent.com/43724855/144641390-184d0ac4-58b2-4989-b883-f2599ebed45a.png">

Seems like "cmake_install.cmake" and "CMakeFiles" are generated after we building it with CMake. Since they are not in the git history, I think we should remove them to fix the warning.