### PR TITLE
add AbsolutePath initializer that take RelativePath

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -101,6 +101,11 @@ public struct AbsolutePath: Hashable {
         }
     }
 
+    /// Initializes an AbsolutePath from a relative path having `basePath` used as the anchor.
+    public init(_ relativePath: RelativePath, relativeTo: AbsolutePath) {
+        self.init(relativePath.pathString, relativeTo: relativeTo)
+    }
+
     /// Initializes the AbsolutePath by concatenating a relative path to an
     /// existing absolute path, and renormalizing if necessary.
     public init(_ absPath: AbsolutePath, _ relPath: RelativePath) {

--- a/Tests/TSCBasicTests/PathTests.swift
+++ b/Tests/TSCBasicTests/PathTests.swift
@@ -39,6 +39,12 @@ class PathTests: XCTestCase {
         XCTAssertEqual(abs5, AbsolutePath("/base/path/a/b/c"))
         let abs6 = AbsolutePath("~/bla", relativeTo: base)  // `~` isn't special
         XCTAssertEqual(abs6, AbsolutePath("/base/path/~/bla"))
+        let abs7 = AbsolutePath(RelativePath("a/b/c"), relativeTo: base)
+        XCTAssertEqual(abs7, AbsolutePath("/base/path/a/b/c"))
+        let abs8 = AbsolutePath(RelativePath("./a/b/c"), relativeTo: base)
+        XCTAssertEqual(abs8, AbsolutePath("/base/path/a/b/c"))
+        let abs9 = AbsolutePath(RelativePath("../a/b/c"), relativeTo: base)
+        XCTAssertEqual(abs9, AbsolutePath("/base/a/b/c"))
     }
 
     func testStringLiteralInitialization() {


### PR DESCRIPTION
motivation: with the deprecation of AbsolutePath::appending need a replacement API

changes:
* add AbsolutePath(:relativeTo) API vairant that takes RelativePath
* add tests