### PR TITLE
TSCTestSupport: `SDKROOT` is required for Windows

### DIFF
--- a/Sources/TSCTestSupport/Product.swift
+++ b/Sources/TSCTestSupport/Product.swift
@@ -96,7 +96,9 @@ extension Product {
         // FIXME: We use this private environment variable hack to be able to
         // create special conditions in swift-build for swiftpm tests.
         environment["SWIFTPM_TESTS_MODULECACHE"] = self.path.parentDirectory.pathString
+#if !os(Windows)
         environment["SDKROOT"] = nil
+#endif
 
         // Unset the internal env variable that allows skipping certain tests.
         environment["_SWIFTPM_SKIP_TESTS_LIST"] = nil


### PR DESCRIPTION
The `SDKROOT` environment variable is used to compute the default value
for the `-sdk` parameter to the swift compiler which is required to
locate the standard library.  Do not filter the environment variable on
Windows as that will prevent the SPM test suite from succeeding.