### PR TITLE
address Lock deprecation warnings

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -609,11 +609,11 @@ public class InMemoryFileSystem: FileSystem {
     /// FIXME: Using a single lock for this is a performance problem, but in
     /// reality, the only practical use for InMemoryFileSystem is for unit
     /// tests.
-    private let lock = Lock()
+    private let lock = NSLock()
     /// A map that keeps weak references to all locked files.
     private var lockFiles = Dictionary<AbsolutePath, WeakReference<DispatchQueue>>()
     /// Used to access lockFiles in a thread safe manner.
-    private let lockFilesLock = Lock()
+    private let lockFilesLock = NSLock()
 
     /// Exclusive file system lock vended to clients through `withLock()`.
     // Used to ensure that DispatchQueues are releassed when they are no longer in use.

--- a/Sources/TSCBasic/LazyCache.swift
+++ b/Sources/TSCBasic/LazyCache.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+import class Foundation.NSLock
+
 // FIXME: This wrapper could benefit from local static variables, in which case
 // we could embed the cache object inside the accessor.
 //
@@ -32,7 +34,7 @@ public struct LazyCache<Class, T> {
     // FIXME: It would be nice to avoid a per-instance lock, but this type isn't
     // intended for creating large numbers of instances of. We also really want
     // a reader-writer lock or something similar here.
-    private var lock = Lock()
+    private var lock = NSLock()
     let body: (Class) -> () -> T
     var cachedValue: T?
 

--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -36,6 +36,15 @@ public struct Lock {
     }
 }
 
+// for internal usage
+extension NSLock {
+    internal func withLock<T> (_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer { self.unlock() }
+        return try body()
+    }
+}
+
 enum ProcessLockError: Error {
     case unableToAquireLock(errno: Int32)
 }

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -8,9 +8,10 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import class Foundation.ProcessInfo
 import protocol Foundation.CustomNSError
 import var Foundation.NSLocalizedDescriptionKey
+import class Foundation.NSLock
+import class Foundation.ProcessInfo
 
 #if os(Windows)
 import Foundation
@@ -208,7 +209,7 @@ public final class Process {
     public typealias LoggingHandler = (String) -> Void
 
     private static var _loggingHandler: LoggingHandler?
-    private static let loggingHandlerLock = Lock()
+    private static let loggingHandlerLock = NSLock()
 
     /// Global logging handler. Use with care! preferably use instance level instead of setting one globally.
     public static var loggingHandler: LoggingHandler? {
@@ -237,7 +238,7 @@ public final class Process {
 
     // the log and setter are only required to backward support verbose setter.
     // remove and make loggingHandler a let property once verbose is deprecated
-    private let loggingHandlerLock = Lock()
+    private let loggingHandlerLock = NSLock()
     public private(set) var loggingHandler: LoggingHandler? {
         get {
             self.loggingHandlerLock.withLock {
@@ -290,7 +291,7 @@ public final class Process {
 
     // process execution mutable state
     private var state: State = .idle
-    private let stateLock = Lock()
+    private let stateLock = NSLock()
 
     private static let sharedCompletionQueue = DispatchQueue(label: "org.swift.tools-support-core.process-completion")
     private var completionQueue = Process.sharedCompletionQueue
@@ -311,7 +312,7 @@ public final class Process {
 
     // ideally we would use the state for this, but we need to access it while the waitForExit is locking state
     private var _launched = false
-    private let launchedLock = Lock()
+    private let launchedLock = NSLock()
 
     public var launched: Bool {
         return self.launchedLock.withLock {
@@ -330,7 +331,7 @@ public final class Process {
     /// Key: Executable name or path.
     /// Value: Path to the executable, if found.
     private static var validatedExecutablesMap = [String: AbsolutePath?]()
-    private static let validatedExecutablesMapLock = Lock()
+    private static let validatedExecutablesMapLock = NSLock()
 
     /// Create a new process instance.
     ///
@@ -727,7 +728,7 @@ public final class Process {
             }
         } else {
             var pending: Result<[UInt8], Swift.Error>?
-            let pendingLock = Lock()
+            let pendingLock = NSLock()
 
             let outputClosures = outputRedirection.outputClosures
 

--- a/Sources/TSCUtility/Platform.swift
+++ b/Sources/TSCUtility/Platform.swift
@@ -28,7 +28,7 @@ public enum Platform: Equatable {
     public static var currentPlatform = Platform.findCurrentPlatform(localFileSystem)
 
     /// Returns the cache directories used in Darwin.
-    private static var darwinCacheDirectoriesLock = Lock()
+    private static var darwinCacheDirectoriesLock = NSLock()
     private static var _darwinCacheDirectories: [AbsolutePath]? = .none
 
     /// Attempt to match `uname` with recognized platforms.

--- a/Sources/TSCUtility/misc.swift
+++ b/Sources/TSCUtility/misc.swift
@@ -42,3 +42,12 @@ public func measure<T>(_ label: String = "", _ f: () throws -> (T)) rethrows -> 
     print("\(label): Time taken", endTime)
     return result
 }
+
+// for internal usage
+extension NSLock {
+    internal func withLock<T> (_ body: () throws -> T) rethrows -> T {
+        self.lock()
+        defer { self.unlock() }
+        return try body()
+    }
+}

--- a/Tests/TSCBasicTests/LockTests.swift
+++ b/Tests/TSCBasicTests/LockTests.swift
@@ -14,6 +14,7 @@ import TSCBasic
 import TSCTestSupport
 
 class LockTests: XCTestCase {
+    @available(*, deprecated)
     func testBasics() {
         // FIXME: Make this a more interesting test once we have concurrency primitives.
         let lock = TSCBasic.Lock()

--- a/Tests/TSCBasicTests/SynchronizedQueueTests.swift
+++ b/Tests/TSCBasicTests/SynchronizedQueueTests.swift
@@ -8,9 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+@testable import TSCBasic
 import XCTest
-
-import TSCBasic
 
 class SyncronizedQueueTests: XCTestCase {
     func testSingleProducerConsumer() {
@@ -46,7 +45,7 @@ class SyncronizedQueueTests: XCTestCase {
         let queueElementsTwo = Set(100..<500)
 
         var consumed = Set<Int>()
-        let consumedLock = TSCBasic.Lock()
+        let consumedLock = NSLock()
 
         // Create two producers.
         let producers = [queueElementsOne, queueElementsTwo].map { queueElements in


### PR DESCRIPTION
motivation: we recently deprecated TSCBasic::Lock

changes:
* use NSLock instead of TSCBasic::Lock
* add internal extension as necessary for a locked block