### PR TITLE
Potential workaround for a CI issue

### DIFF
--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -466,12 +466,7 @@ class ProcessTests: XCTestCase {
 
 fileprivate extension Process {
     private static func env() -> [String:String] {
-        var env = ProcessEnv.vars
-        #if os(macOS)
-        // Many of these tests use Python which might not be in the default `PATH` when running these tests from Xcode.
-        env["PATH"] = "\(env["PATH"] ?? ""):/usr/local/bin"
-        #endif
-        return env
+        return ProcessEnv.vars
     }
 
     private static func script(_ name: String) -> String {

--- a/Tests/TSCBasicTests/processInputs/deadlock-if-blocking-io
+++ b/Tests/TSCBasicTests/processInputs/deadlock-if-blocking-io
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/Tests/TSCBasicTests/processInputs/in-to-out
+++ b/Tests/TSCBasicTests/processInputs/in-to-out
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/Tests/TSCBasicTests/processInputs/long-stdout-stderr
+++ b/Tests/TSCBasicTests/processInputs/long-stdout-stderr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/Tests/TSCBasicTests/processInputs/simple-stdout-stderr
+++ b/Tests/TSCBasicTests/processInputs/simple-stdout-stderr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/Utilities/ci.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Utilities/ci.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,79 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "IndexStoreDB",
+        "repositoryURL": "https://github.com/apple/indexstore-db.git",
+        "state": {
+          "branch": "main",
+          "revision": "89ec16c2ac1bb271614e734a2ee792224809eb20",
+          "version": null
+        }
+      },
+      {
+        "package": "swift-asn1",
+        "repositoryURL": "https://github.com/apple/swift-asn1.git",
+        "state": {
+          "branch": null,
+          "revision": "805deae27a7506dcad043604c00a9dc52d465dcb",
+          "version": "0.7.0"
+        }
+      },
+      {
+        "package": "swift-certificates",
+        "repositoryURL": "https://github.com/apple/swift-certificates.git",
+        "state": {
+          "branch": null,
+          "revision": "54b9711034c0bd9b18f9ac0fb262d493130bcf13",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "swift-crypto",
+        "repositoryURL": "https://github.com/apple/swift-crypto.git",
+        "state": {
+          "branch": null,
+          "revision": "da0fe44138ab86e380f40a2acbd8a611b07d3f64",
+          "version": "2.4.0"
+        }
+      },
+      {
+        "package": "llbuild",
+        "repositoryURL": "https://github.com/apple/swift-llbuild.git",
+        "state": {
+          "branch": "main",
+          "revision": "4cc1ea448e236c2f4dfe622cec786bce4bd56c45",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftSyntax",
+        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "state": {
+          "branch": "main",
+          "revision": "2d5575b8771c5ccd5673428d959085ddb74dbbf7",
+          "version": null
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
+          "version": "1.1.1"
+        }
+      }
+    ]
+  },
+  "version": 1
+}


### PR DESCRIPTION
The macOS CI does not seem to work with Xcode 14.2 as superior, hitting

```
error: Error Domain=NSCocoaErrorDomain Code=4 "The file "swiftpm" doesn't exist." UserInfo={NSFilePath=/Users/ec2-user/jenkins/workspace/pr-swift-tools-support-core-macos/branch-main/swift-tools-support-core/Utilities/ci.xcworkspace/xcshareddata/swiftpm, NSUnderlyingError=0x600000a5a310 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```

I have a theory that this is triggered by us using a workspace that does not contain a resolved file, but that case works for me with SwiftPM 5.9 locally, so not sure.