### PR TITLE
Make a few diagnostics-related types `Sendable`

### DIFF
--- a/Sources/TSCBasic/DiagnosticsEngine.swift
+++ b/Sources/TSCBasic/DiagnosticsEngine.swift
@@ -11,14 +11,14 @@
 import Dispatch
 
 /// The payload of a diagnostic.
-public protocol DiagnosticData: CustomStringConvertible {
+public protocol DiagnosticData: Sendable, CustomStringConvertible {
 }
 
 extension DiagnosticData {
     public var localizedDescription: String { self.description }
 }
 
-public protocol DiagnosticLocation: CustomStringConvertible {
+public protocol DiagnosticLocation: Sendable, CustomStringConvertible {
 }
 
 public struct Diagnostic: CustomStringConvertible {

--- a/Sources/TSCUtility/SerializedDiagnostics.swift
+++ b/Sources/TSCUtility/SerializedDiagnostics.swift
@@ -149,7 +149,7 @@ extension SerializedDiagnostics {
     }
   }
 
-  public struct SourceLocation: Equatable {
+  public struct SourceLocation: Equatable, Sendable {
     /// The filename associated with the diagnostic.
     public var filename: String
     public var line: UInt64


### PR DESCRIPTION
This makes it easier to migrate more SwiftPM's types to Swift Concurrency.