### PR TITLE
🍒 [5.7] Specified WASI dynamic library extension

### DIFF
--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -224,7 +224,7 @@ extension Triple {
         case .windows:
             return ".dll"
         case .wasi:
-            fatalError("WebAssembly/WASI doesn't support dynamic library yet")
+            return ".wasm"
         }
     }
 

--- a/Tests/TSCUtilityTests/TripleTests.swift
+++ b/Tests/TSCUtilityTests/TripleTests.swift
@@ -43,4 +43,12 @@ class TripleTests : XCTestCase {
         let intelMacOSTriple = try Triple("x86_64-apple-macos")
         XCTAssertNotEqual(macOSTriple, intelMacOSTriple)
     }
+
+    func testWASI() throws {
+        let wasi = try Triple("wasm32-unknown-wasi")
+
+        // WASI dynamic libraries are only experimental,
+        // but SwiftPM requires this property not to crash.
+        _ = wasi.dynamicLibraryExtension
+    }
 }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift-tools-support-core/pull/311 to 5.7 release branch because it blocks the use of various libraries and plugins. (e.g. Adding swift-format for command plugin hits the fatalError)