### PR TITLE
[5.7] allow modificaiton of Git.environemnt (#371)

### DIFF
--- a/Sources/TSCUtility/Git.swift
+++ b/Sources/TSCUtility/Git.swift
@@ -57,6 +57,7 @@ public enum Git {
     }
 
     /// A shell command to run for Git. Can be either a name or a path.
+    ///  - Note: modification is not thread safe, designed for testing only
     public static var tool: String = "git\(executableFileSuffix)"
 
     /// Returns true if the git reference name is well formed.
@@ -69,32 +70,40 @@ public enum Git {
         }
     }
 
+    private static var _gitEnvironment = ProcessInfo.processInfo.environment
+
     /// Returns the environment variables for launching the git subprocess.
     ///
     /// This contains the current environment with custom overrides for using
     /// git from swift build.
+    ///  - Note: modification is not thread safe, designed for testing only
     public static var environment: [String: String] {
-        var env = ProcessInfo.processInfo.environment
+        get {
+            var env = Self._gitEnvironment
 
-        // These variables are inserted into the environment when shelling out
-        // to git if not already present.
-        let underrideVariables =  [
-            // Disable terminal prompts in git. This will make git error out and return
-            // when it needs a user/pass etc instead of hanging the terminal (SR-3981).
-            "GIT_TERMINAL_PROMPT": "0",
+            // These variables are inserted into the environment when shelling out
+            // to git if not already present.
+            let underrideVariables =  [
+                // Disable terminal prompts in git. This will make git error out and return
+                // when it needs a user/pass etc instead of hanging the terminal (SR-3981).
+                "GIT_TERMINAL_PROMPT": "0",
 
-            // The above is env variable is not enough. However, ssh_config's batch
-            // mode is made for this purpose. see: https://linux.die.net/man/5/ssh_config
-            "GIT_SSH_COMMAND": "ssh -oBatchMode=yes",
-        ]
+                // The above is env variable is not enough. However, ssh_config's batch
+                // mode is made for this purpose. see: https://linux.die.net/man/5/ssh_config
+                "GIT_SSH_COMMAND": "ssh -oBatchMode=yes",
+            ]
 
-        for (key, value) in underrideVariables {
-            // Skip this key is already present in the env.
-            if env.keys.contains(key) { continue }
+            for (key, value) in underrideVariables {
+                // Skip this key is already present in the env.
+                if env.keys.contains(key) { continue }
 
-            env[key] = value
+                env[key] = value
+            }
+
+            return env
         }
-
-        return env
+        set {
+            Self._gitEnvironment = newValue
+        }
     }
 }


### PR DESCRIPTION
motivation: enable testing of submodules that requires specialize env variables set

changes: make Git.environemnt mutable for testing
(cherry picked from commit 4cac812e26a1c9ec0379de9ec86c7da2f9e87863)