### PR TITLE
build: disable in-tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ else()
 endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+set(CMAKE_DISABLE_IN_SOURCE_BUILD YES)
+
 option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 
 find_package(dispatch QUIET)


### PR DESCRIPTION
This ensures that one does not accidentally build t-s-c in tree, which
means that the source tree is always pristine and the build tree root is
different from the source tree.  The previous change to ignore CMake
artifacts would only be caused by an accidental in-tree build which
should be frowned upon and be treated as unsupported.