### PR TITLE
Implement custom equatable for `Triple`

### DIFF
--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -197,6 +197,10 @@ public struct Triple: Encodable, Equatable {
             fatalError("Failed to parse triple string (\(error)).\nTriple string: \(tripleString)")
         }
     }
+
+    public static func ==(lhs: Triple, rhs: Triple) -> Bool {
+        return lhs.arch == rhs.arch && lhs.vendor == rhs.vendor && lhs.os == rhs.os && lhs.abi == rhs.abi && lhs.osVersion == rhs.osVersion && lhs.abiVersion == rhs.abiVersion
+    }
 }
 
 extension Triple {

--- a/Tests/TSCUtilityTests/TripleTests.swift
+++ b/Tests/TSCUtilityTests/TripleTests.swift
@@ -34,4 +34,13 @@ class TripleTests : XCTestCase {
         XCTAssertEqual(android!.os, .linux)
         XCTAssertEqual(android!.abiVersion, "24")
     }
+
+    func testEquality() throws {
+        let macOSTriple = try Triple("arm64-apple-macos")
+        let macOSXTriple = try Triple("arm64-apple-macosx")
+        XCTAssertEqual(macOSTriple, macOSXTriple)
+
+        let intelMacOSTriple = try Triple("x86_64-apple-macos")
+        XCTAssertNotEqual(macOSTriple, intelMacOSTriple)
+    }
 }


### PR DESCRIPTION
It seems like equality for triples should depend on the parsed version and exclude the initial string representation.

Eventually, we should probably get rid of storing the original string and compute that from the parsed version, but I am just trying to address equality for now.