### PR TITLE
add isReadable and isWritable APIs to FileSystem

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -162,6 +162,12 @@ public protocol FileSystem: AnyObject {
     /// Check whether the given path is accessible and is a symbolic link.
     func isSymlink(_ path: AbsolutePath) -> Bool
 
+    /// Check whether the given path is accessible and readable.
+    func isReadable(_ path: AbsolutePath) -> Bool
+
+    /// Check whether the given path is accessible and writable.
+    func isWritable(_ path: AbsolutePath) -> Bool
+
     // FIXME: Actual file system interfaces will allow more efficient access to
     // more data than just the name here.
     //
@@ -319,6 +325,14 @@ private class LocalFileSystem: FileSystem {
     func isSymlink(_ path: AbsolutePath) -> Bool {
         let attrs = try? FileManager.default.attributesOfItem(atPath: path.pathString)
         return attrs?[.type] as? FileAttributeType == .typeSymbolicLink
+    }
+
+    func isReadable(_ path: AbsolutePath) -> Bool {
+        FileManager.default.isReadableFile(atPath: path.pathString)
+    }
+
+    func isWritable(_ path: AbsolutePath) -> Bool {
+        FileManager.default.isWritableFile(atPath: path.pathString)
     }
 
     func getFileInfo(_ path: AbsolutePath) throws -> FileInfo {
@@ -715,6 +729,14 @@ public class InMemoryFileSystem: FileSystem {
         }
     }
 
+    public func isReadable(_ path: AbsolutePath) -> Bool {
+        self.exists(path)
+    }
+
+    public func isWritable(_ path: AbsolutePath) -> Bool {
+        self.exists(path)
+    }
+
     public func isExecutableFile(_ path: AbsolutePath) -> Bool {
         // FIXME: Always return false until in-memory implementation
         // gets permission semantics.
@@ -1026,6 +1048,14 @@ public class RerootedFileSystemView: FileSystem {
 
     public func isSymlink(_ path: AbsolutePath) -> Bool {
         return underlyingFileSystem.isSymlink(formUnderlyingPath(path))
+    }
+
+    public func isReadable(_ path: AbsolutePath) -> Bool {
+        return underlyingFileSystem.isReadable(formUnderlyingPath(path))
+    }
+
+    public func isWritable(_ path: AbsolutePath) -> Bool {
+        return underlyingFileSystem.isWritable(formUnderlyingPath(path))
     }
 
     public func isExecutableFile(_ path: AbsolutePath) -> Bool {

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -183,6 +183,74 @@ class FileSystemTests: XCTestCase {
         }
     }
 
+    func testLocalReadableWritable() throws {
+        try testWithTemporaryDirectory { tmpdir in
+            let fs = localFileSystem
+
+            // directory
+
+            do {
+                let directory = tmpdir.appending(component: "directory")
+                try fs.createDirectory(directory, recursive: true)
+
+                // should be readable and writable by default
+                XCTAssertTrue(fs.isReadable(directory))
+                XCTAssertTrue(fs.isWritable(directory))
+
+                // set to non-readable non-writable.
+                _ = try Process.popen(args: "chmod", "-r-w", directory.pathString)
+                XCTAssertFalse(fs.isReadable(directory))
+                XCTAssertFalse(fs.isWritable(directory))
+
+                // set to readable non-writable.
+                _ = try Process.popen(args: "chmod", "+r-w", directory.pathString)
+                XCTAssertTrue(fs.isReadable(directory))
+                XCTAssertFalse(fs.isWritable(directory))
+
+                // set to non-readable writable.
+                _ = try Process.popen(args: "chmod", "-r+w", directory.pathString)
+                XCTAssertFalse(fs.isReadable(directory))
+                XCTAssertTrue(fs.isWritable(directory))
+
+                // set to readable and writable.
+                _ = try Process.popen(args: "chmod", "+r+w", directory.pathString)
+                XCTAssertTrue(fs.isReadable(directory))
+                XCTAssertTrue(fs.isWritable(directory))
+            }
+
+            // file
+
+            do {
+                let file = tmpdir.appending(component: "file")
+                try fs.writeFileContents(file, bytes: "")
+
+                // should be readable and writable by default
+                XCTAssertTrue(fs.isReadable(file))
+                XCTAssertTrue(fs.isWritable(file))
+
+                // set to non-readable non-writable.
+                _ = try Process.popen(args: "chmod", "-r-w", file.pathString)
+                XCTAssertFalse(fs.isReadable(file))
+                XCTAssertFalse(fs.isWritable(file))
+
+                // set to readable non-writable.
+                _ = try Process.popen(args: "chmod", "+r-w", file.pathString)
+                XCTAssertTrue(fs.isReadable(file))
+                XCTAssertFalse(fs.isWritable(file))
+
+                // set to non-readable writable.
+                _ = try Process.popen(args: "chmod", "-r+w", file.pathString)
+                XCTAssertFalse(fs.isReadable(file))
+                XCTAssertTrue(fs.isWritable(file))
+
+                // set to readable and writable.
+                _ = try Process.popen(args: "chmod", "+r+w", file.pathString)
+                XCTAssertTrue(fs.isReadable(file))
+                XCTAssertTrue(fs.isWritable(file))
+            }
+        }
+    }
+
     func testLocalCreateDirectory() throws {
         let fs = TSCBasic.localFileSystem
 


### PR DESCRIPTION
motivation: users often need to check if a path is readable and / or writable

changes:
* add isReadable and isWritable APIs to FileSystem
* implement in relevant FileSystem implementations
* add tests