### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -1028,7 +1028,7 @@ public class RerootedFileSystemView: FileSystem {
             return root
         } else {
             // FIXME: Optimize?
-            return root.appending(RelativePath(String(path.pathString.dropFirst(1))))
+            return AbsolutePath(String(path.pathString.dropFirst(1)), relativeTo: root)
         }
     }
 

--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -930,7 +930,7 @@ extension AbsolutePath {
             result = RelativePath(relComps.joined(separator: "/"))
 #endif
         }
-        assert(base.appending(result) == self)
+        assert(AbsolutePath(base, result) == self)
         return result
     }
 

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -458,7 +458,7 @@ public final class Process {
         // The program might be a multi-component relative path.
         if let rel = try? RelativePath(validating: program), rel.components.count > 1 {
             if let cwd = cwdOpt {
-                let abs = cwd.appending(rel)
+                let abs = AbsolutePath(cwd, rel)
                 if localFileSystem.isExecutableFile(abs) {
                     return abs
                 }

--- a/Sources/TSCBasic/TemporaryFile.swift
+++ b/Sources/TSCBasic/TemporaryFile.swift
@@ -87,7 +87,7 @@ public struct TemporaryFile {
         // Determine in which directory to create the temporary file.
         self.dir = try determineTempDirectory(dir)
         // Construct path to the temporary file.
-        let path = self.dir.appending(RelativePath(prefix + ".XXXXXX" + suffix))
+        let path = AbsolutePath(prefix + ".XXXXXX" + suffix, relativeTo: self.dir)
 
         // Convert path to a C style string terminating with null char to be an valid input
         // to mkstemps method. The XXXXXX in this string will be replaced by a random string
@@ -236,7 +236,7 @@ public func withTemporaryDirectory<Result>(
     dir: AbsolutePath? = nil, prefix: String = "TemporaryDirectory" , _ body: (AbsolutePath, @escaping (AbsolutePath) -> Void) throws -> Result
 ) throws -> Result {
     // Construct path to the temporary directory.
-    let templatePath = try determineTempDirectory(dir).appending(RelativePath(prefix + ".XXXXXX"))
+    let templatePath = try AbsolutePath(prefix + ".XXXXXX", relativeTo: determineTempDirectory(dir))
 
     // Convert templatePath to a C style string terminating with null char to be an valid input
     // to mkdtemp method. The XXXXXX in this string will be replaced by a random string

--- a/Sources/TSCTestSupport/FileSystemExtensions.swift
+++ b/Sources/TSCTestSupport/FileSystemExtensions.swift
@@ -52,7 +52,7 @@ extension FileSystem {
         do {
             try createDirectory(root, recursive: true)
             for path in files {
-                let path = root.appending(RelativePath(String(path.dropFirst())))
+                let path = AbsolutePath(String(path.dropFirst()), relativeTo: root)
                 try createDirectory(path.parentDirectory, recursive: true)
                 try writeFileContents(path, bytes: "")
             }

--- a/Sources/TSCTestSupport/Product.swift
+++ b/Sources/TSCTestSupport/Product.swift
@@ -35,7 +35,7 @@ extension Product {
     public var path: AbsolutePath {
       #if canImport(Darwin)
         for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-            return AbsolutePath(bundle.bundlePath).parentDirectory.appending(self.exec)
+            return AbsolutePath(AbsolutePath(bundle.bundlePath).parentDirectory, self.exec)
         }
         fatalError()
       #else
@@ -116,7 +116,7 @@ extension Product {
         let packagesPath = packageRoot.appending(components: ".build", "checkouts")
         for name in try localFileSystem.getDirectoryContents(packagesPath) {
             if name.hasPrefix(packageName) {
-                return packagesPath.appending(RelativePath(name))
+                return AbsolutePath(name, relativeTo: packagesPath)
             }
         }
         throw SwiftPMProductError.packagePathNotFound

--- a/Sources/TSCUtility/dlopen.swift
+++ b/Sources/TSCUtility/dlopen.swift
@@ -88,6 +88,7 @@ public enum DLError: Error {
     case close(String)
 }
 
+@available(*, deprecated, message: "moved to swift-driver")
 extension DLError: CustomNSError {
     public var errorUserInfo: [String : Any] {
         return [NSLocalizedDescriptionKey: "\(self)"]

--- a/Tests/TSCBasicPerformanceTests/PathPerfTests.swift
+++ b/Tests/TSCBasicPerformanceTests/PathPerfTests.swift
@@ -16,6 +16,7 @@ import TSCTestSupport
 class PathPerfTests: XCTestCasePerf {
     
     /// Tests creating very long AbsolutePaths by joining path components.
+    @available(*, deprecated)
     func testJoinPerf_X100000() {
       #if canImport(Darwin)
         let absPath = AbsolutePath("/hello/little")

--- a/Tests/TSCBasicTests/PathTests.swift
+++ b/Tests/TSCBasicTests/PathTests.swift
@@ -205,6 +205,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b").parentDirectory.parentDirectory, AbsolutePath("/yabba"))
     }
 
+    @available(*, deprecated)
     func testConcatenation() {
         XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).pathString, "/")
         XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).pathString, "/")

--- a/Tests/TSCUtilityTests/ArchiverTests.swift
+++ b/Tests/TSCUtilityTests/ArchiverTests.swift
@@ -107,6 +107,7 @@ private struct DummyError: Error, Equatable {
 
 private typealias Extraction = (AbsolutePath, AbsolutePath, (Result<Void, Error>) -> Void) -> Void
 
+@available(*, deprecated)
 private struct MockArchiver: Archiver {
     let supportedExtensions: Set<String>
     private let extract: Extraction


### PR DESCRIPTION
This fixes almost all deprecation warnings in TSC, except for the ones in `IndexStoreAPIImpl`. That code is using `DLHandle` etc which was marked as "moved to swift-driver" when being deprecated, so not sure what the right solution here is.