### PR TITLE
Require a 5.8 compiler to conditionally compile the noasync attribute

### DIFF
--- a/Sources/TSCBasic/Await.swift
+++ b/Sources/TSCBasic/Await.swift
@@ -14,14 +14,14 @@
 ///                   should be passed to the async method's completion handler.
 /// - Returns: The value wrapped by the async method's result.
 /// - Throws: The error wrapped by the async method's result
-#if compiler(>=5.7)
+#if compiler(>=5.8)
 @available(*, noasync)
 #endif
 public func tsc_await<T, ErrorType>(_ body: (@escaping (Result<T, ErrorType>) -> Void) -> Void) throws -> T {
     return try tsc_await(body).get()
 }
 
-#if compiler(>=5.7)
+#if compiler(>=5.8)
 @available(*, noasync)
 #endif
 public func tsc_await<T>(_ body: (@escaping (T) -> Void) -> Void) -> T {

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -835,7 +835,7 @@ public final class Process {
     }
 
     /// Blocks the calling process until the subprocess finishes execution.
-    #if compiler(>=5.7)
+    #if compiler(>=5.8)
     @available(*, noasync)
     #endif
     @discardableResult
@@ -1060,7 +1060,7 @@ extension Process {
     ///   - loggingHandler: Handler for logging messages
     ///   - queue: Queue to use for callbacks
     ///   - completion: A completion handler to return the process result
-    #if compiler(>=5.7)
+    #if compiler(>=5.8)
     @available(*, noasync)
     #endif
     static public func popen(
@@ -1097,7 +1097,7 @@ extension Process {
     ///     will be inherited.
     ///   - loggingHandler: Handler for logging messages
     /// - Returns: The process result.
-    #if compiler(>=5.7)
+    #if compiler(>=5.8)
     @available(*, noasync)
     #endif
     @discardableResult
@@ -1124,7 +1124,7 @@ extension Process {
     ///     will be inherited.
     ///   - loggingHandler: Handler for logging messages
     /// - Returns: The process result.
-    #if compiler(>=5.7)
+    #if compiler(>=5.8)
     @available(*, noasync)
     #endif
     @discardableResult
@@ -1144,7 +1144,7 @@ extension Process {
     ///     will be inherited.
     ///   - loggingHandler: Handler for logging messages
     /// - Returns: The process output (stdout + stderr).
-    #if compiler(>=5.7)
+    #if compiler(>=5.8)
     @available(*, noasync)
     #endif
     @discardableResult
@@ -1176,7 +1176,7 @@ extension Process {
     ///     will be inherited.
     ///   - loggingHandler: Handler for logging messages
     /// - Returns: The process output (stdout + stderr).
-    #if compiler(>=5.7)
+    #if compiler(>=5.8)
     @available(*, noasync)
     #endif
     @discardableResult

--- a/Sources/TSCBasic/ProcessSet.swift
+++ b/Sources/TSCBasic/ProcessSet.swift
@@ -64,7 +64,7 @@ public final class ProcessSet {
     /// Terminate all the processes. This method blocks until all processes in the set are terminated.
     ///
     /// A process set cannot be used once it has been asked to terminate.
-    #if compiler(>=5.7)
+    #if compiler(>=5.8)
     @available(*, noasync)
     #endif
     public func terminate() {

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -479,7 +479,7 @@ fileprivate extension Process {
         self.init(arguments: [Self.script(scriptName)] + arguments, environment: Self.env(), outputRedirection: outputRedirection)
     }
 
-    #if compiler(>=5.7)
+    #if compiler(>=5.8)
     @available(*, noasync)
     #endif
     static func checkNonZeroExit(
@@ -498,7 +498,7 @@ fileprivate extension Process {
         return try await checkNonZeroExit(args: script(scriptName), environment: environment, loggingHandler: loggingHandler)
     }
 
-    #if compiler(>=5.7)
+    #if compiler(>=5.8)
     @available(*, noasync)
     #endif
     @discardableResult


### PR DESCRIPTION
This grammar isn't supported in 5.7.