### PR TITLE
Deprecate `BuildFlags` as unused

### DIFF
--- a/Sources/TSCUtility/BuildFlags.swift
+++ b/Sources/TSCUtility/BuildFlags.swift
@@ -12,6 +12,7 @@
 // for BuildSupport style logic yet.
 //
 /// Build-tool independent flags.
+@available(*, deprecated, message: "replace with SwiftPM `PackageModel.BuildFlags`")
 public struct BuildFlags: Encodable {
 
     /// Flags to pass to the C compiler.


### PR DESCRIPTION
Follows up on https://github.com/apple/swift-package-manager/pull/5837.