### PR TITLE
Fatal error in unimplemented cases of `exec`

### DIFF
--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -163,6 +163,8 @@ public func exec(path: String, args: [String]) throws -> Never {
         throw SystemError.exec(errno, path: path, args: args)
     }
     fatalError("unreachable")
+  #else
+    fatalError("not implemented")
   #endif
 }
 


### PR DESCRIPTION
The `exec` function was missing an `#else` branch which prohibited compilation on some platforms, this adds a fatal error on platforms where we have no implementation.