### PR TITLE
more Sendable conformances & Sendable Context

### DIFF
--- a/Sources/TSCBasic/CodableResult.swift
+++ b/Sources/TSCBasic/CodableResult.swift
@@ -49,6 +49,8 @@ public struct CodableResult<Success, Failure>: Codable where Success: Codable, F
     }
 }
 
+extension CodableResult: Sendable where Success: Sendable, Failure: Sendable {}
+
 extension CodableResult where Failure == StringError {
     public init(body: () throws -> Success) {
         do {

--- a/Sources/TSCBasic/Condition.swift
+++ b/Sources/TSCBasic/Condition.swift
@@ -50,3 +50,7 @@ public struct Condition {
         return try body()
     }
 }
+
+#if compiler(>=5.7)
+extension Condition: Sendable {}
+#endif

--- a/Sources/TSCBasic/DeltaAlgorithm.swift
+++ b/Sources/TSCBasic/DeltaAlgorithm.swift
@@ -27,7 +27,7 @@
 /// It is not an error to provide a predicate that does not satisfy these
 /// requirements, and the algorithm will generally produce reasonable results.
 /// However, it may run substantially more tests than with a good predicate.
-public struct DeltaAlgorithm<Change: Hashable> {
+public struct DeltaAlgorithm<Change: Hashable>: Sendable {
 
     public init() {}
 

--- a/Sources/TSCBasic/DiagnosticsEngine.swift
+++ b/Sources/TSCBasic/DiagnosticsEngine.swift
@@ -21,9 +21,9 @@ extension DiagnosticData {
 public protocol DiagnosticLocation: Sendable, CustomStringConvertible {
 }
 
-public struct Diagnostic: CustomStringConvertible {
+public struct Diagnostic: CustomStringConvertible, Sendable {
     /// The behavior associated with this diagnostic.
-    public enum Behavior {
+    public enum Behavior: Sendable {
         /// An error which will halt the operation.
         case error
 
@@ -38,7 +38,7 @@ public struct Diagnostic: CustomStringConvertible {
         case ignored
     }
 
-    public struct Message {
+    public struct Message: Sendable {
         /// The diagnostic's behavior.
         public let behavior: Behavior
 
@@ -191,7 +191,7 @@ extension Diagnostic.Message {
     }
 }
 
-public struct StringDiagnostic: DiagnosticData {
+public struct StringDiagnostic: DiagnosticData, Sendable {
     /// The diagnostic description.
     public let description: String
 

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -13,8 +13,8 @@ import Foundation
 import Dispatch
 import SystemPackage
 
-public struct FileSystemError: Error, Equatable {
-    public enum Kind: Equatable {
+public struct FileSystemError: Error, Equatable, Sendable {
+    public enum Kind: Equatable, Sendable {
         /// Access to the path is denied.
         ///
         /// This is used when an operation cannot be completed because a component of

--- a/Sources/TSCBasic/HashAlgorithms.swift
+++ b/Sources/TSCBasic/HashAlgorithms.swift
@@ -12,7 +12,7 @@
 import CryptoKit
 #endif
 
-public protocol HashAlgorithm {
+public protocol HashAlgorithm: Sendable {
 
     /// Hashes the input bytes, returning the digest.
     ///
@@ -31,7 +31,7 @@ extension HashAlgorithm {
 /// SHA-256 implementation from Secure Hash Algorithm 2 (SHA-2) set of
 /// cryptographic hash functions (FIPS PUB 180-2).
 ///  Uses CryptoKit where available
-public struct SHA256: HashAlgorithm {
+public struct SHA256: HashAlgorithm, Sendable {
     private let underlying: HashAlgorithm
 
     public init() {
@@ -197,7 +197,7 @@ struct InternalSHA256: HashAlgorithm {
 #if canImport(CryptoKit)
 @available(*, deprecated, message: "use SHA256 which abstract over platform differences")
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct CryptoKitSHA256: HashAlgorithm {
+public struct CryptoKitSHA256: HashAlgorithm, Sendable {
     let underlying = _CryptoKitSHA256()
     public init() {}
     public func hash(_ bytes: ByteString) -> ByteString {

--- a/Sources/TSCBasic/KeyedPair.swift
+++ b/Sources/TSCBasic/KeyedPair.swift
@@ -50,3 +50,5 @@ public struct KeyedPair<T, K: Hashable>: Hashable {
         return lhs.key == rhs.key
     }
 }
+
+extension KeyedPair: Sendable where T: Sendable, K: Sendable {}

--- a/Sources/TSCBasic/LazyCache.swift
+++ b/Sources/TSCBasic/LazyCache.swift
@@ -30,6 +30,7 @@ import class Foundation.NSLock
 /// ```
 ///
 /// See: https://bugs.swift.org/browse/SR-1042
+@available(*, deprecated, message: "This implementation does not work -- https://github.com/apple/swift-tools-support-core/issues/385")
 public struct LazyCache<Class, T> {
     // FIXME: It would be nice to avoid a per-instance lock, but this type isn't
     // intended for creating large numbers of instances of. We also really want
@@ -57,3 +58,8 @@ public struct LazyCache<Class, T> {
         }
     }
 }
+
+#if swift(>=5.6)
+@available(*, unavailable) // until https://github.com/apple/swift-tools-support-core/issues/385 is fixed
+extension LazyCache: Sendable {}
+#endif

--- a/Sources/TSCBasic/OrderedDictionary.swift
+++ b/Sources/TSCBasic/OrderedDictionary.swift
@@ -123,3 +123,5 @@ extension OrderedDictionary: RandomAccessCollection {
         return (key, value)
     }
 }
+
+extension OrderedDictionary: Sendable where Key: Sendable, Value: Sendable {}

--- a/Sources/TSCBasic/OrderedSet.swift
+++ b/Sources/TSCBasic/OrderedSet.swift
@@ -128,3 +128,5 @@ public func == <T>(lhs: OrderedSet<T>, rhs: OrderedSet<T>) -> Bool {
 }
 
 extension OrderedSet: Hashable where Element: Hashable { }
+
+extension OrderedSet: Sendable where Element: Sendable { }

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -264,6 +264,8 @@ public struct CodableRange<Bound> where Bound: Comparable & Codable {
     }
 }
 
+extension CodableRange: Sendable where Bound: Sendable {}
+
 extension CodableRange: Codable {
     private enum CodingKeys: String, CodingKey {
         case lowerBound, upperBound

--- a/Sources/TSCUtility/Context.swift
+++ b/Sources/TSCUtility/Context.swift
@@ -9,11 +9,127 @@
 */
 
 import Foundation
+import _Concurrency
 
-/// Typealias for an any typed dictionary for arbitrary usage to store context.
-public typealias Context = [ObjectIdentifier: Any]
+
+public struct Context {
+    private var backing: [ObjectIdentifier: Any] = [:]
+
+#if compiler(>=5.5.2)
+    @available(*, deprecated, message: "Values should be Sendable")
+    @_disfavoredOverload
+    public init(dictionaryLiteral keyValuePairs: (ObjectIdentifier, Any)...) {
+        self.backing = Dictionary(uniqueKeysWithValues: keyValuePairs)
+    }
+
+    public init(dictionaryLiteral keyValuePairs: (ObjectIdentifier, Sendable)...) {
+        self.backing = Dictionary(uniqueKeysWithValues: keyValuePairs)
+    }
+
+    @available(*, deprecated, message: "Values should be Sendable")
+    @_disfavoredOverload
+    public subscript(key: ObjectIdentifier) -> Any? {
+        get {
+            return self.backing[key]
+        }
+        set {
+            self.backing[key] = newValue
+        }
+    }
+
+    public subscript<Value>(key: ObjectIdentifier, as type: Value.Type = Value.self) -> Value? where Value: Sendable {
+        get {
+            return self.backing[key] as? Value
+        }
+        set {
+            self.backing[key] = newValue
+        }
+    }
+#else
+    public init(dictionaryLiteral keyValuePairs: (ObjectIdentifier, Any)...) {
+        self.backing = Dictionary(uniqueKeysWithValues: keyValuePairs)
+    }
+
+    @_disfavoredOverload
+    public subscript(key: ObjectIdentifier) -> Any? {
+        get {
+            return self.backing[key]
+        }
+        set {
+            self.backing[key] = newValue
+        }
+    }
+
+    public subscript<Value>(key: ObjectIdentifier, as type: Value.Type = Value.self) -> Value? {
+        get {
+            return self.backing[key] as? Value
+        }
+        set {
+            self.backing[key] = newValue
+        }
+    }
+#endif
+}
+
+#if compiler(>=5.7)
+extension Context: /* until we can remove the support for 'Any' values */ @unchecked Sendable {}
+#else
+#if compiler(>=5.5.2)
+extension Context: UnsafeSendable {}
+#endif
+#endif
+
+@available(*, deprecated, renamed: "init()")
+extension Context: ExpressibleByDictionaryLiteral {
+    public typealias Key = ObjectIdentifier
+    public typealias Value = Any
+}
 
 extension Context {
+#if compiler(>=5.5.2)
+    /// Get the value for the given type.
+    @available(*, deprecated, message: "Values should be Sendable")
+    @_disfavoredOverload
+    public func get<T>(_ type: T.Type = T.self) -> T {
+        guard let value = getOptional(type) else {
+            fatalError("no type \(T.self) in context")
+        }
+        return value
+    }
+
+    public func get<T: Sendable>(_ type: T.Type = T.self) -> T {
+        guard let value = self.getOptional(type) else {
+            fatalError("no type \(T.self) in context")
+        }
+        return value
+    }
+
+    /// Get the value for the given type, if present.
+    @available(*, deprecated, message: "Values should be Sendable")
+    @_disfavoredOverload
+    public func getOptional<T>(_ type: T.Type = T.self) -> T? {
+        guard let value = self[ObjectIdentifier(T.self)] else {
+            return nil
+        }
+        return value as? T
+    }
+
+    /// Get the value for the given type, if present.
+    public func getOptional<T: Sendable>(_ type: T.Type = T.self) -> T? {
+        return self[ObjectIdentifier(T.self)]
+    }
+
+    /// Set a context value for a type.
+    @available(*, deprecated, message: "Values should be Sendable")
+    @_disfavoredOverload
+    public mutating func set<T>(_ value: T) {
+        self[ObjectIdentifier(T.self)] = value
+    }
+
+    public mutating func set<Value: Sendable>(_ value: Value) {
+        self[ObjectIdentifier(Value.self)] = value
+    }
+#else
     /// Get the value for the given type.
     public func get<T>(_ type: T.Type = T.self) -> T {
         guard let value = getOptional(type) else {
@@ -34,4 +150,5 @@ extension Context {
     public mutating func set<T>(_ value: T) {
         self[ObjectIdentifier(T.self)] = value
     }
+#endif
 }

--- a/Sources/TSCUtility/SerializedDiagnostics.swift
+++ b/Sources/TSCUtility/SerializedDiagnostics.swift
@@ -11,7 +11,7 @@ import Foundation
 import TSCBasic
 
 /// Represents diagnostics serialized in a .dia file by the Swift compiler or Clang.
-public struct SerializedDiagnostics {
+public struct SerializedDiagnostics: Sendable {
   public enum Error: Swift.Error {
     case badMagic
     case unexpectedTopLevelRecord
@@ -61,7 +61,7 @@ extension SerializedDiagnostics.Error: CustomNSError {
 extension SerializedDiagnostics {
   public struct Diagnostic {
 
-    public enum Level: UInt64 {
+    public enum Level: UInt64, Sendable {
       case ignored, note, warning, error, fatal, remark
     }
     /// The diagnostic message text.
@@ -168,7 +168,7 @@ extension SerializedDiagnostics {
     }
   }
 
-  public struct FixIt {
+  public struct FixIt: Sendable {
     /// Start location.
     public var start: SourceLocation
     /// End location.
@@ -177,6 +177,12 @@ extension SerializedDiagnostics {
     public var text: String
   }
 }
+
+#if compiler(>=5.7)
+extension SerializedDiagnostics.Diagnostic: Sendable {}
+#else
+extension SerializedDiagnostics.Diagnostic: UnsafeSendable {}
+#endif
 
 extension SerializedDiagnostics {
   private struct Reader: BitstreamVisitor {

--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -20,7 +20,7 @@ import TSCBasic
 /// @see Destination.target
 /// @see https://github.com/apple/swift-llvm/blob/stable/include/llvm/ADT/Triple.h
 ///
-public struct Triple: Encodable, Equatable {
+public struct Triple: Encodable, Equatable, Sendable {
     public let tripleString: String
 
     public let arch: Arch
@@ -36,7 +36,7 @@ public struct Triple: Encodable, Equatable {
         case unknownOS(os: String)
     }
 
-    public enum Arch: String, Encodable {
+    public enum Arch: String, Encodable, Sendable {
         case x86_64
         case x86_64h
         case i686
@@ -59,12 +59,12 @@ public struct Triple: Encodable, Equatable {
         case mips64el
     }
 
-    public enum Vendor: String, Encodable {
+    public enum Vendor: String, Encodable, Sendable {
         case unknown
         case apple
     }
 
-    public enum OS: String, Encodable, CaseIterable {
+    public enum OS: String, Encodable, CaseIterable, Sendable {
         case darwin
         case macOS = "macosx"
         case linux
@@ -73,7 +73,7 @@ public struct Triple: Encodable, Equatable {
         case openbsd
     }
 
-    public enum ABI: Encodable, Equatable, RawRepresentable {
+    public enum ABI: Encodable, Equatable, RawRepresentable, Sendable {
         case unknown
         case android
         case other(name: String)

--- a/Tests/TSCBasicTests/LazyCacheTests.swift
+++ b/Tests/TSCBasicTests/LazyCacheTests.swift
@@ -13,6 +13,7 @@ import XCTest
 import TSCBasic
 
 class LazyCacheTests: XCTestCase {
+    @available(*, deprecated, message: "LazyCache's implementation is broken -- https://github.com/apple/swift-tools-support-core/issues/385")
     func testBasics() {
         class Foo {
             var numCalls = 0

--- a/Tests/TSCBasicTests/SendableTests.swift
+++ b/Tests/TSCBasicTests/SendableTests.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import _Concurrency
+
+import TSCBasic
+
+final class SendableTests: XCTestCase {
+#if compiler(>=5.5.2)
+    func testByteStringIsSendable() {
+        self.sendableBlackhole(ByteString())
+    }
+
+    // MARK: - Utilities
+    private func sendableBlackhole<T: Sendable>(_ value: T) {}
+#endif
+}

--- a/Tests/TSCUtilityTests/SendableTests.swift
+++ b/Tests/TSCUtilityTests/SendableTests.swift
@@ -1,0 +1,25 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import _Concurrency
+
+import TSCUtility
+
+final class SendableTests: XCTestCase {
+#if compiler(>=5.5.2)
+    func testByteContextIsSendable() {
+        self.sendableBlackhole(Context())
+    }
+
+    // MARK: - Utilities
+    private func sendableBlackhole<T: Sendable>(_ value: T) {}
+#endif
+}


### PR DESCRIPTION
Technically API breaking:

- switches `public typealias Context = Dictionary<...>` for `public struct Context`
- requires `HashingAlgorithm` and `TracingEvent(Collection)` to be `Sendable`