### PR TITLE
TSCTestSupport: avoid dropping path components

### DIFF
--- a/Sources/TSCTestSupport/FileSystemExtensions.swift
+++ b/Sources/TSCTestSupport/FileSystemExtensions.swift
@@ -52,7 +52,7 @@ extension FileSystem {
         do {
             try createDirectory(root, recursive: true)
             for path in files {
-                let path = AbsolutePath(String(path.dropFirst()), relativeTo: root)
+                let path = AbsolutePath(path, relativeTo: root)
                 try createDirectory(path.parentDirectory, recursive: true)
                 try writeFileContents(path, bytes: "")
             }


### PR DESCRIPTION
Given that the `AbsolutePath` constructor invoked here is
`AbsolutePath(_:relativeTo:)` dropping the first component is not
meaningful for UNIX paths as an absolute path relative to root is going
be the same path as the path relative to the root being re-formed to be
relative to the root.  However, this meaningfully impacts paths on
Windows as the shared path representation currently does not include the
drive or server & share (in the UNC case) and the resulting absolute
path representation is a drive-relative path, where dropping the first
component alters the path representation.