### PR TITLE
TSCBasic: special case a few leading character cases for Path

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -760,7 +760,9 @@ private struct UNIXPath: Path {
         defer { fsr.deallocate() }
 
         let realpath: String = String(cString: fsr)
-        if UNIXPath.isAbsolutePath(realpath) {
+        // Treat a relative path as an invalid relative path...
+        if UNIXPath.isAbsolutePath(realpath) ||
+                realpath.first == "~" || realpath.first == "\\" {
             throw PathValidationError.invalidRelativePath(path)
         }
         self.init(normalizingRelativePath: path)
@@ -895,7 +897,7 @@ extension PathValidationError: CustomStringConvertible {
         case .invalidAbsolutePath(let path):
             return "invalid absolute path '\(path)'"
         case .invalidRelativePath(let path):
-            return "invalid relative path '\(path)'; relative path should not begin with '/' or '~'"
+            return "invalid relative path '\(path)'; relative path should not begin with '\(AbsolutePath.root.pathString)' or '~'"
         }
     }
 }


### PR DESCRIPTION
The UNIX implementation special cases `/` and `~` which SPM depends on.
Handle the invalid file system character `~` specially on Windows as
well.  As we are now getting closer to normalized path spellings, we
need to add a special case for the leading path separator character.  On
UNIX, this signifies the root of the singular unified file system view.
However, Windows presents a forest to the user with 26 roots.
Consequently, a path headed by the path separator is a relative path
rather than an absolute path.  However, we treat the root-relative path
as an invalid relative path for the time being as the representation is
not flexible enough to account for this model.