### PR TITLE
TSCUtility: deprecate `Triple` type

### DIFF
--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -20,6 +20,7 @@ import TSCBasic
 /// @see Destination.target
 /// @see https://github.com/apple/swift-llvm/blob/stable/include/llvm/ADT/Triple.h
 ///
+@available(*, deprecated, message: "use `Basics.Triple` if you're libSwiftPM client, create application-specific `Triple` type otherwise")
 public struct Triple: Encodable, Equatable, Sendable {
     public let tripleString: String
 


### PR DESCRIPTION
Since all known major TSC clients define their own `Triple` type or use one from libSwiftPM, it makes sense to deprecate this one.