### PR TITLE
Enforce use of throwing `AbsolutePath` initializer

### DIFF
--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -180,7 +180,7 @@ public final class FileLock {
     
     public static func withLock<T>(fileToLock: AbsolutePath, lockFilesDirectory: AbsolutePath? = nil, type: LockType = .exclusive, body: () throws -> T) throws -> T {
         // unless specified, we use the tempDirectory to store lock files
-        let lockFilesDirectory = lockFilesDirectory ?? localFileSystem.tempDirectory
+        let lockFilesDirectory = try lockFilesDirectory ?? localFileSystem.tempDirectory
         if !localFileSystem.exists(lockFilesDirectory) {
             throw FileSystemError(.noEntry, lockFilesDirectory)
         }
@@ -188,7 +188,7 @@ public final class FileLock {
             throw FileSystemError(.notDirectory, lockFilesDirectory)
         }
         // use the parent path to generate unique filename in temp
-        var lockFileName = (resolveSymlinks(fileToLock.parentDirectory)
+        var lockFileName = try (resolveSymlinks(fileToLock.parentDirectory)
                                 .appending(component: fileToLock.basename))
                                 .components.joined(separator: "_")
                                 .replacingOccurrences(of: ":", with: "_") + ".lock"

--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -59,21 +59,12 @@ public struct AbsolutePath: Hashable {
         _impl = impl
     }
 
-    /// Initializes the AbsolutePath from `absStr`, which must be an absolute
-    /// path (i.e. it must begin with a path separator; this initializer does
-    /// not interpret leading `~` characters as home directory specifiers).
-    /// The input string will be normalized if needed, as described in the
-    /// documentation for AbsolutePath.
-    public init(_ absStr: String) {
-        self.init(PathImpl(normalizingAbsolutePath: absStr))
-    }
-
     /// Initializes an AbsolutePath from a string that may be either absolute
     /// or relative; if relative, `basePath` is used as the anchor; if absolute,
     /// it is used as is, and in this case `basePath` is ignored.
-    public init(_ str: String, relativeTo basePath: AbsolutePath) {
+    public init(validating str: String, relativeTo basePath: AbsolutePath) throws {
         if PathImpl(string: str).isAbsolute {
-            self.init(str)
+            try self.init(validating: str)
         } else {
 #if os(Windows)
             assert(!basePath.pathString.isEmpty)
@@ -115,7 +106,11 @@ public struct AbsolutePath: Hashable {
         self.init(absPath, RelativePath(relStr))
     }
 
-    /// Convenience initializer that verifies that the path is absolute.
+    /// Initializes the AbsolutePath from `absStr`, which must be an absolute
+    /// path (i.e. it must begin with a path separator; this initializer does
+    /// not interpret leading `~` characters as home directory specifiers).
+    /// The input string will be normalized if needed, as described in the
+    /// documentation for AbsolutePath.
     public init(validating path: String) throws {
         try self.init(PathImpl(validatingAbsolutePath: path))
     }
@@ -1064,4 +1059,18 @@ private func mayNeedNormalization(absolute string: String) -> Bool {
         return true
     }
     return false
+}
+
+// MARK: - `AbsolutePath` backwards compatibility, delete after deprecation period.
+
+extension AbsolutePath {
+    @available(*, deprecated, message: "use throwing variant instead")
+    public init(_ absStr: String) {
+        try! self.init(validating: absStr)
+    }
+
+    @available(*, deprecated, message: "use throwing variant instead")
+    public init(_ str: String, relativeTo basePath: AbsolutePath) {
+        try! self.init(validating: str, relativeTo: basePath)
+    }
 }

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -195,7 +195,7 @@ public func getEnvSearchPaths(
 #endif
     return (pathString ?? "").split(separator: pathSeparator).map(String.init).compactMap({ pathString in
         if let cwd = currentWorkingDirectory {
-            return AbsolutePath(pathString, relativeTo: cwd)
+            return try? AbsolutePath(validating: pathString, relativeTo: cwd)
         }
         return try? AbsolutePath(validating: pathString)
     })
@@ -227,9 +227,9 @@ public func lookupExecutablePath(
 
     var paths: [AbsolutePath] = []
 
-    if let cwd = currentWorkingDirectory {
+    if let cwd = currentWorkingDirectory, let path = try? AbsolutePath(validating: value, relativeTo: cwd) {
         // We have a value, but it could be an absolute or a relative path.
-        paths.append(AbsolutePath(value, relativeTo: cwd))
+        paths.append(path)
     } else if let absPath = try? AbsolutePath(validating: value) {
         // Current directory not being available is not a problem
         // for the absolute-specified paths.

--- a/Sources/TSCTestSupport/FileSystemExtensions.swift
+++ b/Sources/TSCTestSupport/FileSystemExtensions.swift
@@ -25,7 +25,7 @@ extension InMemoryFileSystem {
         self.init()
 
         for (path, contents) in files {
-            let path = AbsolutePath(path)
+            let path = try! AbsolutePath(validating: path)
             try! createDirectory(path.parentDirectory, recursive: true)
             try! writeFileContents(path, bytes: contents)
         }
@@ -52,7 +52,7 @@ extension FileSystem {
         do {
             try createDirectory(root, recursive: true)
             for path in files {
-                let path = AbsolutePath(String(path.dropFirst()), relativeTo: root)
+                let path = try AbsolutePath(validating: String(path.dropFirst()), relativeTo: root)
                 try createDirectory(path.parentDirectory, recursive: true)
                 try writeFileContents(path, bytes: "")
             }
@@ -70,5 +70,21 @@ extension FileSystem {
         } catch {
             print(String(describing: error))
         }
+    }
+}
+
+public extension AbsolutePath {
+    init(path: StaticString) {
+        let pathString = path.withUTF8Buffer {
+            String(decoding: $0, as: UTF8.self)
+        }
+        try! self.init(validating: pathString)
+    }
+
+    init(path: StaticString, relativeTo basePath: AbsolutePath) {
+        let pathString = path.withUTF8Buffer {
+            String(decoding: $0, as: UTF8.self)
+        }
+        try! self.init(validating: pathString, relativeTo: basePath)
     }
 }

--- a/Sources/TSCTestSupport/Product.swift
+++ b/Sources/TSCTestSupport/Product.swift
@@ -35,11 +35,11 @@ extension Product {
     public var path: AbsolutePath {
       #if canImport(Darwin)
         for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
-            return AbsolutePath(AbsolutePath(bundle.bundlePath).parentDirectory, self.exec)
+            return try! AbsolutePath(AbsolutePath(validating: bundle.bundlePath).parentDirectory, self.exec)
         }
         fatalError()
       #else
-        return AbsolutePath(CommandLine.arguments.first!, relativeTo: localFileSystem.currentWorkingDirectory!)
+        return try! AbsolutePath(CommandLine.arguments.first!, relativeTo: localFileSystem.currentWorkingDirectory!)
             .parentDirectory.appending(self.exec)
       #endif
     }
@@ -118,7 +118,7 @@ extension Product {
         let packagesPath = packageRoot.appending(components: ".build", "checkouts")
         for name in try localFileSystem.getDirectoryContents(packagesPath) {
             if name.hasPrefix(packageName) {
-                return AbsolutePath(name, relativeTo: packagesPath)
+                return try AbsolutePath(validating: name, relativeTo: packagesPath)
             }
         }
         throw SwiftPMProductError.packagePathNotFound

--- a/Sources/TSCUtility/ArgumentParser.swift
+++ b/Sources/TSCUtility/ArgumentParser.swift
@@ -257,7 +257,7 @@ public struct PathArgument: ArgumentKind {
     public init(argument: String) throws {
         // FIXME: This should check for invalid paths.
         if let cwd = localFileSystem.currentWorkingDirectory {
-            path = AbsolutePath(argument, relativeTo: cwd)
+            path = try AbsolutePath(validating: argument, relativeTo: cwd)
         } else {
             path = try AbsolutePath(validating: argument)
         }

--- a/Sources/TSCUtility/FSWatch.swift
+++ b/Sources/TSCUtility/FSWatch.swift
@@ -761,7 +761,7 @@ private func callback(
     let eventPaths = unsafeBitCast(eventPaths, to: NSArray.self) as? [String] ?? []
 
     // Compute the set of paths that were changed.
-    let paths = eventPaths.map({ AbsolutePath($0) })
+    let paths = eventPaths.compactMap({ try? AbsolutePath(validating: $0) })
 
     eventStream.callbacksQueue.async {
         eventStream.delegate.pathsDidReceiveEvent(paths)

--- a/Sources/TSCUtility/Netrc.swift
+++ b/Sources/TSCUtility/Netrc.swift
@@ -49,13 +49,13 @@ public struct Netrc {
     /// Reads file at path or default location, and returns parsed Netrc representation
     /// - Parameter fileURL: Location of netrc file, defaults to `~/.netrc`
     /// - Returns: `Netrc` container with parsed connection settings, or error
-    public static func load(fromFileAtPath filePath: AbsolutePath? = nil) -> Result<Netrc, Netrc.Error> {
-        let filePath = filePath ?? AbsolutePath("\(NSHomeDirectory())/.netrc")
+    public static func load(fromFileAtPath filePath: AbsolutePath? = nil) throws -> Result<Netrc, Netrc.Error> {
+        let filePath = try filePath ?? AbsolutePath(validating: "\(NSHomeDirectory())/.netrc")
         
         guard FileManager.default.fileExists(atPath: filePath.pathString) else { return .failure(.fileNotFound(filePath)) }
-        guard FileManager.default.isReadableFile(atPath: filePath.pathString),
-              let fileContents = try? String(contentsOf: filePath.asURL, encoding: .utf8) else { return .failure(.unreadableFile(filePath)) }
-        
+        guard FileManager.default.isReadableFile(atPath: filePath.pathString) else { return .failure(.unreadableFile(filePath)) }
+
+        let fileContents = try String(contentsOf: filePath.asURL, encoding: .utf8)
         return Netrc.from(fileContents)
     }
     

--- a/Tests/TSCBasicPerformanceTests/PathPerfTests.swift
+++ b/Tests/TSCBasicPerformanceTests/PathPerfTests.swift
@@ -19,7 +19,7 @@ class PathPerfTests: XCTestCasePerf {
     @available(*, deprecated)
     func testJoinPerf_X100000() {
       #if canImport(Darwin)
-        let absPath = AbsolutePath("/hello/little")
+        let absPath = AbsolutePath(path: "/hello/little")
         let relPath = RelativePath("world")
         let N = 100000
         self.measure {

--- a/Tests/TSCBasicTests/LockTests.swift
+++ b/Tests/TSCBasicTests/LockTests.swift
@@ -115,31 +115,33 @@ class LockTests: XCTestCase {
     func testFileLockLocation() throws {
         do {
             let fileName = UUID().uuidString
-            let fileToLock = localFileSystem.homeDirectory.appending(component: fileName)
+            let fileToLock = try localFileSystem.homeDirectory.appending(component: fileName)
             try localFileSystem.withLock(on: fileToLock, type: .exclusive) {}
             
             // lock file expected at temp when lockFilesDirectory set to nil
             // which is the case when going through localFileSystem
-            let lockFile = try localFileSystem.getDirectoryContents(localFileSystem.tempDirectory)
+            let tempDirectory = try localFileSystem.tempDirectory
+            let lockFile = try localFileSystem.getDirectoryContents(tempDirectory)
                 .first(where: { $0.contains(fileName) })
-            XCTAssertNotNil(lockFile, "expected lock file at \(localFileSystem.tempDirectory)")
+            XCTAssertNotNil(lockFile, "expected lock file at \(tempDirectory)")
         }
         
         do {
             let fileName = UUID().uuidString
-            let fileToLock = localFileSystem.homeDirectory.appending(component: fileName)
+            let fileToLock = try localFileSystem.homeDirectory.appending(component: fileName)
             try FileLock.withLock(fileToLock: fileToLock, lockFilesDirectory: nil, body: {})
             
             // lock file expected at temp when lockFilesDirectory set to nil
-            let lockFile = try localFileSystem.getDirectoryContents(localFileSystem.tempDirectory)
+            let tempDirectory = try localFileSystem.tempDirectory
+            let lockFile = try localFileSystem.getDirectoryContents(tempDirectory)
                 .first(where: { $0.contains(fileName) })
-            XCTAssertNotNil(lockFile, "expected lock file at \(localFileSystem.tempDirectory)")
+            XCTAssertNotNil(lockFile, "expected lock file at \(tempDirectory)")
         }
         
         do {
             try withTemporaryDirectory { tempDir in
                 let fileName = UUID().uuidString
-                let fileToLock = localFileSystem.homeDirectory.appending(component: fileName)
+                let fileToLock = try localFileSystem.homeDirectory.appending(component: fileName)
                 try FileLock.withLock(fileToLock: fileToLock, lockFilesDirectory: tempDir, body: {})
                 
                 // lock file expected at specified directory when lockFilesDirectory is set to a valid directory
@@ -151,8 +153,8 @@ class LockTests: XCTestCase {
         
         do {
             let fileName = UUID().uuidString
-            let fileToLock = localFileSystem.homeDirectory.appending(component: fileName)
-            let lockFilesDirectory = localFileSystem.homeDirectory.appending(component: UUID().uuidString)
+            let fileToLock = try localFileSystem.homeDirectory.appending(component: fileName)
+            let lockFilesDirectory = try localFileSystem.homeDirectory.appending(component: UUID().uuidString)
             XCTAssertThrows(FileSystemError(.noEntry, lockFilesDirectory)) {
                 try FileLock.withLock(fileToLock: fileToLock, lockFilesDirectory: lockFilesDirectory, body: {})
             }
@@ -160,8 +162,8 @@ class LockTests: XCTestCase {
         
         do {
             let fileName = UUID().uuidString
-            let fileToLock = localFileSystem.homeDirectory.appending(component: fileName)
-            let lockFilesDirectory = localFileSystem.homeDirectory.appending(component: UUID().uuidString)
+            let fileToLock = try localFileSystem.homeDirectory.appending(component: fileName)
+            let lockFilesDirectory = try localFileSystem.homeDirectory.appending(component: UUID().uuidString)
             try localFileSystem.writeFileContents(lockFilesDirectory, bytes: [])
             XCTAssertThrows(FileSystemError(.notDirectory, lockFilesDirectory)) {
                 try FileLock.withLock(fileToLock: fileToLock, lockFilesDirectory: lockFilesDirectory, body: {})

--- a/Tests/TSCBasicTests/PathShimTests.swift
+++ b/Tests/TSCBasicTests/PathShimTests.swift
@@ -33,23 +33,23 @@ class PathShimTests : XCTestCase {
 
 class WalkTests : XCTestCase {
 
-    func testNonRecursive() {
+    func testNonRecursive() throws {
       #if os(Android)
         let root = "/system"
         var expected = [
-            AbsolutePath("\(root)/usr"),
-            AbsolutePath("\(root)/bin"),
-            AbsolutePath("\(root)/xbin")
+            AbsolutePath(path: "\(root)/usr"),
+            AbsolutePath(path: "\(root)/bin"),
+            AbsolutePath(path: "\(root)/xbin")
         ]
       #else
         let root = ""
         var expected = [
-            AbsolutePath("/usr"),
-            AbsolutePath("/bin"),
-            AbsolutePath("/sbin")
+            AbsolutePath(path: "/usr"),
+            AbsolutePath(path: "/bin"),
+            AbsolutePath(path: "/sbin")
         ]
       #endif
-        for x in try! walk(AbsolutePath("\(root)/"), recursively: false) {
+        for x in try walk(AbsolutePath(validating: "\(root)/"), recursively: false) {
             if let i = expected.firstIndex(of: x) {
                 expected.remove(at: i)
             }
@@ -63,7 +63,7 @@ class WalkTests : XCTestCase {
     }
 
     func testRecursive() {
-        let root = AbsolutePath(#file).parentDirectory.parentDirectory.parentDirectory.appending(component: "Sources")
+        let root = AbsolutePath(path: #file).parentDirectory.parentDirectory.parentDirectory.appending(component: "Sources")
         var expected = [
             root.appending(component: "TSCBasic"),
             root.appending(component: "TSCUtility")

--- a/Tests/TSCBasicTests/PathTests.swift
+++ b/Tests/TSCBasicTests/PathTests.swift
@@ -16,9 +16,9 @@ import TSCBasic
 class PathTests: XCTestCase {
 
     func testBasics() {
-        XCTAssertEqual(AbsolutePath("/").pathString, "/")
-        XCTAssertEqual(AbsolutePath("/a").pathString, "/a")
-        XCTAssertEqual(AbsolutePath("/a/b/c").pathString, "/a/b/c")
+        XCTAssertEqual(AbsolutePath(path: "/").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/a").pathString, "/a")
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c").pathString, "/a/b/c")
         XCTAssertEqual(RelativePath(".").pathString, ".")
         XCTAssertEqual(RelativePath("a").pathString, "a")
         XCTAssertEqual(RelativePath("a/b/c").pathString, "a/b/c")
@@ -26,23 +26,23 @@ class PathTests: XCTestCase {
     }
 
     func testStringInitialization() {
-        let abs1 = AbsolutePath("/")
+        let abs1 = AbsolutePath(path: "/")
         let abs2 = AbsolutePath(abs1, ".")
         XCTAssertEqual(abs1, abs2)
         let rel3 = "."
         let abs3 = AbsolutePath(abs2, rel3)
         XCTAssertEqual(abs2, abs3)
-        let base = AbsolutePath("/base/path")
-        let abs4 = AbsolutePath("/a/b/c", relativeTo: base)
-        XCTAssertEqual(abs4, AbsolutePath("/a/b/c"))
-        let abs5 = AbsolutePath("./a/b/c", relativeTo: base)
-        XCTAssertEqual(abs5, AbsolutePath("/base/path/a/b/c"))
-        let abs6 = AbsolutePath("~/bla", relativeTo: base)  // `~` isn't special
-        XCTAssertEqual(abs6, AbsolutePath("/base/path/~/bla"))
+        let base = AbsolutePath(path: "/base/path")
+        let abs4 = AbsolutePath(path: "/a/b/c", relativeTo: base)
+        XCTAssertEqual(abs4, AbsolutePath(path: "/a/b/c"))
+        let abs5 = AbsolutePath(path: "./a/b/c", relativeTo: base)
+        XCTAssertEqual(abs5, AbsolutePath(path: "/base/path/a/b/c"))
+        let abs6 = AbsolutePath(path: "~/bla", relativeTo: base)  // `~` isn't special
+        XCTAssertEqual(abs6, AbsolutePath(path: "/base/path/~/bla"))
     }
 
     func testStringLiteralInitialization() {
-        let abs = AbsolutePath("/")
+        let abs = AbsolutePath(path: "/")
         XCTAssertEqual(abs.pathString, "/")
         let rel1 = RelativePath(".")
         XCTAssertEqual(rel1.pathString, ".")
@@ -51,34 +51,34 @@ class PathTests: XCTestCase {
     }
 
     func testRepeatedPathSeparators() {
-        XCTAssertEqual(AbsolutePath("/ab//cd//ef").pathString, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab///cd//ef").pathString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath(path: "/ab//cd//ef").pathString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath(path: "/ab///cd//ef").pathString, "/ab/cd/ef")
         XCTAssertEqual(RelativePath("ab//cd//ef").pathString, "ab/cd/ef")
         XCTAssertEqual(RelativePath("ab//cd///ef").pathString, "ab/cd/ef")
     }
 
     func testTrailingPathSeparators() {
-        XCTAssertEqual(AbsolutePath("/ab/cd/ef/").pathString, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab/cd/ef//").pathString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath(path: "/ab/cd/ef/").pathString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath(path: "/ab/cd/ef//").pathString, "/ab/cd/ef")
         XCTAssertEqual(RelativePath("ab/cd/ef/").pathString, "ab/cd/ef")
         XCTAssertEqual(RelativePath("ab/cd/ef//").pathString, "ab/cd/ef")
     }
 
     func testDotPathComponents() {
-        XCTAssertEqual(AbsolutePath("/ab/././cd//ef").pathString, "/ab/cd/ef")
-        XCTAssertEqual(AbsolutePath("/ab/./cd//ef/.").pathString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath(path: "/ab/././cd//ef").pathString, "/ab/cd/ef")
+        XCTAssertEqual(AbsolutePath(path: "/ab/./cd//ef/.").pathString, "/ab/cd/ef")
         XCTAssertEqual(RelativePath("ab/./cd/././ef").pathString, "ab/cd/ef")
         XCTAssertEqual(RelativePath("ab/./cd/ef/.").pathString, "ab/cd/ef")
     }
 
     func testDotDotPathComponents() {
-        XCTAssertEqual(AbsolutePath("/..").pathString, "/")
-        XCTAssertEqual(AbsolutePath("/../../../../..").pathString, "/")
-        XCTAssertEqual(AbsolutePath("/abc/..").pathString, "/")
-        XCTAssertEqual(AbsolutePath("/abc/../..").pathString, "/")
-        XCTAssertEqual(AbsolutePath("/../abc").pathString, "/abc")
-        XCTAssertEqual(AbsolutePath("/../abc/..").pathString, "/")
-        XCTAssertEqual(AbsolutePath("/../abc/../def").pathString, "/def")
+        XCTAssertEqual(AbsolutePath(path: "/..").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/../../../../..").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/abc/..").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/abc/../..").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/../abc").pathString, "/abc")
+        XCTAssertEqual(AbsolutePath(path: "/../abc/..").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/../abc/../def").pathString, "/def")
         XCTAssertEqual(RelativePath("..").pathString, "..")
         XCTAssertEqual(RelativePath("../..").pathString, "../..")
         XCTAssertEqual(RelativePath(".././..").pathString, "../..")
@@ -88,8 +88,8 @@ class PathTests: XCTestCase {
     }
 
     func testCombinationsAndEdgeCases() {
-        XCTAssertEqual(AbsolutePath("///").pathString, "/")
-        XCTAssertEqual(AbsolutePath("/./").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "///").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/./").pathString, "/")
         XCTAssertEqual(RelativePath("").pathString, ".")
         XCTAssertEqual(RelativePath(".").pathString, ".")
         XCTAssertEqual(RelativePath("./abc").pathString, "abc")
@@ -117,11 +117,11 @@ class PathTests: XCTestCase {
     }
 
     func testDirectoryNameExtraction() {
-        XCTAssertEqual(AbsolutePath("/").dirname, "/")
-        XCTAssertEqual(AbsolutePath("/a").dirname, "/")
-        XCTAssertEqual(AbsolutePath("/./a").dirname, "/")
-        XCTAssertEqual(AbsolutePath("/../..").dirname, "/")
-        XCTAssertEqual(AbsolutePath("/ab/c//d/").dirname, "/ab/c")
+        XCTAssertEqual(AbsolutePath(path: "/").dirname, "/")
+        XCTAssertEqual(AbsolutePath(path: "/a").dirname, "/")
+        XCTAssertEqual(AbsolutePath(path: "/./a").dirname, "/")
+        XCTAssertEqual(AbsolutePath(path: "/../..").dirname, "/")
+        XCTAssertEqual(AbsolutePath(path: "/ab/c//d/").dirname, "/ab/c")
         XCTAssertEqual(RelativePath("ab/c//d/").dirname, "ab/c")
         XCTAssertEqual(RelativePath("../a").dirname, "..")
         XCTAssertEqual(RelativePath("../a/..").dirname, ".")
@@ -134,10 +134,10 @@ class PathTests: XCTestCase {
     }
 
     func testBaseNameExtraction() {
-        XCTAssertEqual(AbsolutePath("/").basename, "/")
-        XCTAssertEqual(AbsolutePath("/a").basename, "a")
-        XCTAssertEqual(AbsolutePath("/./a").basename, "a")
-        XCTAssertEqual(AbsolutePath("/../..").basename, "/")
+        XCTAssertEqual(AbsolutePath(path: "/").basename, "/")
+        XCTAssertEqual(AbsolutePath(path: "/a").basename, "a")
+        XCTAssertEqual(AbsolutePath(path: "/./a").basename, "a")
+        XCTAssertEqual(AbsolutePath(path: "/../..").basename, "/")
         XCTAssertEqual(RelativePath("../..").basename, "..")
         XCTAssertEqual(RelativePath("../a").basename, "a")
         XCTAssertEqual(RelativePath("../a/..").basename, "..")
@@ -150,10 +150,10 @@ class PathTests: XCTestCase {
     }
 
     func testBaseNameWithoutExt() {
-        XCTAssertEqual(AbsolutePath("/").basenameWithoutExt, "/")
-        XCTAssertEqual(AbsolutePath("/a").basenameWithoutExt, "a")
-        XCTAssertEqual(AbsolutePath("/./a").basenameWithoutExt, "a")
-        XCTAssertEqual(AbsolutePath("/../..").basenameWithoutExt, "/")
+        XCTAssertEqual(AbsolutePath(path: "/").basenameWithoutExt, "/")
+        XCTAssertEqual(AbsolutePath(path: "/a").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath(path: "/./a").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath(path: "/../..").basenameWithoutExt, "/")
         XCTAssertEqual(RelativePath("../..").basenameWithoutExt, "..")
         XCTAssertEqual(RelativePath("../a").basenameWithoutExt, "a")
         XCTAssertEqual(RelativePath("../a/..").basenameWithoutExt, "..")
@@ -164,8 +164,8 @@ class PathTests: XCTestCase {
         XCTAssertEqual(RelativePath("").basenameWithoutExt, ".")
         XCTAssertEqual(RelativePath(".").basenameWithoutExt, ".")
 
-        XCTAssertEqual(AbsolutePath("/a.txt").basenameWithoutExt, "a")
-        XCTAssertEqual(AbsolutePath("/./a.txt").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath(path: "/a.txt").basenameWithoutExt, "a")
+        XCTAssertEqual(AbsolutePath(path: "/./a.txt").basenameWithoutExt, "a")
         XCTAssertEqual(RelativePath("../a.bc").basenameWithoutExt, "a")
         XCTAssertEqual(RelativePath("abc.swift").basenameWithoutExt, "abc")
         XCTAssertEqual(RelativePath("../a.b.c").basenameWithoutExt, "a.b")
@@ -198,60 +198,60 @@ class PathTests: XCTestCase {
     }
 
     func testParentDirectory() {
-        XCTAssertEqual(AbsolutePath("/").parentDirectory, AbsolutePath("/"))
-        XCTAssertEqual(AbsolutePath("/").parentDirectory.parentDirectory, AbsolutePath("/"))
-        XCTAssertEqual(AbsolutePath("/bar").parentDirectory, AbsolutePath("/"))
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//").parentDirectory.parentDirectory, AbsolutePath("/"))
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b").parentDirectory.parentDirectory, AbsolutePath("/yabba"))
+        XCTAssertEqual(AbsolutePath(path: "/").parentDirectory, AbsolutePath(path: "/"))
+        XCTAssertEqual(AbsolutePath(path: "/").parentDirectory.parentDirectory, AbsolutePath(path: "/"))
+        XCTAssertEqual(AbsolutePath(path: "/bar").parentDirectory, AbsolutePath(path: "/"))
+        XCTAssertEqual(AbsolutePath(path: "/bar/../foo/..//").parentDirectory.parentDirectory, AbsolutePath(path: "/"))
+        XCTAssertEqual(AbsolutePath(path: "/bar/../foo/..//yabba/a/b").parentDirectory.parentDirectory, AbsolutePath(path: "/yabba"))
     }
 
     @available(*, deprecated)
     func testConcatenation() {
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("")).pathString, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath(".")).pathString, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("..")).pathString, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/"), RelativePath("bar")).pathString, "/bar")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/foo/bar"), RelativePath("..")).pathString, "/foo")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo")).pathString, "/foo")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar"), RelativePath("../foo/..//")).pathString, "/")
-        XCTAssertEqual(AbsolutePath(AbsolutePath("/bar/../foo/..//yabba/"), RelativePath("a/b")).pathString, "/yabba/a/b")
+        XCTAssertEqual(AbsolutePath(AbsolutePath(path: "/"), RelativePath("")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath(path: "/"), RelativePath(".")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath(path: "/"), RelativePath("..")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath(path: "/"), RelativePath("bar")).pathString, "/bar")
+        XCTAssertEqual(AbsolutePath(AbsolutePath(path: "/foo/bar"), RelativePath("..")).pathString, "/foo")
+        XCTAssertEqual(AbsolutePath(AbsolutePath(path: "/bar"), RelativePath("../foo")).pathString, "/foo")
+        XCTAssertEqual(AbsolutePath(AbsolutePath(path: "/bar"), RelativePath("../foo/..//")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(AbsolutePath(path: "/bar/../foo/..//yabba/"), RelativePath("a/b")).pathString, "/yabba/a/b")
 
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("")).pathString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath(".")).pathString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("..")).pathString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(RelativePath("bar")).pathString, "/bar")
-        XCTAssertEqual(AbsolutePath("/foo/bar").appending(RelativePath("..")).pathString, "/foo")
-        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo")).pathString, "/foo")
-        XCTAssertEqual(AbsolutePath("/bar").appending(RelativePath("../foo/..//")).pathString, "/")
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/").appending(RelativePath("a/b")).pathString, "/yabba/a/b")
+        XCTAssertEqual(AbsolutePath(path: "/").appending(RelativePath("")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/").appending(RelativePath(".")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/").appending(RelativePath("..")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/").appending(RelativePath("bar")).pathString, "/bar")
+        XCTAssertEqual(AbsolutePath(path: "/foo/bar").appending(RelativePath("..")).pathString, "/foo")
+        XCTAssertEqual(AbsolutePath(path: "/bar").appending(RelativePath("../foo")).pathString, "/foo")
+        XCTAssertEqual(AbsolutePath(path: "/bar").appending(RelativePath("../foo/..//")).pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/bar/../foo/..//yabba/").appending(RelativePath("a/b")).pathString, "/yabba/a/b")
 
-        XCTAssertEqual(AbsolutePath("/").appending(component: "a").pathString, "/a")
-        XCTAssertEqual(AbsolutePath("/a").appending(component: "b").pathString, "/a/b")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "a", "b").pathString, "/a/b")
-        XCTAssertEqual(AbsolutePath("/a").appending(components: "b", "c").pathString, "/a/b/c")
+        XCTAssertEqual(AbsolutePath(path: "/").appending(component: "a").pathString, "/a")
+        XCTAssertEqual(AbsolutePath(path: "/a").appending(component: "b").pathString, "/a/b")
+        XCTAssertEqual(AbsolutePath(path: "/").appending(components: "a", "b").pathString, "/a/b")
+        XCTAssertEqual(AbsolutePath(path: "/a").appending(components: "b", "c").pathString, "/a/b/c")
 
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "", "c").pathString, "/a/b/c/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "").pathString, "/a/b/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: ".").pathString, "/a/b/c")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..").pathString, "/a/b")
-        XCTAssertEqual(AbsolutePath("/a/b/c").appending(components: "..", "d").pathString, "/a/b/d")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "..").pathString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(components: ".").pathString, "/")
-        XCTAssertEqual(AbsolutePath("/").appending(components: "..", "a").pathString, "/a")
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c").appending(components: "", "c").pathString, "/a/b/c/c")
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c").appending(components: "").pathString, "/a/b/c")
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c").appending(components: ".").pathString, "/a/b/c")
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c").appending(components: "..").pathString, "/a/b")
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c").appending(components: "..", "d").pathString, "/a/b/d")
+        XCTAssertEqual(AbsolutePath(path: "/").appending(components: "..").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/").appending(components: ".").pathString, "/")
+        XCTAssertEqual(AbsolutePath(path: "/").appending(components: "..", "a").pathString, "/a")
 
         XCTAssertEqual(RelativePath("hello").appending(components: "a", "b", "c", "..").pathString, "hello/a/b")
         XCTAssertEqual(RelativePath("hello").appending(RelativePath("a/b/../c/d")).pathString, "hello/a/c/d")
     }
 
     func testPathComponents() {
-        XCTAssertEqual(AbsolutePath("/").components, ["/"])
-        XCTAssertEqual(AbsolutePath("/.").components, ["/"])
-        XCTAssertEqual(AbsolutePath("/..").components, ["/"])
-        XCTAssertEqual(AbsolutePath("/bar").components, ["/", "bar"])
-        XCTAssertEqual(AbsolutePath("/foo/bar/..").components, ["/", "foo"])
-        XCTAssertEqual(AbsolutePath("/bar/../foo").components, ["/", "foo"])
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//").components, ["/"])
-        XCTAssertEqual(AbsolutePath("/bar/../foo/..//yabba/a/b/").components, ["/", "yabba", "a", "b"])
+        XCTAssertEqual(AbsolutePath(path: "/").components, ["/"])
+        XCTAssertEqual(AbsolutePath(path: "/.").components, ["/"])
+        XCTAssertEqual(AbsolutePath(path: "/..").components, ["/"])
+        XCTAssertEqual(AbsolutePath(path: "/bar").components, ["/", "bar"])
+        XCTAssertEqual(AbsolutePath(path: "/foo/bar/..").components, ["/", "foo"])
+        XCTAssertEqual(AbsolutePath(path: "/bar/../foo").components, ["/", "foo"])
+        XCTAssertEqual(AbsolutePath(path: "/bar/../foo/..//").components, ["/"])
+        XCTAssertEqual(AbsolutePath(path: "/bar/../foo/..//yabba/a/b/").components, ["/", "yabba", "a", "b"])
 
         XCTAssertEqual(RelativePath("").components, ["."])
         XCTAssertEqual(RelativePath(".").components, ["."])
@@ -272,44 +272,44 @@ class PathTests: XCTestCase {
     }
 
     func testRelativePathFromAbsolutePaths() {
-        XCTAssertEqual(AbsolutePath("/").relative(to: AbsolutePath("/")), RelativePath("."));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/")), RelativePath("a/b/c/d"));
-        XCTAssertEqual(AbsolutePath("/").relative(to: AbsolutePath("/a/b/c")), RelativePath("../../.."));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/b")), RelativePath("c/d"));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/b/c")), RelativePath("d"));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/a/c/d")), RelativePath("../../b/c/d"));
-        XCTAssertEqual(AbsolutePath("/a/b/c/d").relative(to: AbsolutePath("/b/c/d")), RelativePath("../../../a/b/c/d"));
+        XCTAssertEqual(AbsolutePath(path: "/").relative(to: AbsolutePath(path: "/")), RelativePath("."));
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c/d").relative(to: AbsolutePath(path: "/")), RelativePath("a/b/c/d"));
+        XCTAssertEqual(AbsolutePath(path: "/").relative(to: AbsolutePath(path: "/a/b/c")), RelativePath("../../.."));
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c/d").relative(to: AbsolutePath(path: "/a/b")), RelativePath("c/d"));
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c/d").relative(to: AbsolutePath(path: "/a/b/c")), RelativePath("d"));
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c/d").relative(to: AbsolutePath(path: "/a/c/d")), RelativePath("../../b/c/d"));
+        XCTAssertEqual(AbsolutePath(path: "/a/b/c/d").relative(to: AbsolutePath(path: "/b/c/d")), RelativePath("../../../a/b/c/d"));
     }
 
     func testComparison() {
-        XCTAssertTrue(AbsolutePath("/") <= AbsolutePath("/"));
-        XCTAssertTrue(AbsolutePath("/abc") < AbsolutePath("/def"));
-        XCTAssertTrue(AbsolutePath("/2") <= AbsolutePath("/2.1"));
-        XCTAssertTrue(AbsolutePath("/3.1") > AbsolutePath("/2"));
-        XCTAssertTrue(AbsolutePath("/2") >= AbsolutePath("/2"));
-        XCTAssertTrue(AbsolutePath("/2.1") >= AbsolutePath("/2"));
+        XCTAssertTrue(AbsolutePath(path: "/") <= AbsolutePath(path: "/"));
+        XCTAssertTrue(AbsolutePath(path: "/abc") < AbsolutePath(path: "/def"));
+        XCTAssertTrue(AbsolutePath(path: "/2") <= AbsolutePath(path: "/2.1"));
+        XCTAssertTrue(AbsolutePath(path: "/3.1") > AbsolutePath(path: "/2"));
+        XCTAssertTrue(AbsolutePath(path: "/2") >= AbsolutePath(path: "/2"));
+        XCTAssertTrue(AbsolutePath(path: "/2.1") >= AbsolutePath(path: "/2"));
     }
 
     func testAncestry() {
-        XCTAssertTrue(AbsolutePath("/a/b/c/d/e/f").isDescendantOfOrEqual(to: AbsolutePath("/a/b/c/d")))
-        XCTAssertTrue(AbsolutePath("/a/b/c/d/e/f.swift").isDescendantOfOrEqual(to: AbsolutePath("/a/b/c")))
-        XCTAssertTrue(AbsolutePath("/").isDescendantOfOrEqual(to: AbsolutePath("/")))
-        XCTAssertTrue(AbsolutePath("/foo/bar").isDescendantOfOrEqual(to: AbsolutePath("/")))
-        XCTAssertFalse(AbsolutePath("/foo/bar").isDescendantOfOrEqual(to: AbsolutePath("/foo/bar/baz")))
-        XCTAssertFalse(AbsolutePath("/foo/bar").isDescendantOfOrEqual(to: AbsolutePath("/bar")))
+        XCTAssertTrue(AbsolutePath(path: "/a/b/c/d/e/f").isDescendantOfOrEqual(to: AbsolutePath(path: "/a/b/c/d")))
+        XCTAssertTrue(AbsolutePath(path: "/a/b/c/d/e/f.swift").isDescendantOfOrEqual(to: AbsolutePath(path: "/a/b/c")))
+        XCTAssertTrue(AbsolutePath(path: "/").isDescendantOfOrEqual(to: AbsolutePath(path: "/")))
+        XCTAssertTrue(AbsolutePath(path: "/foo/bar").isDescendantOfOrEqual(to: AbsolutePath(path: "/")))
+        XCTAssertFalse(AbsolutePath(path: "/foo/bar").isDescendantOfOrEqual(to: AbsolutePath(path: "/foo/bar/baz")))
+        XCTAssertFalse(AbsolutePath(path: "/foo/bar").isDescendantOfOrEqual(to: AbsolutePath(path: "/bar")))
 
-        XCTAssertFalse(AbsolutePath("/foo/bar").isDescendant(of: AbsolutePath("/foo/bar")))
-        XCTAssertTrue(AbsolutePath("/foo/bar").isDescendant(of: AbsolutePath("/foo")))
+        XCTAssertFalse(AbsolutePath(path: "/foo/bar").isDescendant(of: AbsolutePath(path: "/foo/bar")))
+        XCTAssertTrue(AbsolutePath(path: "/foo/bar").isDescendant(of: AbsolutePath(path: "/foo")))
 
-        XCTAssertTrue(AbsolutePath("/a/b/c/d").isAncestorOfOrEqual(to: AbsolutePath("/a/b/c/d/e/f")))
-        XCTAssertTrue(AbsolutePath("/a/b/c").isAncestorOfOrEqual(to: AbsolutePath("/a/b/c/d/e/f.swift")))
-        XCTAssertTrue(AbsolutePath("/").isAncestorOfOrEqual(to: AbsolutePath("/")))
-        XCTAssertTrue(AbsolutePath("/").isAncestorOfOrEqual(to: AbsolutePath("/foo/bar")))
-        XCTAssertFalse(AbsolutePath("/foo/bar/baz").isAncestorOfOrEqual(to: AbsolutePath("/foo/bar")))
-        XCTAssertFalse(AbsolutePath("/bar").isAncestorOfOrEqual(to: AbsolutePath("/foo/bar")))
+        XCTAssertTrue(AbsolutePath(path: "/a/b/c/d").isAncestorOfOrEqual(to: AbsolutePath(path: "/a/b/c/d/e/f")))
+        XCTAssertTrue(AbsolutePath(path: "/a/b/c").isAncestorOfOrEqual(to: AbsolutePath(path: "/a/b/c/d/e/f.swift")))
+        XCTAssertTrue(AbsolutePath(path: "/").isAncestorOfOrEqual(to: AbsolutePath(path: "/")))
+        XCTAssertTrue(AbsolutePath(path: "/").isAncestorOfOrEqual(to: AbsolutePath(path: "/foo/bar")))
+        XCTAssertFalse(AbsolutePath(path: "/foo/bar/baz").isAncestorOfOrEqual(to: AbsolutePath(path: "/foo/bar")))
+        XCTAssertFalse(AbsolutePath(path: "/bar").isAncestorOfOrEqual(to: AbsolutePath(path: "/foo/bar")))
 
-        XCTAssertFalse(AbsolutePath("/foo/bar").isAncestor(of: AbsolutePath("/foo/bar")))
-        XCTAssertTrue(AbsolutePath("/foo").isAncestor(of: AbsolutePath("/foo/bar")))
+        XCTAssertFalse(AbsolutePath(path: "/foo/bar").isAncestor(of: AbsolutePath(path: "/foo/bar")))
+        XCTAssertTrue(AbsolutePath(path: "/foo").isAncestor(of: AbsolutePath(path: "/foo/bar")))
     }
 
     func testAbsolutePathValidation() {
@@ -350,14 +350,14 @@ class PathTests: XCTestCase {
         }
 
         do {
-            let foo = Foo(path: AbsolutePath("/path/to/foo"))
+            let foo = Foo(path: AbsolutePath(path: "/path/to/foo"))
             let data = try JSONEncoder().encode(foo)
             let decodedFoo = try JSONDecoder().decode(Foo.self, from: data)
             XCTAssertEqual(foo, decodedFoo)
         }
 
         do {
-            let foo = Foo(path: AbsolutePath("/path/to/../to/foo"))
+            let foo = Foo(path: AbsolutePath(path: "/path/to/../to/foo"))
             let data = try JSONEncoder().encode(foo)
             let decodedFoo = try JSONDecoder().decode(Foo.self, from: data)
             XCTAssertEqual(foo, decodedFoo)

--- a/Tests/TSCBasicTests/ProcessEnvTests.swift
+++ b/Tests/TSCBasicTests/ProcessEnvTests.swift
@@ -26,7 +26,7 @@ class ProcessEnvTests: XCTestCase {
 
     func testChdir() throws {
         try testWithTemporaryDirectory { tmpdir in
-            let path = resolveSymlinks(tmpdir)
+            let path = try resolveSymlinks(tmpdir)
             try ProcessEnv.chdir(path)
             XCTAssertEqual(ProcessEnv.cwd, path)
         }

--- a/Tests/TSCBasicTests/ProcessSetTests.swift
+++ b/Tests/TSCBasicTests/ProcessSetTests.swift
@@ -17,7 +17,7 @@ import TSCTestSupport
 class ProcessSetTests: XCTestCase {
   #if !os(Windows) // Signals are not supported in Windows
     func script(_ name: String) -> String {
-        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).pathString
+        return AbsolutePath(path: #file).parentDirectory.appending(components: "processInputs", name).pathString
     }
 
     func testSigInt() throws {

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -20,7 +20,7 @@ typealias Process = TSCBasic.Process
 
 class ProcessTests: XCTestCase {
     func script(_ name: String) -> String {
-        return AbsolutePath(#file).parentDirectory.appending(components: "processInputs", name).pathString
+        return AbsolutePath(path: #file).parentDirectory.appending(components: "processInputs", name).pathString
     }
 
     func testBasics() throws {

--- a/Tests/TSCBasicTests/miscTests.swift
+++ b/Tests/TSCBasicTests/miscTests.swift
@@ -48,13 +48,13 @@ class miscTests: XCTestCase {
     }
     
     func testEnvSearchPaths() throws {
-        let cwd = AbsolutePath("/dummy")
+        let cwd = AbsolutePath(path: "/dummy")
         let paths = getEnvSearchPaths(pathString: "something:.:abc/../.build/debug:/usr/bin:/bin/", currentWorkingDirectory: cwd)
-        XCTAssertEqual(paths, ["/dummy/something", "/dummy", "/dummy/.build/debug", "/usr/bin", "/bin"].map({AbsolutePath($0)}))
+        XCTAssertEqual(paths, try ["/dummy/something", "/dummy", "/dummy/.build/debug", "/usr/bin", "/bin"].map({ try AbsolutePath(validating: $0)}))
     }
     
     func testEmptyEnvSearchPaths() throws {
-        let cwd = AbsolutePath("/dummy")
+        let cwd = AbsolutePath(path: "/dummy")
         let paths = getEnvSearchPaths(pathString: "", currentWorkingDirectory: cwd)
         XCTAssertEqual(paths, [])
         

--- a/Tests/TSCUtilityTests/ArchiverTests.swift
+++ b/Tests/TSCUtilityTests/ArchiverTests.swift
@@ -23,7 +23,7 @@ class ArchiverTests: XCTestCase {
             let expectation = XCTestExpectation(description: "success")
 
             let archiver = ZipArchiver()
-            let inputArchivePath = AbsolutePath(#file).parentDirectory.appending(components: "Inputs", "archive.zip")
+            let inputArchivePath = AbsolutePath(path: #file).parentDirectory.appending(components: "Inputs", "archive.zip")
             archiver.extract(from: inputArchivePath, to: tmpdir, completion: { result in
                 XCTAssertResultSuccess(result) { _ in
                     let content = tmpdir.appending(component: "file")
@@ -42,8 +42,8 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem()
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let archive = AbsolutePath("/archive.zip")
-        archiver.extract(from: archive, to: AbsolutePath("/"), completion: { result in
+        let archive = AbsolutePath(path: "/archive.zip")
+        archiver.extract(from: archive, to: AbsolutePath(path: "/"), completion: { result in
             XCTAssertResultFailure(result, equals: FileSystemError(.noEntry, archive))
             expectation.fulfill()
         })
@@ -56,8 +56,8 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let destination = AbsolutePath("/destination")
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+        let destination = AbsolutePath(path: "/destination")
+        archiver.extract(from: AbsolutePath(path: "/archive.zip"), to: destination, completion: { result in
             XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
@@ -70,8 +70,8 @@ class ArchiverTests: XCTestCase {
 
         let fileSystem = InMemoryFileSystem(emptyFiles: "/archive.zip", "/destination")
         let archiver = ZipArchiver(fileSystem: fileSystem)
-        let destination = AbsolutePath("/destination")
-        archiver.extract(from: AbsolutePath("/archive.zip"), to: destination, completion: { result in
+        let destination = AbsolutePath(path: "/destination")
+        archiver.extract(from: AbsolutePath(path: "/archive.zip"), to: destination, completion: { result in
             XCTAssertResultFailure(result, equals: FileSystemError(.notDirectory, destination))
             expectation.fulfill()
         })
@@ -84,7 +84,7 @@ class ArchiverTests: XCTestCase {
             let expectation = XCTestExpectation(description: "failure")
 
             let archiver = ZipArchiver()
-            let inputArchivePath = AbsolutePath(#file).parentDirectory
+            let inputArchivePath = AbsolutePath(path: #file).parentDirectory
                 .appending(components: "Inputs", "invalid_archive.zip")
             archiver.extract(from: inputArchivePath, to: tmpdir, completion: { result in
                 XCTAssertResultFailure(result) { error in

--- a/Tests/TSCUtilityTests/BitstreamTests.swift
+++ b/Tests/TSCUtilityTests/BitstreamTests.swift
@@ -33,7 +33,7 @@ final class BitstreamTests: XCTestCase {
             }
         }
 
-        let bitstreamPath = AbsolutePath(#file).parentDirectory
+        let bitstreamPath = AbsolutePath(path: #file).parentDirectory
             .appending(components: "Inputs", "serialized.dia")
         let contents = try localFileSystem.readFileContents(bitstreamPath)
         var visitor = LoggingVisitor()
@@ -126,7 +126,7 @@ final class BitstreamTests: XCTestCase {
             }
         }
 
-        let bitstreamPath = AbsolutePath(#file).parentDirectory
+        let bitstreamPath = AbsolutePath(path: #file).parentDirectory
             .appending(components: "Inputs", "serialized.dia")
         let contents = try localFileSystem.readFileContents(bitstreamPath)
         var visitor = LoggingVisitor()

--- a/Tests/TSCUtilityTests/PkgConfigParserTests.swift
+++ b/Tests/TSCUtilityTests/PkgConfigParserTests.swift
@@ -18,7 +18,7 @@ import TSCTestSupport
 @available(*, deprecated, message: "moved into SwiftPM")
 final class PkgConfigParserTests: XCTestCase {
     func testCircularPCFile() throws {
-        XCTAssertTrue(try PkgConfig(name: "harfbuzz", additionalSearchPaths: [AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs")], diagnostics: DiagnosticsEngine(), brewPrefix: nil).diagnostics.diagnostics.contains { diagnostic in
+        XCTAssertTrue(try PkgConfig(name: "harfbuzz", additionalSearchPaths: [AbsolutePath(validating: #file).parentDirectory.appending(components: "pkgconfigInputs")], diagnostics: DiagnosticsEngine(), brewPrefix: nil).diagnostics.diagnostics.contains { diagnostic in
             diagnostic.message.text == "circular dependency detected while parsing harfbuzz: harfbuzz -> freetype2 -> harfbuzz"
         })
     }
@@ -107,8 +107,8 @@ final class PkgConfigParserTests: XCTestCase {
             "/usr/lib/pkgconfig/foo.pc",
             "/usr/local/opt/foo/lib/pkgconfig/foo.pc",
             "/custom/foo.pc")
-        XCTAssertEqual("/custom/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [AbsolutePath("/custom")], fileSystem: fs).pathString)
-        XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath("/custom")], diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.pathString)
+        XCTAssertEqual("/custom/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [AbsolutePath(path: "/custom")], fileSystem: fs).pathString)
+        XCTAssertEqual("/custom/foo.pc", try PkgConfig(name: "foo", additionalSearchPaths: [AbsolutePath(path: "/custom")], diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.pathString)
         XCTAssertEqual("/usr/lib/pkgconfig/foo.pc", try PCFileFinder(diagnostics: diagnostics, brewPrefix: nil).locatePCFile(name: "foo", customSearchPaths: [], fileSystem: fs).pathString)
         try withCustomEnv(["PKG_CONFIG_PATH": "/usr/local/opt/foo/lib/pkgconfig"]) {
             XCTAssertEqual("/usr/local/opt/foo/lib/pkgconfig/foo.pc", try PkgConfig(name: "foo", diagnostics: diagnostics, fileSystem: fs, brewPrefix: nil).pcFile.pathString)
@@ -139,7 +139,7 @@ final class PkgConfigParserTests: XCTestCase {
             _ = PCFileFinder(diagnostics: diagnostics, brewPrefix: fakePkgConfig.parentDirectory.parentDirectory)
         }
 
-        XCTAssertEqual(PCFileFinder.pkgConfigPaths, [AbsolutePath("/Volumes/BestDrive/pkgconfig")])
+        XCTAssertEqual(PCFileFinder.pkgConfigPaths, [AbsolutePath(path: "/Volumes/BestDrive/pkgconfig")])
     }
 
     func testAbsolutePathDependency() throws {
@@ -166,10 +166,10 @@ final class PkgConfigParserTests: XCTestCase {
         XCTAssertNoThrow(
             try PkgConfig(
                 name: "gobject-2.0",
-                additionalSearchPaths: [AbsolutePath("/usr/local/opt/glib/lib/pkgconfig")],
+                additionalSearchPaths: [AbsolutePath(path: "/usr/local/opt/glib/lib/pkgconfig")],
                 diagnostics: DiagnosticsEngine(),
                 fileSystem: fileSystem,
-                brewPrefix: AbsolutePath("/usr/local")))
+                brewPrefix: AbsolutePath(path: "/usr/local")))
     }
 
     func testUnevenQuotes() throws {
@@ -182,7 +182,7 @@ final class PkgConfigParserTests: XCTestCase {
     }
 
     private func pcFilePath(_ inputName: String) -> AbsolutePath {
-        return AbsolutePath(#file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
+        return AbsolutePath(path: #file).parentDirectory.appending(components: "pkgconfigInputs", inputName)
     }
 
     private func loadPCFile(_ inputName: String, body: ((PkgConfigParser) -> Void)? = nil) throws {

--- a/Tests/TSCUtilityTests/SerializedDiagnosticsTests.swift
+++ b/Tests/TSCUtilityTests/SerializedDiagnosticsTests.swift
@@ -15,7 +15,7 @@ import TSCUtility
 
 final class SerializedDiagnosticsTests: XCTestCase {
   func testReadSwiftDiagnosticWithNote() throws {
-    let serializedDiagnosticsPath = AbsolutePath(#file).parentDirectory
+    let serializedDiagnosticsPath = AbsolutePath(path: #file).parentDirectory
       .appending(components: "Inputs", "multiblock.dia")
     let contents = try localFileSystem.readFileContents(serializedDiagnosticsPath)
     let serializedDiags = try SerializedDiagnostics(bytes: contents)
@@ -97,7 +97,7 @@ final class SerializedDiagnosticsTests: XCTestCase {
   }
 
   func testReadSwiftSerializedDiags() throws {
-    let serializedDiagnosticsPath = AbsolutePath(#file).parentDirectory
+    let serializedDiagnosticsPath = AbsolutePath(path: #file).parentDirectory
         .appending(components: "Inputs", "serialized.dia")
     let contents = try localFileSystem.readFileContents(serializedDiagnosticsPath)
     let serializedDiags = try SerializedDiagnostics(bytes: contents)
@@ -145,7 +145,7 @@ final class SerializedDiagnosticsTests: XCTestCase {
   }
 
   func testReadDiagsWithNoLocation() throws {
-    let serializedDiagnosticsPath = AbsolutePath(#file).parentDirectory
+    let serializedDiagnosticsPath = AbsolutePath(path: #file).parentDirectory
         .appending(components: "Inputs", "no-location.dia")
     let contents = try localFileSystem.readFileContents(serializedDiagnosticsPath)
     let serializedDiags = try SerializedDiagnostics(bytes: contents)
@@ -164,7 +164,7 @@ final class SerializedDiagnosticsTests: XCTestCase {
   }
 
   func testReadClangSerializedDiags() throws {
-    let serializedDiagnosticsPath = AbsolutePath(#file).parentDirectory
+    let serializedDiagnosticsPath = AbsolutePath(path: #file).parentDirectory
         .appending(components: "Inputs", "clang.dia")
     let contents = try localFileSystem.readFileContents(serializedDiagnosticsPath)
     let serializedDiags = try SerializedDiagnostics(bytes: contents)

--- a/Tests/TSCUtilityTests/SimplePersistenceTests.swift
+++ b/Tests/TSCUtilityTests/SimplePersistenceTests.swift
@@ -32,14 +32,14 @@ fileprivate class Foo: SimplePersistanceProtocol {
 
     func restore(from json: JSON) throws {
         self.int = try json.get("int")
-        self.path = try AbsolutePath(json.get("path"))
+        self.path = try AbsolutePath(validating: json.get("path"))
     }
 
     func restore(from json: JSON, supportedSchemaVersion: Int) throws {
         switch supportedSchemaVersion {
         case 0:
             self.int = try json.get("old_int")
-            self.path = try AbsolutePath(json.get("old_path"))
+            self.path = try AbsolutePath(validating: json.get("old_path"))
         default:
             fatalError()
         }
@@ -119,7 +119,7 @@ class SimplePersistenceTests: XCTestCase {
     func testBasics() throws {
         let fs = InMemoryFileSystem()
         let stateFile = AbsolutePath.root.appending(components: "subdir", "state.json")
-        let foo = Foo(int: 1, path: AbsolutePath("/hello"), fileSystem: fs)
+        let foo = Foo(int: 1, path: AbsolutePath(path: "/hello"), fileSystem: fs)
         // Restoring right now should return false because state is not present.
         XCTAssertFalse(try foo.restore())
 
@@ -133,7 +133,7 @@ class SimplePersistenceTests: XCTestCase {
         foo.int = 5
         XCTAssertTrue(try foo.restore())
         XCTAssertEqual(foo.int, 1)
-        XCTAssertEqual(foo.path, AbsolutePath("/hello"))
+        XCTAssertEqual(foo.path, AbsolutePath(path: "/hello"))
 
         // Modify state's schema version.
         let newJSON = JSON(["version": 2])
@@ -194,14 +194,14 @@ class SimplePersistenceTests: XCTestCase {
                 """
         }
 
-        let foo = Foo(int: 1, path: AbsolutePath("/hello"), fileSystem: fs)
-        XCTAssertEqual(foo.path, AbsolutePath("/hello"))
+        let foo = Foo(int: 1, path: AbsolutePath(path: "/hello"), fileSystem: fs)
+        XCTAssertEqual(foo.path, AbsolutePath(path: "/hello"))
         XCTAssertEqual(foo.int, 1)
 
         // Load from an older but supported schema state file.
         XCTAssertTrue(try foo.restore())
 
-        XCTAssertEqual(foo.path, AbsolutePath("/oldpath"))
+        XCTAssertEqual(foo.path, AbsolutePath(path: "/oldpath"))
         XCTAssertEqual(foo.int, 4)
     }
 }


### PR DESCRIPTION
In support of https://github.com/apple/swift-package-manager/pull/5797