### PR TITLE
Allow "macos" when parsing triples

### DIFF
--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -104,11 +104,10 @@ public struct Triple: Encodable, Equatable {
     }
 
     fileprivate static func parseOS(_ string: String) -> OS? {
-        for candidate in OS.allCases where string.hasPrefix(candidate.rawValue) {
-            return candidate
-        }
-
-        return nil
+        var candidates =  OS.allCases.map{ (name: $0.rawValue, value: $0) }
+        // LLVM target triples support this alternate spelling as well.
+        candidates.append((name: "macos", value: .macOS))
+        return candidates.first(where: { string.hasPrefix($0.name)  })?.value
     }
 
     fileprivate static func parseVersion(_ string: String) -> String? {

--- a/Tests/TSCUtilityTests/TripleTests.swift
+++ b/Tests/TSCUtilityTests/TripleTests.swift
@@ -24,6 +24,10 @@ class TripleTests : XCTestCase {
         let newVersion = "10.12"
         let tripleString = macos!.tripleString(forPlatformVersion: newVersion)
         XCTAssertEqual(tripleString, "x86_64-apple-macosx10.12")
+        let macosNoX = try? Triple("x86_64-apple-macos12.2")
+        XCTAssertNotNil(macosNoX!)
+        XCTAssertEqual(macosNoX!.os, .macOS)
+        XCTAssertEqual(macosNoX!.osVersion, "12.2")
 
         let android = try? Triple("aarch64-unknown-linux-android24")
         XCTAssertNotNil(android)


### PR DESCRIPTION
LLVM target triples support either "macosx" or "macos", so our parsing code should also support both spellings.