### PR TITLE
TSCBasic: alter environment handling for Windows

### DIFF
--- a/Sources/TSCBasic/ProcessEnv.swift
+++ b/Sources/TSCBasic/ProcessEnv.swift
@@ -26,11 +26,7 @@ public enum ProcessEnv {
     /// Set the given key and value in the process's environment.
     public static func setVar(_ key: String, value: String) throws {
       #if os(Windows)
-        guard key.withCString(encodedAs: UTF16.self, { keyStr in
-            value.withCString(encodedAs: UTF16.self) { valStr in
-                SetEnvironmentVariableW(keyStr, valStr)
-            }
-        }) else {
+        guard TSCLibc._putenv("\(key)=\(value)") == 0 else {
             throw SystemError.setenv(Int32(GetLastError()), key)
         }
       #else
@@ -44,9 +40,7 @@ public enum ProcessEnv {
     /// Unset the give key in the process's environment.
     public static func unsetVar(_ key: String) throws {
       #if os(Windows)
-        guard key.withCString(encodedAs: UTF16.self, { keyStr in
-            SetEnvironmentVariableW(keyStr, nil)
-        }) else {
+        guard TSCLibc._putenv("\(key)=") == 0 else {
             throw SystemError.unsetenv(Int32(GetLastError()), key)
         }
       #else


### PR DESCRIPTION
Rather than using the unicode environment, which should be preferred,
use the ANSI environment operations.  This is important to do here as
the reading of the environment relies on Foundation, which in turn
relies on CoreFoundation for `_CFEnviron` which returns the ANSI
environment.  As a result, we need to ensure that we use the ANSI
environment variables through out as the C runtime will maintain the two
environments in parallel and may go out of sync.

This will enable additional tests in Swift Package Manager to pass on
Windows, but should really be addressed by changing Foundation to use
the Unicode environment variables and then using that once more here.