### PR TITLE
un-deprecate AbsolutePath::appending(RelativePath)

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -169,7 +169,6 @@ public struct AbsolutePath: Hashable {
     }
 
     /// Returns the absolute path with the relative path applied.
-    @available(*, deprecated, renamed: "AbsolutePath(_:relativeTo:)")
     public func appending(_ subpath: RelativePath) -> AbsolutePath {
         return AbsolutePath(self, subpath)
     }


### PR DESCRIPTION
motivation: concatinating rlative path to absolute path is a key API we should preserve it, but improve the implementation

chnages: remove deprecation marker from AbsolutePath::appending(RelativePath)

work to improve the implementation is tracked in https://github.com/apple/swift-tools-support-core/issues/336