### PR TITLE
TSCBasic: Make Process.waitUntilExit(_ completion:) public

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -701,7 +701,7 @@ public final class Process {
     }
 
     /// Executes the process I/O state machine, calling completion block when finished.
-    private func waitUntilExit(_ completion: @escaping (Result<ProcessResult, Swift.Error>) -> Void) {
+    public func waitUntilExit(_ completion: @escaping (Result<ProcessResult, Swift.Error>) -> Void) {
         self.stateLock.lock()
         switch self.state {
         case .idle:


### PR DESCRIPTION
The `Process` exposes a blocking `waitUntilExit()` which is implemented in terms of a non-blocking, private `waitUntilExit(_ completion:)`.

I'd like to be able to make a non-blocking wait from an asynchronous context in Swift >= 5.5.

I think providing an async-await API for `TSCBasic.Process` would be great, but in the meantime I'd like to be able to add the following extension in a dependent project:

```swift
#if swift(>=5.5)
@available(macOS 12.0, *)
extension TSCBasic.Process {
    @discardableResult
    public func awaitUntilExit() async throws -> ProcessResult {
        try await withCheckedThrowingContinuation { self.waitUntilExit($0.resume) }
    }
}
#endif
```

FWICT, `TSCBasic.waitUntilExit(_ completion:)` has locks in place so could be made public to support this effort. This PR does that.