### PR TITLE
[5.7] un-deprecate AbsolutePath::appending(RelativePath)

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -166,7 +166,6 @@ public struct AbsolutePath: Hashable {
     }
 
     /// Returns the absolute path with the relative path applied.
-    @available(*, deprecated, renamed: "AbsolutePath(_:relativeTo:)")
     public func appending(_ subpath: RelativePath) -> AbsolutePath {
         return AbsolutePath(self, subpath)
     }


### PR DESCRIPTION
5.7 cherry pick of #341