### PR TITLE
[5.9] Add `hasAttribute` to `FileSystem`

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -138,10 +138,30 @@ public enum FileMode: Sendable {
 }
 
 /// Extended file system attributes that can applied to a given file path. See also ``FileSystem/hasAttribute(_:_:)``.
-public enum FileSystemAttribute: String {
+public enum FileSystemAttribute: RawRepresentable {
     #if canImport(Darwin)
-    case quarantine = "com.apple.quarantine"
+    case quarantine
     #endif
+
+    public init?(rawValue: String) {
+        switch rawValue {
+        #if canImport(Darwin)
+        case "com.apple.quarantine":
+            self = .quarantine
+        #endif
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        #if canImport(Darwin)
+        case .quarantine:
+            return "com.apple.quarantine"
+        #endif
+        }
+    }
 }
 
 // FIXME: Design an asynchronous story?

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -349,7 +349,7 @@ private class LocalFileSystem: FileSystem {
     }
 
     func hasAttribute(name: String, _ path: AbsolutePath) -> Bool {
-#if canImport(Darwin) || canImport(Glibc)
+#if canImport(Darwin)
         let bufLength = getxattr(path.pathString, name, nil, 0, 0, 0)
 
         return bufLength > 0

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -195,6 +195,9 @@ public protocol FileSystem: AnyObject {
     /// Check whether the given path is accessible and writable.
     func isWritable(_ path: AbsolutePath) -> Bool
 
+    @available(*, deprecated, message: "use `hasAttribute(_:_:)` instead")
+    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool
+
     /// Returns `true` if a given path has an attribute with a given name applied when file system supports this
     /// attribute. Returns `false` if such attribute is not applied or it isn't supported.
     func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool
@@ -324,6 +327,8 @@ public extension FileSystem {
     func withLock<T>(on path: AbsolutePath, type: FileLock.LockType, _ body: () throws -> T) throws -> T {
         throw FileSystemError(.unsupported, path)
     }
+
+    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool { false }
 
     func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool { false }
 }

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -168,6 +168,10 @@ public protocol FileSystem: AnyObject {
     /// Check whether the given path is accessible and writable.
     func isWritable(_ path: AbsolutePath) -> Bool
 
+    /// Returns `true` if a given path has a quarantine attribute applied if when file system supports this attribute.
+    /// Returns `false` if such attribute is not applied or it isn't supported.
+    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool
+
     // FIXME: Actual file system interfaces will allow more efficient access to
     // more data than just the name here.
     //
@@ -293,6 +297,8 @@ public extension FileSystem {
     func withLock<T>(on path: AbsolutePath, type: FileLock.LockType, _ body: () throws -> T) throws -> T {
         throw FileSystemError(.unsupported, path)
     }
+
+    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool { false }
 }
 
 /// Concrete FileSystem implementation which communicates with the local file system.
@@ -340,6 +346,16 @@ private class LocalFileSystem: FileSystem {
     func getFileInfo(_ path: AbsolutePath) throws -> FileInfo {
         let attrs = try FileManager.default.attributesOfItem(atPath: path.pathString)
         return FileInfo(attrs)
+    }
+
+    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool {
+#if canImport(Darwin)
+        let bufLength = getxattr(path.pathString, "com.apple.quarantine", nil, 0, 0, 0)
+
+        return bufLength > 0
+#else
+        return false
+#endif
     }
 
     var currentWorkingDirectory: AbsolutePath? {

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -137,6 +137,13 @@ public enum FileMode: Sendable {
     }
 }
 
+/// Extended file system attributes that can applied to a given file path. See also ``FileSystem/hasAttribute(_:_:)``.
+public enum FileSystemAttribute: String {
+    #if canImport(Darwin)
+    case quarantine = "com.apple.quarantine"
+    #endif
+}
+
 // FIXME: Design an asynchronous story?
 //
 /// Abstracted access to file system operations.
@@ -170,7 +177,7 @@ public protocol FileSystem: AnyObject {
 
     /// Returns `true` if a given path has an attribute with a given name applied when file system supports this
     /// attribute. Returns `false` if such attribute is not applied or it isn't supported.
-    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool
+    func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool
 
     // FIXME: Actual file system interfaces will allow more efficient access to
     // more data than just the name here.
@@ -298,7 +305,7 @@ public extension FileSystem {
         throw FileSystemError(.unsupported, path)
     }
 
-    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool { false }
+    func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool { false }
 }
 
 /// Concrete FileSystem implementation which communicates with the local file system.
@@ -348,9 +355,9 @@ private class LocalFileSystem: FileSystem {
         return FileInfo(attrs)
     }
 
-    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool {
+    func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool {
 #if canImport(Darwin)
-        let bufLength = getxattr(path.pathString, name, nil, 0, 0, 0)
+        let bufLength = getxattr(path.pathString, name.rawValue, nil, 0, 0, 0)
 
         return bufLength > 0
 #else

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -168,9 +168,9 @@ public protocol FileSystem: AnyObject {
     /// Check whether the given path is accessible and writable.
     func isWritable(_ path: AbsolutePath) -> Bool
 
-    /// Returns `true` if a given path has a quarantine attribute applied if when file system supports this attribute.
-    /// Returns `false` if such attribute is not applied or it isn't supported.
-    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool
+    /// Returns `true` if a given path has an attribute with a given name applied when file system supports this
+    /// attribute. Returns `false` if such attribute is not applied or it isn't supported.
+    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool
 
     // FIXME: Actual file system interfaces will allow more efficient access to
     // more data than just the name here.
@@ -298,7 +298,7 @@ public extension FileSystem {
         throw FileSystemError(.unsupported, path)
     }
 
-    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool { false }
+    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool { false }
 }
 
 /// Concrete FileSystem implementation which communicates with the local file system.
@@ -348,9 +348,9 @@ private class LocalFileSystem: FileSystem {
         return FileInfo(attrs)
     }
 
-    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool {
-#if canImport(Darwin)
-        let bufLength = getxattr(path.pathString, "com.apple.quarantine", nil, 0, 0, 0)
+    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool {
+#if canImport(Darwin) || canImport(Glibc)
+        let bufLength = getxattr(path.pathString, name, nil, 0, 0, 0)
 
         return bufLength > 0
 #else

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -864,12 +864,11 @@ class FileSystemTests: XCTestCase {
     func testHasAttribute() throws {
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
             let filePath = tempDir.appending(component: "quarantined")
-            let attributeName = "com.apple.quarantine"
             try localFileSystem.writeFileContents(filePath, bytes: "")
-            try Process.checkNonZeroExit(args: "xattr", "-w", attributeName, "foo", filePath.pathString)
-            XCTAssertTrue(localFileSystem.hasAttribute(name: attributeName, filePath))
-            try Process.checkNonZeroExit(args: "xattr", "-d", attributeName, filePath.pathString)
-            XCTAssertFalse(localFileSystem.hasAttribute(name: attributeName, filePath))
+            try Process.checkNonZeroExit(args: "xattr", "-w", FileSystemAttribute.quarantine.rawValue, "foo", filePath.pathString)
+            XCTAssertTrue(localFileSystem.hasAttribute(.quarantine, filePath))
+            try Process.checkNonZeroExit(args: "xattr", "-d", FileSystemAttribute.quarantine.rawValue, filePath.pathString)
+            XCTAssertFalse(localFileSystem.hasAttribute(.quarantine, filePath))
         }
     }
 #endif

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -860,8 +860,8 @@ class FileSystemTests: XCTestCase {
         try _testFileSystemFileLock(fileSystem: fs, fileA: fileA, fileB: fileB, lockFile: lockFile)
     }
 
-#if canImport(Darwin) || canImport(Glibc)
-    func testQuarantineAttribute() throws {
+#if canImport(Darwin)
+    func testHasAttribute() throws {
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
             let filePath = tempDir.appending(component: "quarantined")
             let attributeName = "com.apple.quarantine"

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -860,15 +860,16 @@ class FileSystemTests: XCTestCase {
         try _testFileSystemFileLock(fileSystem: fs, fileA: fileA, fileB: fileB, lockFile: lockFile)
     }
 
-#if canImport(Darwin)
+#if canImport(Darwin) || canImport(Glibc)
     func testQuarantineAttribute() throws {
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
             let filePath = tempDir.appending(component: "quarantined")
+            let attributeName = "com.apple.quarantine"
             try localFileSystem.writeFileContents(filePath, bytes: "")
-            try Process.checkNonZeroExit(args: "xattr", "-w", "com.apple.quarantine", "foo", filePath.pathString)
-            XCTAssertTrue(localFileSystem.hasQuarantineAttribute(filePath))
-            try Process.checkNonZeroExit(args: "xattr", "-d", "com.apple.quarantine", filePath.pathString)
-            XCTAssertFalse(localFileSystem.hasQuarantineAttribute(filePath))
+            try Process.checkNonZeroExit(args: "xattr", "-w", attributeName, "foo", filePath.pathString)
+            XCTAssertTrue(localFileSystem.hasAttribute(name: attributeName, filePath))
+            try Process.checkNonZeroExit(args: "xattr", "-d", attributeName, filePath.pathString)
+            XCTAssertFalse(localFileSystem.hasAttribute(name: attributeName, filePath))
         }
     }
 #endif

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -860,6 +860,19 @@ class FileSystemTests: XCTestCase {
         try _testFileSystemFileLock(fileSystem: fs, fileA: fileA, fileB: fileB, lockFile: lockFile)
     }
 
+#if canImport(Darwin)
+    func testQuarantineAttribute() throws {
+        try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
+            let filePath = tempDir.appending(component: "quarantined")
+            try localFileSystem.writeFileContents(filePath, bytes: "")
+            try Process.checkNonZeroExit(args: "xattr", "-w", "com.apple.quarantine", "foo", filePath.pathString)
+            XCTAssertTrue(localFileSystem.hasQuarantineAttribute(filePath))
+            try Process.checkNonZeroExit(args: "xattr", "-d", "com.apple.quarantine", filePath.pathString)
+            XCTAssertFalse(localFileSystem.hasQuarantineAttribute(filePath))
+        }
+    }
+#endif
+
     private func _testFileSystemFileLock(fileSystem fs: FileSystem, fileA: AbsolutePath, fileB: AbsolutePath, lockFile: AbsolutePath) throws {
         // write initial value, since reader may start before writers and files would not exist
         try fs.writeFileContents(fileA, bytes: "0")


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-tools-support-core/pull/414.

## Motivation

Detecting whether a given absolute path is quarantined is required for giving an actionable error message to SwiftPM users in case a Swift SDK bundle is quarantined.

## Modifications

This new function returns `true` if a given path has an attribute applied when the file system supports this attribute, and returns `false` if such attribute is not applied or it isn't supported.

## Risk

For TSC itself it's an additive change with low to no risk, as updated protocol requirement has a default implementation. This new requirement is also "standalone" as it isn't used in any other TSC function, so it doesn't have any impact on existing code.

rdar://107392863
