### PR TITLE
Package.swift: bump `swift-tools-version` to 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 
 /*
  This source file is part of the Swift.org open source project


### PR DESCRIPTION
SwiftPM already requires 5.5, but now with `Sendable` introduced on some TSC types in #361, this is unlikely to compile without errors with Swift 5.4.