### PR TITLE
[5.6] FileLock encounters a runtime error when the path of the locked file is long (#277)

### DIFF
--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -178,12 +178,21 @@ public final class FileLock {
             throw FileSystemError(.notDirectory, lockFilesDirectory)
         }
         // use the parent path to generate unique filename in temp
-        var lockFileName = (resolveSymlinks(fileToLock.parentDirectory).appending(component: fileToLock.basename)).components.joined(separator: "_")
+        var lockFileName = (resolveSymlinks(fileToLock.parentDirectory).appending(component: fileToLock.basename)).components.joined(separator: "_") + ".lock"
         if lockFileName.hasPrefix(AbsolutePath.root.pathString) {
             lockFileName = String(lockFileName.dropFirst(AbsolutePath.root.pathString.count))
         }
-        let lockFilePath = lockFilesDirectory.appending(component: lockFileName + ".lock")
-        
+        // back off until it occupies at most `NAME_MAX` UTF-8 bytes but without splitting scalars
+        // (we might split clusters but it's not worth the effort to keep them together as long as we get a valid file name)
+        var lockFileUTF8 = lockFileName.utf8.suffix(Int(NAME_MAX))
+        while String(lockFileUTF8) == nil {
+            // in practice this will only be a few iterations
+            lockFileUTF8 = lockFileUTF8.dropFirst()
+        }
+        // we will never end up with nil since we have ASCII characters at the end
+        lockFileName = String(lockFileUTF8) ?? lockFileName
+        let lockFilePath = lockFilesDirectory.appending(component: lockFileName)
+
         let lock = FileLock(at: lockFilePath)
         return try lock.withLock(type: type, body)
     }

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -768,10 +768,10 @@ class FileSystemTests: XCTestCase {
 
             try _testFileSystemFileLock(fileSystem: localFileSystem, fileA: fileA, fileB: fileB, lockFile: lockFile)
 
-            // Test some long and edge case paths. We arrange to split between the C and the Cedilla if NAME_MAX is 255.
-            let longEdgeCase1 = tempDir.appending(component: String(repeating: "Façade!  ", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
+            // Test some long and edge case paths. We arrange to split between the C and the Cedilla by repeating 255 times.
+            let longEdgeCase1 = tempDir.appending(component: String(repeating: "Façade!  ", count: 255).decomposedStringWithCanonicalMapping)
             try localFileSystem.withLock(on: longEdgeCase1, type: .exclusive, {})
-            let longEdgeCase2 = tempDir.appending(component: String(repeating: "🏁", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
+            let longEdgeCase2 = tempDir.appending(component: String(repeating: "🏁", count: 255).decomposedStringWithCanonicalMapping)
             try localFileSystem.withLock(on: longEdgeCase2, type: .exclusive, {})
         }
     }

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -767,6 +767,12 @@ class FileSystemTests: XCTestCase {
             let lockFile = tempDir.appending(component: "lockfile")
 
             try _testFileSystemFileLock(fileSystem: localFileSystem, fileA: fileA, fileB: fileB, lockFile: lockFile)
+
+            // Test some long and edge case paths. We arrange to split between the C and the Cedilla if NAME_MAX is 255.
+            let longEdgeCase1 = tempDir.appending(component: String(repeating: "Façade!  ", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
+            try localFileSystem.withLock(on: longEdgeCase1, type: .exclusive, {})
+            let longEdgeCase2 = tempDir.appending(component: String(repeating: "🏁", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
+            try localFileSystem.withLock(on: longEdgeCase2, type: .exclusive, {})
         }
     }
 


### PR DESCRIPTION
This is cherry-picked from #277. 

**Explanation:**  FileLock constructs the name of the lock file based on the path of the file being locked.  When this path is very long, the name of the constructed lock file exceeds `NAME_MAX` (or more specifically the directory entry name length limit of the file system on which the directory that contains it resides, but `NAME_MAX` is a decent approximation on modern file systems commonly in use).

**Scope of Issue:**  This can affect any use of the file locking where the locked file is at a long path (i.e. deeply nested and/or with long path components).  This issue was seen in SwiftPM.

**Reason for Nominating to 5.6:**  This causes unit test failures in SwiftPM and can cause runtime failures in actual use (typically not crashes but errors such as build errors and other kinds of failures).  Although this can be worked around by moving the packages to a shallower path, it's not at all obvious that this is the problem nor is it always possibly to affect the paths of for example CI systems.

**Risk:**  Low — the problem is understood and the fix is straightforward.  The main issue would be if there is something special about Unicode content of paths that hasn't been accounted for.  Any failure to fix the problem should be evident from continued failure of unit tests such as in SwiftPM and its client IDEs.

**Reviewed By:**  @tomerd, @neonichu 

**Automated Testing:**  An updated unit test checks for this condition.

**Dependencies:**  None

**Impact on CI:**  None

**How to Verify:**  Create a package that uses this API and try to lock a path whose total length in UTF-8 bytes is greater than the value of `NAME_MAX` (this is also what the unit test does).

rdar://87471360