### PR TITLE
FileLock encounters a runtime error when the path of the locked file is long

### DIFF
--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -178,12 +178,21 @@ public final class FileLock {
             throw FileSystemError(.notDirectory, lockFilesDirectory)
         }
         // use the parent path to generate unique filename in temp
-        var lockFileName = (resolveSymlinks(fileToLock.parentDirectory).appending(component: fileToLock.basename)).components.joined(separator: "_")
+        var lockFileName = (resolveSymlinks(fileToLock.parentDirectory).appending(component: fileToLock.basename)).components.joined(separator: "_") + ".lock"
         if lockFileName.hasPrefix(AbsolutePath.root.pathString) {
             lockFileName = String(lockFileName.dropFirst(AbsolutePath.root.pathString.count))
         }
-        let lockFilePath = lockFilesDirectory.appending(component: lockFileName + ".lock")
-        
+        // back off until it occupies at most `NAME_MAX` UTF-8 bytes but without splitting scalars
+        // (we might split clusters but it's not worth the effort to keep them together as long as we get a valid file name)
+        var lockFileUTF8 = lockFileName.utf8.suffix(Int(NAME_MAX))
+        while String(lockFileUTF8) == nil {
+            // in practice this will only be a few iterations
+            lockFileUTF8 = lockFileUTF8.dropFirst()
+        }
+        // we will never end up with nil since we have ASCII characters at the end
+        lockFileName = String(lockFileUTF8) ?? lockFileName
+        let lockFilePath = lockFilesDirectory.appending(component: lockFileName)
+
         let lock = FileLock(at: lockFilePath)
         return try lock.withLock(type: type, body)
     }

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -767,6 +767,12 @@ class FileSystemTests: XCTestCase {
             let lockFile = tempDir.appending(component: "lockfile")
 
             try _testFileSystemFileLock(fileSystem: localFileSystem, fileA: fileA, fileB: fileB, lockFile: lockFile)
+
+            // Test some long and edge case paths. We arrange to split between the C and the Cedilla if NAME_MAX is 255.
+            let longEdgeCase1 = tempDir.appending(component: String(repeating: "Façade!  ", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
+            try localFileSystem.withLock(on: longEdgeCase1, type: .exclusive, {})
+            let longEdgeCase2 = tempDir.appending(component: String(repeating: "🏁", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
+            try localFileSystem.withLock(on: longEdgeCase2, type: .exclusive, {})
         }
     }
 


### PR DESCRIPTION
FileLock constructs the name of the lock file based on the path of the file being locked.  When this path is very long, the name of the constructed lock file exceeds `NAME_MAX` (or more specifically the directory entry name length limit of the file system on which the directory that contains it resides, but `NAME_MAX` is a decent approximation on modern file systems commonly in use).

This change truncates it to `NAME_MAX` UTF-8 bytes (starting from the end), rounding down to avoid splitting Unicode scalars (but making no effort to avoid splitting clusters, since they don't affect the validity of the filename).  Another possible refinement would be to also include a hash of the elided part of the filename — in the interest of avoiding complexity this implementation doesn't do that, and it's not clear that it's needed given that 255 (the common value of `NAME_MAX`) usually results in a unique enough name in any practical circumstances.

rdar://87471360