### PR TITLE
[5.6] [TSCUtility] Added Armv5 support

### DIFF
--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -45,6 +45,8 @@ public struct Triple: Encodable, Equatable {
         case aarch64
         case amd64
         case armv7
+        case armv6
+        case armv5
         case arm
         case arm64
         case arm64e


### PR DESCRIPTION
Backported https://github.com/apple/swift-tools-support-core/pull/296 for Swift 5.6 release.