### PR TITLE
Mark Lock as deprecated

### DIFF
--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -11,6 +11,7 @@
 import Foundation
 import TSCLibc
 
+@available(*, deprecated, message: "Use NSLock directly instead. SPM has a withLock extension function" )
 /// A simple lock wrapper.
 public struct Lock {
     private let _lock = NSLock()


### PR DESCRIPTION
As mentioned by https://github.com/apple/swift-tools-support-core/pull/327#issuecomment-1150395797 there is a desire to transform away from Lock wrapper and so to mark it as deprecated