### PR TITLE
TSCUtility: deprecate dl*

### DIFF
--- a/Sources/TSCUtility/dlopen.swift
+++ b/Sources/TSCUtility/dlopen.swift
@@ -12,6 +12,8 @@ import protocol Foundation.CustomNSError
 import var Foundation.NSLocalizedDescriptionKey
 import TSCLibc
 
+// FIXME: deprecate 2/2022, remove once clients transitioned
+@available(*, deprecated, message: "moved to swift-driver")
 public final class DLHandle {
   #if os(Windows)
     typealias Handle = HMODULE
@@ -48,6 +50,8 @@ public final class DLHandle {
     }
 }
 
+// FIXME: deprecate 2/2022, remove once clients transitioned
+@available(*, deprecated, message: "moved to swift-driver")
 public struct DLOpenFlags: RawRepresentable, OptionSet {
 
   #if !os(Windows)
@@ -77,6 +81,8 @@ public struct DLOpenFlags: RawRepresentable, OptionSet {
     }
 }
 
+// FIXME: deprecate 2/2022, remove once clients transitioned
+@available(*, deprecated, message: "moved to swift-driver")
 public enum DLError: Error {
     case `open`(String)
     case close(String)
@@ -88,6 +94,8 @@ extension DLError: CustomNSError {
     }
 }
 
+// FIXME: deprecate 2/2022, remove once clients transitioned
+@available(*, deprecated, message: "moved to swift-driver")
 public func dlopen(_ path: String?, mode: DLOpenFlags) throws -> DLHandle {
   #if os(Windows)
     guard let handle = path?.withCString(encodedAs: UTF16.self, LoadLibraryW) else {
@@ -101,6 +109,8 @@ public func dlopen(_ path: String?, mode: DLOpenFlags) throws -> DLHandle {
     return DLHandle(rawValue: handle)
 }
 
+// FIXME: deprecate 2/2022, remove once clients transitioned
+@available(*, deprecated, message: "moved to swift-driver")
 public func dlsym<T>(_ handle: DLHandle, symbol: String) -> T? {
   #if os(Windows)
     guard let ptr = GetProcAddress(handle.rawValue!, symbol) else {
@@ -114,11 +124,15 @@ public func dlsym<T>(_ handle: DLHandle, symbol: String) -> T? {
     return unsafeBitCast(ptr, to: T.self)
 }
 
+// FIXME: deprecate 2/2022, remove once clients transitioned
+@available(*, deprecated, message: "moved to swift-driver")
 public func dlclose(_ handle: DLHandle) throws {
     try handle.close()
 }
 
 #if !os(Windows)
+// FIXME: deprecate 2/2022, remove once clients transitioned
+@available(*, deprecated, message: "moved to swift-driver")
 public func dlerror() -> String? {
     if let err: UnsafeMutablePointer<Int8> = dlerror() {
         return String(cString: err)


### PR DESCRIPTION
Mark the dl* helper functions as deprecated.  There currently is a
singular user of these functions - swift-driver.  swift-driver is able
to host the functions for the proper handling of the shared library
loading/unloading and symbol lookup.