### PR TITLE
Fix JSONMessageStreamingParser error message formatting

### DIFF
--- a/Sources/TSCUtility/JSONMessageStreamingParser.swift
+++ b/Sources/TSCUtility/JSONMessageStreamingParser.swift
@@ -168,7 +168,8 @@ private extension JSONMessageStreamingParser {
         do {
             return try decoder.decode(Message.self, from: data)
         } catch {
-            throw ParsingError(reason: "unexpected JSON message: \(ByteString(buffer).cString)", underlyingError: error)
+            let message = ByteString(Array(data)).cString
+            throw ParsingError(reason: "unexpected JSON message: \(message)", underlyingError: error)
         }
     }
 }


### PR DESCRIPTION
When json parsing fails in `JSONMessageStreamingParser`, the error thrown was meant to include the message that failed to parse, but it referred to a buffer that had already been cleared by the `buffer.removeAll()` line.

This is especially useful to debug `swiftc` crashes when invoked through `swift build`, where the call stack should be in the JSON message that is not printed between the two colons `: :` :

```
error: failed parsing the Swift compiler output: unexpected JSON message: : dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "kind", intValue: nil)], debugDescription: "invalid kind", underlyingError: nil))