### PR TITLE
TSCBasic: repair the Windows build after #277

### DIFF
--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -768,10 +768,10 @@ class FileSystemTests: XCTestCase {
 
             try _testFileSystemFileLock(fileSystem: localFileSystem, fileA: fileA, fileB: fileB, lockFile: lockFile)
 
-            // Test some long and edge case paths. We arrange to split between the C and the Cedilla if NAME_MAX is 255.
-            let longEdgeCase1 = tempDir.appending(component: String(repeating: "Façade!  ", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
+            // Test some long and edge case paths. We arrange to split between the C and the Cedilla by repeating 255 times.
+            let longEdgeCase1 = tempDir.appending(component: String(repeating: "Façade!  ", count: 255).decomposedStringWithCanonicalMapping)
             try localFileSystem.withLock(on: longEdgeCase1, type: .exclusive, {})
-            let longEdgeCase2 = tempDir.appending(component: String(repeating: "🏁", count: Int(NAME_MAX)).decomposedStringWithCanonicalMapping)
+            let longEdgeCase2 = tempDir.appending(component: String(repeating: "🏁", count: 255).decomposedStringWithCanonicalMapping)
             try localFileSystem.withLock(on: longEdgeCase2, type: .exclusive, {})
         }
     }


### PR DESCRIPTION
This fixes multiple issues with the file locking implementation on
Windows.  `AbsolutePath.root` is meaningless on Windows - there is
no concept of a singular root on Windows, instead you have have 26
individual roots - A-Z.  Stripping the count of characters for the
root path leaves us with an invalid path string as the root drives
have been stripped.  The next character is an invalid character on
most file systems, and so we must replace `:`.  Instead of using a
`MAX_NAME` to compute a length of the ARC, enforce a limit for the
complete path (though an ARC would be limited to 255 codepoints on
NTFS).  This incidentally also corrects the emitted path, previous
path computation left us with the file in PWD.