### PR TITLE
update swift-system dependency to upToNextMinor instead of upToNextMajor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -106,7 +106,7 @@ let package = Package(
 
  if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
      package.dependencies += [
-         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.0.0")),
+         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.1.1")),
      ]
  } else {
      package.dependencies += [

--- a/Package.swift
+++ b/Package.swift
@@ -106,7 +106,7 @@ let package = Package(
 
  if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
      package.dependencies += [
-         .package(url: "https://github.com/apple/swift-system.git", from: "1.0.0"),
+         .package(url: "https://github.com/apple/swift-system.git", .upToNextMinor(from: "1.0.0")),
      ]
  } else {
      package.dependencies += [


### PR DESCRIPTION
motivation: align with SwiftPM and reduce risk

changes: 
* update swift-system dependency to upToNextMinor instead of upToNextMajor
* update min version of swift-system to 1.1.1
