### PR TITLE
TSCUtility: deprecate `Platform`

### DIFF
--- a/Sources/TSCUtility/Platform.swift
+++ b/Sources/TSCUtility/Platform.swift
@@ -12,6 +12,7 @@ import TSCBasic
 import Foundation
 
 /// Recognized Platform types.
+@available(*, deprecated, message: "moved to SourceKit-LSP")
 public enum Platform: Equatable {
     case android
     case darwin


### PR DESCRIPTION
This marks the `Platform` type as deprecated.  The functionality has been split up into swift-package-manager and sourcekit-lsp as appropriate.  There remain no users of this at this point.

https://github.com/apple/sourcekit-lsp/pull/686
https://github.com/apple/swift-package-manager/pull/6011