### PR TITLE
TSCUtility: deprecate SQLite, PersistenceCache

### DIFF
--- a/Sources/TSCUtility/PersistenceCache.swift
+++ b/Sources/TSCUtility/PersistenceCache.swift
@@ -12,6 +12,7 @@ import TSCBasic
 import Foundation
 
 /// A protocol for Data -> Data cache.
+@available(*, deprecated, message: "Unused")
 public protocol PersistentCacheProtocol {
     func get(key: Data) throws -> Data?
     func put(key: Data, value: Data) throws
@@ -19,6 +20,7 @@ public protocol PersistentCacheProtocol {
 }
 
 /// SQLite backed persistent cache.
+@available(*, deprecated, message: "Unused")
 public final class SQLiteBackedPersistentCache: PersistentCacheProtocol, Closable {
     let db: SQLite
 

--- a/Sources/TSCUtility/SQLite.swift
+++ b/Sources/TSCUtility/SQLite.swift
@@ -14,6 +14,7 @@ import TSCBasic
 @_implementationOnly import CSQLite3
 
 /// A minimal SQLite wrapper.
+@available(*, deprecated, message: "moved to SwiftPM")
 public struct SQLite {
     /// The location of the database.
     public let location: Location
@@ -291,6 +292,7 @@ public struct SQLite {
     }
 }
 
+@available(*, deprecated, message: "Moved to SwiftPM")
 private func sqlite_callback(
     _ ctx: UnsafeMutableRawPointer?,
     _ numColumns: Int32,


### PR DESCRIPTION
The single use of `SQLite` was SwiftPM which now homes the interface. Mark the two interfaces as being deprecated now as the consumer has taken ownership.  This progresses towards hollowing out tools-support-core.