### PR TITLE
make lock lock&unlock methods public for process migration to spm

### DIFF
--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -19,11 +19,11 @@ public struct Lock {
     public init() {
     }
 
-    func lock() {
+    public func lock() {
         _lock.lock()
     }
 
-    func unlock() {
+    public func unlock() {
         _lock.unlock()
     }
 

--- a/Tests/TSCBasicTests/LockTests.swift
+++ b/Tests/TSCBasicTests/LockTests.swift
@@ -26,6 +26,18 @@ class LockTests: XCTestCase {
         }
         XCTAssertEqual(count, N)
     }
+    
+    func testLockUnlock() {
+        let lock = TSCBasic.Lock()
+        var count = 0
+        let N = 100
+        for _ in 0..<N {
+            lock.lock()
+            count += 1
+            lock.unlock()
+        }
+        XCTAssertEqual(count, N)
+    }
 
     func testFileLock() throws {
         // Shared resource file.


### PR DESCRIPTION
As mentioned in https://github.com/apple/swift-package-manager/pull/5532#issuecomment-1133212593 there is a need to migrate some bits of `Process` to spm and in order to do that the `Lock.lock` and `Lock.unlock` are needed to be public