### PR TITLE
TSCBasic: remove uses of `any` from `FileSystem.swift`

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -1162,10 +1162,10 @@ public final class RerootedFileSystemView: FileSystem {
 // `underlyingFileSystem` is required to be `Sendable`.
 extension RerootedFileSystemView: @unchecked Sendable {}
 
-private var _localFileSystem: any FileSystem = LocalFileSystem()
+private var _localFileSystem: FileSystem = LocalFileSystem()
 
 /// Public access to the local FS proxy.
-public var localFileSystem: any FileSystem {
+public var localFileSystem: FileSystem {
     get {
          return _localFileSystem
     }


### PR DESCRIPTION
In case any of our CI nodes still use older Swift with no support for `any`, it's better to remove this new keyword for now, especially as it has no impact on the behavior.