### PR TITLE
[Linux] Define _GNU_SOURCE when building TSCclibc

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -125,4 +125,10 @@ let package = Package(
       .linkedLibrary("Pathcch", .when(platforms: [.windows])),
     ]
   }
+#elseif os(Linux)
+  if let TSCclibc = package.targets.first(where: { $0.name == "TSCclibc" }) {
+    TSCclibc.cSettings = [
+      .define("_GNU_SOURCE", .when(platforms: [.linux])),
+    ]
+  }
 #endif

--- a/Sources/TSCclibc/CMakeLists.txt
+++ b/Sources/TSCclibc/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(TSCclibc STATIC
   libc.c process.c)
 target_include_directories(TSCclibc PUBLIC
   include)
+target_compile_definitions(TSCclibc PRIVATE
+  "$<$<PLATFORM_ID:Linux>:_GNU_SOURCE>")
 
 if(NOT BUILD_SHARED_LIBS)
   install(TARGETS TSCclibc


### PR DESCRIPTION
Fixes missing declaration for `posix_spawn_file_actions_addchdir_np` on
Linux.