### PR TITLE
TSCBasic: mark `ThreadSafeOutputByteStream` as `Sendable`

### DIFF
--- a/Sources/TSCBasic/WritableByteStream.swift
+++ b/Sources/TSCBasic/WritableByteStream.swift
@@ -348,6 +348,13 @@ public final class ThreadSafeOutputByteStream: WritableByteStream {
     }
 }
 
+
+#if swift(<5.7)
+extension ThreadSafeOutputByteStream: UnsafeSendable {}
+#else
+extension ThreadSafeOutputByteStream: @unchecked Sendable {}
+#endif
+
 /// Define an output stream operator. We need it to be left associative, so we
 /// use `<<<`.
 infix operator <<< : StreamingPrecedence


### PR DESCRIPTION
Since we still have to support Swift 5.5, this is marked as either `UnsafeSendable` or `@unchecked Sendable`, depending on the version of the Swift compiler.