### PR TITLE
TSCTestSupport: support more complex file systems

### DIFF
--- a/Sources/TSCTestSupport/misc.swift
+++ b/Sources/TSCTestSupport/misc.swift
@@ -33,7 +33,8 @@ public func testWithTemporaryDirectory(
         .replacingOccurrences(of: "(", with: "")
         .replacingOccurrences(of: ")", with: "")
         .replacingOccurrences(of: ".", with: "")
-    try withTemporaryDirectory(prefix: "spm-tests-\(cleanedFunction)") { tmpDirPath in
+    try withTemporaryDirectory(dir: localFileSystem.currentWorkingDirectory,
+                               prefix: "spm-tests-\(cleanedFunction)") { tmpDirPath in
         defer {
             // Unblock and remove the tmp dir on deinit.
             try? localFileSystem.chmod(.userWritable, path: tmpDirPath, options: [.recursive])


### PR DESCRIPTION
File systems are not guaranteed to be uniformly accessible through a
singular view.  Always use the current working directory to determine
the of the temporary directory as the path may not be viable for
conversion to a relative path.  This is mandatory for resolving
assumptions in the swift-package-manager test suite.