### PR TITLE
TSCLibc: convert library to static

### DIFF
--- a/Sources/TSCBasic/CMakeLists.txt
+++ b/Sources/TSCBasic/CMakeLists.txt
@@ -57,10 +57,10 @@ target_compile_options(TSCBasic PUBLIC
   # Ignore secure function warnings on Windows.
   "$<$<PLATFORM_ID:Windows>:SHELL:-Xcc -D_CRT_SECURE_NO_WARNINGS>")
 target_link_libraries(TSCBasic PUBLIC
-  SwiftSystem::SystemPackage
-  TSCLibc)
+  SwiftSystem::SystemPackage)
 target_link_libraries(TSCBasic PRIVATE
-   TSCclibc)
+  TSCclibc
+  TSCLibc)
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   if(Foundation_FOUND)
     target_link_libraries(TSCBasic PUBLIC

--- a/Sources/TSCLibc/CMakeLists.txt
+++ b/Sources/TSCLibc/CMakeLists.txt
@@ -6,20 +6,9 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
-add_library(TSCLibc
+add_library(TSCLibc STATIC
   libc.swift)
 
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
-  target_compile_options(TSCLibc PRIVATE
-    -autolink-force-load)
-endif()
 # NOTE(compnerd) workaround for CMake not setting up include flags yet
 set_target_properties(TSCLibc PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-
-install(TARGETS TSCLibc
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
-
-set_property(GLOBAL APPEND PROPERTY TSC_EXPORTS TSCLibc)


### PR DESCRIPTION
This library is mostly unused on other targets outside of the re-export of the C library.  Convert the library to static as it is unused outside of TSCBasic.  This simplifies the redistribution.