### PR TITLE
TSCBasic: deprecate `AbsolutePath.appending(_:)`

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -166,6 +166,7 @@ public struct AbsolutePath: Hashable {
     }
 
     /// Returns the absolute path with the relative path applied.
+    @available(*, deprecated, renamed: "AbsolutePath(_:relativeTo:)")
     public func appending(_ subpath: RelativePath) -> AbsolutePath {
         return AbsolutePath(self, subpath)
     }


### PR DESCRIPTION
This deprecates the `AbsolutePath.appending(_:)` overload for
constructing an `AbsolutePath` by appending a `RelativePath`.  Users
should prefer `AbsolutePath(_:relativeTo:)`.

Addresses feedback from apple/swift-package-manager#4237