### PR TITLE
TSCBasic: make FS-related value types Sendable

### DIFF
--- a/Sources/TSCBasic/ByteString.swift
+++ b/Sources/TSCBasic/ByteString.swift
@@ -23,7 +23,7 @@ import Foundation
 /// strings or and by eliminating wasted space in growable arrays). For
 /// construction of byte arrays, clients should use the `WritableByteStream` class
 /// and then convert to a `ByteString` when complete.
-public struct ByteString: ExpressibleByArrayLiteral, Hashable {
+public struct ByteString: ExpressibleByArrayLiteral, Hashable, Sendable {
     /// The buffer contents.
     @usableFromInline
     internal var _bytes: [UInt8]

--- a/Sources/TSCBasic/FileInfo.swift
+++ b/Sources/TSCBasic/FileInfo.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+ Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information
@@ -9,6 +9,10 @@
  */
 
 import Foundation
+
+// FIXME: this conformance can be removed when TSC starts requiring more recent versions of the compiler.
+extension FileAttributeType: @unchecked Sendable {}
+extension Date: @unchecked Sendable {}
 
 /// File system information for a particular file.
 public struct FileInfo: Equatable, Codable, Sendable {

--- a/Sources/TSCBasic/FileInfo.swift
+++ b/Sources/TSCBasic/FileInfo.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 /// File system information for a particular file.
-public struct FileInfo: Equatable, Codable {
+public struct FileInfo: Equatable, Codable, Sendable {
 
     /// The device number.
     public let device: UInt64

--- a/Sources/TSCBasic/FileInfo.swift
+++ b/Sources/TSCBasic/FileInfo.swift
@@ -10,9 +10,10 @@
 
 import Foundation
 
-// FIXME: this conformance can be removed when TSC starts requiring more recent versions of the compiler.
-extension FileAttributeType: @unchecked Sendable {}
-extension Date: @unchecked Sendable {}
+#if swift(<5.6)
+extension FileAttributeType: UnsafeSendable {}
+extension Date: UnsafeSendable {}
+#endif
 
 /// File system information for a particular file.
 public struct FileInfo: Equatable, Codable, Sendable {

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -111,9 +111,9 @@ public extension FileSystemError {
 }
 
 /// Defines the file modes.
-public enum FileMode {
+public enum FileMode: Sendable {
 
-    public enum Option: Int {
+    public enum Option: Int, Sendable {
         case recursive
         case onlyFiles
     }
@@ -122,17 +122,17 @@ public enum FileMode {
     case userWritable
     case executable
 
-    internal var setMode: (Int16) -> Int16 {
+    public func setMode(_ originalMode: Int16) -> Int16 {
         switch self {
         case .userUnWritable:
             // r-x rwx rwx
-            return {$0 & 0o577}
+            return originalMode & 0o577
         case .userWritable:
             // -w- --- ---
-            return {$0 | 0o200}
+            return originalMode | 0o200
         case .executable:
             // --x --x --x
-            return {$0 | 0o111}
+            return originalMode | 0o111
         }
     }
 }


### PR DESCRIPTION
When using `FileSystem`-related code in `async` context we need these types to be `Sendable`.