### PR TITLE
Make `PolymorphicCodable` conform to `Sendable`

### DIFF
--- a/Sources/TSCUtility/PolymorphicCodable.swift
+++ b/Sources/TSCUtility/PolymorphicCodable.swift
@@ -42,6 +42,8 @@ public struct PolymorphicCodable<T: PolymorphicCodableProtocol>: Codable {
     }
 }
 
+extension PolymorphicCodable: Sendable where T: Sendable {}
+
 @propertyWrapper
 public struct PolymorphicCodableArray<T: PolymorphicCodableProtocol>: Codable {
     public let value: [PolymorphicCodable<T>]
@@ -54,3 +56,5 @@ public struct PolymorphicCodableArray<T: PolymorphicCodableProtocol>: Codable {
         return value.map{ $0.value }
     }
 }
+
+extension PolymorphicCodableArray: Sendable where T: Sendable {}


### PR DESCRIPTION
This allows making types that use `PolymorphicCodable` and `PolymorphicCodableArray` property wrappers `Sendable`.