### PR TITLE
Revert "TSCUtility: deprecate Bitstream interfaces"

### DIFF
--- a/Sources/TSCUtility/Bits.swift
+++ b/Sources/TSCUtility/Bits.swift
@@ -11,7 +11,6 @@
 import Foundation
 import TSCBasic
 
-@available(*, deprecated, message: "moved to swift-driver")
 struct Bits: RandomAccessCollection {
   var buffer: ByteString
 

--- a/Sources/TSCUtility/Bitstream.swift
+++ b/Sources/TSCUtility/Bitstream.swift
@@ -12,7 +12,6 @@ import Foundation
 
 /// Represents the contents of a file encoded using the
 /// [LLVM bitstream container format](https://llvm.org/docs/BitCodeFormat.html#bitstream-container-format)
-@available(*, deprecated, message: "moved to swift-driver")
 public struct Bitcode {
   public let signature: Signature
   public let elements: [BitcodeElement]
@@ -20,7 +19,6 @@ public struct Bitcode {
 }
 
 /// A non-owning view of a bitcode element.
-@available(*, deprecated, message: "moved to swift-driver")
 public enum BitcodeElement {
   public struct Block {
     public var id: UInt64
@@ -49,7 +47,6 @@ public enum BitcodeElement {
   case record(Record)
 }
 
-@available(*, deprecated, message: "moved to swift-driver")
 extension BitcodeElement.Record.Payload: CustomStringConvertible {
   public var description: String {
     switch self {
@@ -65,14 +62,12 @@ extension BitcodeElement.Record.Payload: CustomStringConvertible {
   }
 }
 
-@available(*, deprecated, message: "moved to swift-driver")
 public struct BlockInfo {
   public var name: String = ""
   public var recordNames: [UInt64: String] = [:]
 }
 
 extension Bitcode {
-  @available(*, deprecated, message: "moved to swift-driver")
   public struct Signature: Equatable {
     private var value: UInt32
 
@@ -93,7 +88,6 @@ extension Bitcode {
 }
 
 /// A visitor which receives callbacks while reading a bitstream.
-@available(*, deprecated, message: "moved to swift-driver")
 public protocol BitstreamVisitor {
   /// Customization point to validate a bitstream's signature or "magic number".
   func validate(signature: Bitcode.Signature) throws
@@ -107,14 +101,12 @@ public protocol BitstreamVisitor {
 }
 
 /// A top-level namespace for all bitstream-related structures.
-@available(*, deprecated, message: "moved to swift-driver")
 public enum Bitstream {}
 
 extension Bitstream {
   /// An `Abbreviation` represents the encoding definition for a user-defined
   /// record. An `Abbreviation` is the primary form of compression available in
   /// a bitstream file.
-  @available(*, deprecated, message: "moved to swift-driver")
   public struct Abbreviation {
     public enum Operand {
       /// A literal value (emitted as a VBR8 field).
@@ -182,7 +174,6 @@ extension Bitstream {
     /// a name is given to a block or record with `blockName` or
     /// `setRecordName`, debugging tools like `llvm-bcanalyzer` can be used to
     /// introspect the structure of blocks and records in the bitstream file.
-    @available(*, deprecated, message: "moved to swift-driver")
     public enum BlockInfoCode: UInt8 {
         /// Indicates which block ID is being described.
         case setBID = 1
@@ -212,7 +203,6 @@ extension Bitstream {
   ///     static let diagnostics  = Self.firstApplicationID + 1
   /// }
   /// ```
-  @available(*, deprecated, message: "moved to swift-driver")
   public struct BlockID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
     public var rawValue: UInt8
 
@@ -250,7 +240,6 @@ extension Bitstream {
   ///            abbreviation defined by `BitstreamWriter`. Always use
   ///            `BitstreamWriter.defineBlockInfoAbbreviation(_:_:)`
   ///            to register abbreviations.
-  @available(*, deprecated, message: "moved to swift-driver")
   public struct AbbreviationID: RawRepresentable, Equatable, Hashable, Comparable, Identifiable {
     public var rawValue: UInt64
 

--- a/Sources/TSCUtility/BitstreamReader.swift
+++ b/Sources/TSCUtility/BitstreamReader.swift
@@ -14,7 +14,6 @@ import TSCBasic
 extension Bitcode {
   /// Traverse a bitstream using the specified `visitor`, which will receive
   /// callbacks when blocks and records are encountered.
-  @available(*, deprecated, message: "moved to swift-driver")
   public static func read<Visitor: BitstreamVisitor>(bytes: ByteString, using visitor: inout Visitor) throws {
     precondition(bytes.count > 4)
     var reader = BitstreamReader(buffer: bytes)
@@ -27,12 +26,10 @@ extension Bitcode {
 }
 
 private extension Bits.Cursor {
-  @available(*, deprecated, message: "moved to swift-driver")
   enum BitcodeError: Swift.Error {
     case vbrOverflow
   }
 
-  @available(*, deprecated, message: "moved to swift-driver")
   mutating func readVBR(_ width: Int) throws -> UInt64 {
     precondition(width > 1)
     let testBit = UInt64(1 << (width &- 1))
@@ -52,7 +49,6 @@ private extension Bits.Cursor {
   }
 }
 
-@available(*, deprecated, message: "moved to swift-driver")
 private struct BitstreamReader {
   enum Error: Swift.Error {
     case invalidAbbrev

--- a/Sources/TSCUtility/BitstreamWriter.swift
+++ b/Sources/TSCUtility/BitstreamWriter.swift
@@ -90,7 +90,6 @@
 ///
 /// The higher-level APIs will automatically ensure that `BitstreamWriter.data`
 /// is valid. Once serialization has completed, simply emit this data to a file.
-@available(*, deprecated, message: "moved to swift-driver")
 public final class BitstreamWriter {
     /// The buffer of data being written to.
     private(set) public var data: [UInt8]
@@ -160,7 +159,6 @@ public final class BitstreamWriter {
 
 extension BitstreamWriter {
     /// Writes the provided UInt32 to the data stream directly.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func write(_ int: UInt32) {
         let index = data.count
 
@@ -179,7 +177,6 @@ extension BitstreamWriter {
     ///   - int: The integer containing the bits you'd like to write
     ///   - width: The number of low-bits of the integer you're writing to the
     ///            buffer
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeVBR<IntType>(_ int: IntType, width: UInt8)
         where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
     {
@@ -202,7 +199,6 @@ extension BitstreamWriter {
     ///   - int: The integer containing the bits you'd like to write
     ///   - width: The number of low-bits of the integer you're writing to the
     ///            buffer
-    @available(*, deprecated, message: "moved to swift-driver")
     public func write<IntType>(_ int: IntType, width: UInt8)
         where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
     {
@@ -249,7 +245,6 @@ extension BitstreamWriter {
         currentBit = (currentBit + width) & 31
     }
 
-    @available(*, deprecated, message: "moved to swift-driver")
     public func alignIfNeeded() {
         guard currentBit > 0 else { return }
         write(currentValue)
@@ -259,13 +254,11 @@ extension BitstreamWriter {
     }
 
     /// Writes a Bool as a 1-bit integer value.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func write(_ bool: Bool) {
         write(bool ? 1 as UInt : 0, width: 1)
     }
 
     /// Writes the provided BitCode Abbrev operand to the stream.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func write(_ abbrevOp: Bitstream.Abbreviation.Operand) {
         write(abbrevOp.isLiteral) // the Literal bit.
         switch abbrevOp {
@@ -295,13 +288,11 @@ extension BitstreamWriter {
     }
 
     /// Writes the specified abbreviaion value to the stream, as a 32-bit quantity.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeCode(_ code: Bitstream.AbbreviationID) {
         writeCode(code.rawValue)
     }
 
     /// Writes the specified Code value to the stream, as a 32-bit quantity.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeCode<IntType>(_ code: IntType)
         where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
     {
@@ -309,7 +300,6 @@ extension BitstreamWriter {
     }
 
     /// Writes an ASCII character to the stream, as an 8-bit ascii value.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeASCII(_ character: Character) {
         precondition(character.unicodeScalars.count == 1, "character is not ASCII")
         let c = UInt8(ascii: character.unicodeScalars.first!)
@@ -322,7 +312,6 @@ extension BitstreamWriter {
 extension BitstreamWriter {
     /// Defines an abbreviation and returns the unique identifier for that
     /// abbreviation.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func defineAbbreviation(_ abbrev: Bitstream.Abbreviation) -> Bitstream.AbbreviationID {
         encodeAbbreviation(abbrev)
         currentAbbreviations.append(abbrev)
@@ -332,7 +321,6 @@ extension BitstreamWriter {
     }
 
     /// Encodes the definition of an abbreviation to the stream.
-    @available(*, deprecated, message: "moved to swift-driver")
     private func encodeAbbreviation(_ abbrev: Bitstream.Abbreviation) {
         writeCode(.defineAbbreviation)
         writeVBR(UInt(abbrev.operands.count), width: 5)
@@ -345,7 +333,6 @@ extension BitstreamWriter {
 // MARK: Writing Records
 
 extension BitstreamWriter {
-    @available(*, deprecated, message: "moved to swift-driver")
     public struct RecordBuffer {
         private(set) var values = [UInt32]()
 
@@ -389,7 +376,6 @@ extension BitstreamWriter {
     }
 
     /// Writes an unabbreviated record to the stream.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeRecord<CodeType>(_ code: CodeType, _ composeRecord: (inout RecordBuffer) -> Void)
         where CodeType: RawRepresentable, CodeType.RawValue == UInt8
     {
@@ -406,7 +392,6 @@ extension BitstreamWriter {
     /// Writes a record with the provided abbreviation ID and record contents.
     /// Optionally, emits the provided blob if the abbreviation referenced
     /// by that ID requires it.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeRecord(
         _ abbrevID: Bitstream.AbbreviationID,
         _ composeRecord: (inout RecordBuffer) -> Void,
@@ -470,14 +455,12 @@ extension BitstreamWriter {
     /// '0' .. '9' --- 52 .. 61
     ///        '.' --- 62
     ///        '_' --- 63
-    @available(*, deprecated, message: "moved to swift-driver")
     private static let char6Map =
         Array(zip("abcdefghijklmnopqrstuvwxyz" +
                     "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
                     "0123456789._", (0 as UInt)...))
 
     /// Writes a char6-encoded value.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeChar6<IntType>(_ value: IntType)
         where IntType: UnsignedInteger & ExpressibleByIntegerLiteral
     {
@@ -489,7 +472,6 @@ extension BitstreamWriter {
     }
 
     /// Writes a value with the provided abbreviation encoding.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeAbbrevField(_ op: Bitstream.Abbreviation.Operand, value: UInt32) {
         switch op {
         case .literal(let literalValue):
@@ -510,7 +492,6 @@ extension BitstreamWriter {
 
     /// Writes a block, beginning with the provided block code and the
     /// abbreviation width
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeBlock(
         _ blockID: Bitstream.BlockID,
         newAbbrevWidth: UInt8? = nil,
@@ -521,7 +502,6 @@ extension BitstreamWriter {
         endBlock()
     }
 
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeBlob<S>(_ bytes: S, includeSize: Bool = true)
         where S: Collection, S.Element == UInt8
     {
@@ -547,7 +527,6 @@ extension BitstreamWriter {
 
     /// Writes the blockinfo block and allows emitting abbreviations
     /// and records in it.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func writeBlockInfoBlock(emitRecords: () -> Void) {
         writeBlock(.blockInfo, newAbbrevWidth: 2) {
             currentBlockID = nil
@@ -566,7 +545,6 @@ extension BitstreamWriter {
     ///   - blockID: The ID of the block to emit.
     ///   - abbreviationBitWidth: The width of the largest abbreviation ID in this block.
     ///   - defineSubBlock: A closure that is called to define the contents of the new block.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func withSubBlock(
         _ blockID: Bitstream.BlockID,
         abbreviationBitWidth: UInt8? = nil,
@@ -588,7 +566,6 @@ extension BitstreamWriter {
     /// - Parameters:
     ///   - blockID: The ID of the block to emit.
     ///   - abbreviationBitWidth: The width of the largest abbreviation ID in this block.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func enterSubblock(
         _ blockID: Bitstream.BlockID,
         abbreviationBitWidth: UInt8? = nil
@@ -622,7 +599,6 @@ extension BitstreamWriter {
     }
 
     /// Marks the end of a new block record.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func endBlock() {
         guard let block = blockScope.popLast() else {
             fatalError("endBlock() called with no block registered")
@@ -645,7 +621,6 @@ extension BitstreamWriter {
 
     /// Defines an abbreviation within the blockinfo block for the provided
     /// block ID.
-    @available(*, deprecated, message: "moved to swift-driver")
     public func defineBlockInfoAbbreviation(
         _ blockID: Bitstream.BlockID,
         _ abbrev: Bitstream.Abbreviation
@@ -659,7 +634,6 @@ extension BitstreamWriter {
     }
 
 
-    @available(*, deprecated, message: "moved to swift-driver")
     private func overwriteBytes(_ int: UInt32, byteIndex: Int) {
         let i = int.littleEndian
         data.withUnsafeMutableBytes { ptr in
@@ -669,7 +643,6 @@ extension BitstreamWriter {
 
     /// Gets the BlockInfo for the provided ID or creates it if it hasn't been
     /// created already.
-    @available(*, deprecated, message: "moved to swift-driver")
     private func getOrCreateBlockInfo(_ id: UInt8) -> BlockInfo {
         if let blockInfo = blockInfoRecords[id] { return blockInfo }
         let info = BlockInfo()
@@ -677,7 +650,6 @@ extension BitstreamWriter {
         return info
     }
 
-    @available(*, deprecated, message: "moved to swift-driver")
     private func `switch`(to blockID: Bitstream.BlockID) {
         if currentBlockID == blockID { return }
         writeRecord(Bitstream.BlockInfoCode.setBID) {


### PR DESCRIPTION
Reverts apple/swift-tools-support-core#351

This change introduced warnings for `SerializedDiagnostics` which is used by SwiftPM.