### PR TITLE
TSCBasic: correct path componentization on Windows

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -544,7 +544,10 @@ private struct UNIXPath: Path {
     //
     var components: [String] {
 #if os(Windows)
-        return string.components(separatedBy: "\\").filter { !$0.isEmpty }
+        let normalized: UnsafePointer<Int8> = string.fileSystemRepresentation
+        defer { normalized.deallocate() }
+
+        return String(cString: normalized).components(separatedBy: "\\").filter { !$0.isEmpty }
 #else
         // FIXME: This isn't particularly efficient; needs optimization, and
         // in fact, it might well be best to return a custom iterator so we


### PR DESCRIPTION
When converting a path to components on Windows, we need to split on
both `/` and `\`.  Instead, prefer to normalize the path and split using
the Foundation extension which will already perform the necessary
operations properly and is well tested.