### PR TITLE
Fix build regression on iOS from #283

### DIFF
--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -162,8 +162,8 @@ public func exec(path: String, args: [String]) throws -> Never {
     guard execv(path, cArgs.cArray) != -1 else {
         throw SystemError.exec(errno, path: path, args: args)
     }
-    fatalError("unreachable")
   #endif
+    fatalError("unreachable")
 }
 
 @_disfavoredOverload


### PR DESCRIPTION
@compnerd Is this OK for Windows? Builds fine for macOS and iOS without warnings.