### PR TITLE
Make `FileSystem` and conforming types as `Sendable`

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -146,7 +146,7 @@ public enum FileMode: Sendable {
 /// substitute a virtual file system or redirect file system operations.
 ///
 /// - Note: All of these APIs are synchronous and can block.
-public protocol FileSystem: AnyObject {
+public protocol FileSystem: AnyObject, Sendable {
     /// Check whether the given path exists and is accessible.
     func exists(_ path: AbsolutePath, followSymlink: Bool) -> Bool
 
@@ -548,8 +548,6 @@ private class LocalFileSystem: FileSystem {
     }
 }
 
-// FIXME: This class does not yet support concurrent mutation safely.
-//
 /// Concrete FileSystem implementation which simulates an empty disk.
 public class InMemoryFileSystem: FileSystem {
 
@@ -1008,6 +1006,9 @@ public class InMemoryFileSystem: FileSystem {
     }
 }
 
+// Internal state of `InMemoryFileSystem` is protected with a lock in all of its `public` methods.
+extension InMemoryFileSystem: @unchecked Sendable {}
+
 /// A rerooted view on an existing FileSystem.
 ///
 /// This is a simple wrapper which creates a new FileSystem view into a subtree
@@ -1159,8 +1160,15 @@ public class RerootedFileSystemView: FileSystem {
     }
 }
 
+// `RerootedFileSystemView` doesn't hold any internal state and can be considered `Sendable` since
+// `underlyingFileSystem` is required to be `Sendable`.
+extension RerootedFileSystemView: @unchecked Sendable {}
+
 /// Public access to the local FS proxy.
 public var localFileSystem: FileSystem = LocalFileSystem()
+
+// `LocalFileSystem` doesn't hold any internal state and all of its underlying operations are blocking.
+extension LocalFileSystem: @unchecked Sendable {}
 
 extension FileSystem {
     /// Print the filesystem tree of the given path.


### PR DESCRIPTION
Types that conform to `FileSystem` either don't have in-memory state to be protected with locks at all and use blocking I/O under the hood (like `LocalFileSystem`), or already protect their state with locks, like `InMemoryFileSystem`. Few other types in SwiftPM conforming to `FileSystem` either also use locks (like `GitFileSystemView`) or are read-only (like `VirtualFileSystem`). I'm convinced that adding a `Sendable` requirement on `FileSystem` is beneficial overall, since it's already passed around between Dispatch queues and other concurrent code that would allow us to resolve sendability warnings.