### PR TITLE
Clarify when we're creating a TSC Thread and not a Foundation Thread

### DIFF
--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -823,7 +823,7 @@ public final class FSEventStream {
 
     // Start the runloop.
     public func start() throws {
-        let thread = Thread { [weak self] in
+        let thread = TSCBasic.Thread { [weak self] in
             guard let `self` = self else { return }
             self.runLoop = CFRunLoopGetCurrent()
             // Schedule the run loop.


### PR DESCRIPTION
Fixes an ambiguity that crops up with Sendable adoption (rdar://97223378).