### PR TITLE
Revert "FileLock encounters a runtime error when the path of the locked file is long"

### DIFF
--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -178,21 +178,12 @@ public final class FileLock {
             throw FileSystemError(.notDirectory, lockFilesDirectory)
         }
         // use the parent path to generate unique filename in temp
-        var lockFileName = (resolveSymlinks(fileToLock.parentDirectory).appending(component: fileToLock.basename)).components.joined(separator: "_") + ".lock"
+        var lockFileName = (resolveSymlinks(fileToLock.parentDirectory).appending(component: fileToLock.basename)).components.joined(separator: "_")
         if lockFileName.hasPrefix(AbsolutePath.root.pathString) {
             lockFileName = String(lockFileName.dropFirst(AbsolutePath.root.pathString.count))
         }
-        // back off until it occupies at most `NAME_MAX` UTF-8 bytes but without splitting scalars
-        // (we might split clusters but it's not worth the effort to keep them together as long as we get a valid file name)
-        var lockFileUTF8 = lockFileName.utf8.suffix(Int(NAME_MAX))
-        while String(lockFileUTF8) == nil {
-            // in practice this will only be a few iterations
-            lockFileUTF8 = lockFileUTF8.dropFirst()
-        }
-        // we will never end up with nil since we have ASCII characters at the end
-        lockFileName = String(lockFileUTF8) ?? lockFileName
-        let lockFilePath = lockFilesDirectory.appending(component: lockFileName)
-
+        let lockFilePath = lockFilesDirectory.appending(component: lockFileName + ".lock")
+        
         let lock = FileLock(at: lockFilePath)
         return try lock.withLock(type: type, body)
     }

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -767,12 +767,6 @@ class FileSystemTests: XCTestCase {
             let lockFile = tempDir.appending(component: "lockfile")
 
             try _testFileSystemFileLock(fileSystem: localFileSystem, fileA: fileA, fileB: fileB, lockFile: lockFile)
-
-            // Test some long and edge case paths. We arrange to split between the C and the Cedilla if NAME_MAX is 255.
-            let longEdgeCase1 = tempDir.appending(component: String(repeating: "Façade!  ", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
-            try localFileSystem.withLock(on: longEdgeCase1, type: .exclusive, {})
-            let longEdgeCase2 = tempDir.appending(component: String(repeating: "🏁", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
-            try localFileSystem.withLock(on: longEdgeCase2, type: .exclusive, {})
         }
     }
 


### PR DESCRIPTION
Reverts apple/swift-tools-support-core#277