### PR TITLE
address deprecation warnings

### DIFF
--- a/Sources/TSCUtility/Triple.swift
+++ b/Sources/TSCUtility/Triple.swift
@@ -235,6 +235,7 @@ public struct Triple: Encodable, Equatable, Sendable {
     }
 }
 
+@available(*, deprecated)
 extension Triple {
     /// The file prefix for dynamic libraries
     public var dynamicLibraryPrefix: String {
@@ -290,6 +291,7 @@ extension Triple {
     }
 }
 
+@available(*, deprecated)
 extension Triple.Error: CustomNSError {
     public var errorUserInfo: [String : Any] {
         return [NSLocalizedDescriptionKey: "\(self)"]

--- a/Tests/TSCUtilityTests/PlatformTests.swift
+++ b/Tests/TSCUtilityTests/PlatformTests.swift
@@ -14,6 +14,7 @@ import TSCTestSupport
 
 @testable import TSCUtility
 
+@available(*, deprecated)
 final class PlatformTests: XCTestCase {
     func testFindCurrentPlatformDebian() {
         let fs = InMemoryFileSystem(files: ["/etc/debian_version": "xxx"])

--- a/Tests/TSCUtilityTests/TripleTests.swift
+++ b/Tests/TSCUtilityTests/TripleTests.swift
@@ -11,6 +11,7 @@
 import TSCUtility
 import XCTest
 
+@available(*, deprecated)
 class TripleTests : XCTestCase {
     func testTriple() {
         let linux = try? Triple("x86_64-unknown-linux-gnu")


### PR DESCRIPTION
motivation: less warnings

changes: deprecate Triple related tests and extensions given Triple is deprecated