### PR TITLE
Build process.c with _GNU_SOURCE

### DIFF
--- a/Sources/TSCclibc/process.c
+++ b/Sources/TSCclibc/process.c
@@ -1,5 +1,9 @@
 #if defined(__linux__)
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* for posix_spawn_file_actions_addchdir_np */
+#endif
+
 #include <errno.h>
 
 #include "process.h"


### PR DESCRIPTION
Otherwise the build will fail on glibc 2.29 and later because posix_spawn_file_actions_addchdir_np is not declared.

A glibc change has been submitted as well, but it will not become available until glibc 2.37:

[PATCH] posix: Make posix_spawn extensions available by default https://sourceware.org/pipermail/libc-alpha/2022-November/143197.html