### PR TITLE
TSCBasic: deprecate `<<<` operator

### DIFF
--- a/Sources/TSCBasic/DiagnosticsEngine.swift
+++ b/Sources/TSCBasic/DiagnosticsEngine.swift
@@ -148,11 +148,11 @@ public final class DiagnosticsEngine: CustomStringConvertible {
 
     public var description: String {
         let stream = BufferedOutputByteStream()
-        stream <<< "["
+        stream.send("[")
         for diag in diagnostics {
-            stream <<< diag.description <<< ", "
+            stream.send(diag.description).send(", ")
         }
-        stream <<< "]"
+        stream.send("]")
         return stream.bytes.description
     }
 }

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -458,7 +458,7 @@ private struct LocalFileSystem: FileSystem {
                 }
                 break
             }
-            data <<< tmpBuffer[0..<n]
+            data.send(tmpBuffer[0..<n])
         }
 
         return data.bytes

--- a/Sources/TSCBasic/JSON.swift
+++ b/Sources/TSCBasic/JSON.swift
@@ -126,41 +126,41 @@ extension JSON: ByteStreamable {
         let shouldIndent = indent != nil
         switch self {
         case .null:
-            stream <<< "null"
+            stream.send("null")
         case .bool(let value):
-            stream <<< Format.asJSON(value)
+            stream.send(Format.asJSON(value))
         case .int(let value):
-            stream <<< Format.asJSON(value)
+            stream.send(Format.asJSON(value))
         case .double(let value):
             // FIXME: What happens for NaN, etc.?
-            stream <<< Format.asJSON(value)
+            stream.send(Format.asJSON(value))
         case .string(let value):
-            stream <<< Format.asJSON(value)
+            stream.send(Format.asJSON(value))
         case .array(let contents):
-            stream <<< "[" <<< (shouldIndent ? "\n" : "")
+            stream.send("[").send(shouldIndent ? "\n" : "")
             for (i, item) in contents.enumerated() {
-                if i != 0 { stream <<< "," <<< (shouldIndent ? "\n" : " ") }
-                stream <<< indentStreamable(offset: 2)
+                if i != 0 { stream.send(",").send(shouldIndent ? "\n" : " ") }
+                stream.send(indentStreamable(offset: 2))
                 item.write(to: stream, indent: indent.flatMap({ $0 + 2 }))
             }
-            stream <<< (shouldIndent ? "\n" : "") <<< indentStreamable() <<< "]"
+            stream.send(shouldIndent ? "\n" : "").send(indentStreamable()).send("]")
         case .dictionary(let contents):
             // We always output in a deterministic order.
-            stream <<< "{" <<< (shouldIndent ? "\n" : "")
+            stream.send("{").send(shouldIndent ? "\n" : "")
             for (i, key) in contents.keys.sorted().enumerated() {
-                if i != 0 { stream <<< "," <<< (shouldIndent ? "\n" : " ") }
-                stream <<< indentStreamable(offset: 2) <<< Format.asJSON(key) <<< ": "
+                if i != 0 { stream.send(",").send(shouldIndent ? "\n" : " ") }
+                stream.send(indentStreamable(offset: 2)).send(Format.asJSON(key)).send(": ")
                 contents[key]!.write(to: stream, indent: indent.flatMap({ $0 + 2 }))
             }
-            stream <<< (shouldIndent ? "\n" : "") <<< indentStreamable() <<< "}"
+            stream.send(shouldIndent ? "\n" : "").send(indentStreamable()).send("}")
         case .orderedDictionary(let contents):
-            stream <<< "{" <<< (shouldIndent ? "\n" : "")
+            stream.send("{").send(shouldIndent ? "\n" : "")
             for (i, item) in contents.enumerated() {
-                if i != 0 { stream <<< "," <<< (shouldIndent ? "\n" : " ") }
-                stream <<< indentStreamable(offset: 2) <<< Format.asJSON(item.key) <<< ": "
+                if i != 0 { stream.send(",").send(shouldIndent ? "\n" : " ") }
+                stream.send(indentStreamable(offset: 2)).send(Format.asJSON(item.key)).send(": ")
                 item.value.write(to: stream, indent: indent.flatMap({ $0 + 2 }))
             }
-            stream <<< (shouldIndent ? "\n" : "") <<< indentStreamable() <<< "}"
+            stream.send(shouldIndent ? "\n" : "").send(indentStreamable()).send("}")
         }
     }
 }

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -389,7 +389,7 @@ public final class Process {
             outputRedirection: outputRedirection,
             startNewProcessGroup: startNewProcessGroup,
             loggingHandler: verbose ? { message in
-                stdoutStream <<< message <<< "\n"
+                stdoutStream.send(message).send("\n")
                 stdoutStream.flush()
             } : nil
         )
@@ -1276,13 +1276,13 @@ extension ProcessResult.Error: CustomStringConvertible {
             let stream = BufferedOutputByteStream()
             switch result.exitStatus {
             case .terminated(let code):
-                stream <<< "terminated(\(code)): "
+                stream.send("terminated(\(code)): ")
 #if os(Windows)
             case .abnormal(let exception):
-                stream <<< "abnormal(\(exception)): "
+                stream.send("abnormal(\(exception)): ")
 #else
             case .signalled(let signal):
-                stream <<< "signalled(\(signal)): "
+                stream.send("signalled(\(signal)): ")
 #endif
             }
 
@@ -1292,15 +1292,15 @@ extension ProcessResult.Error: CustomStringConvertible {
             if args.first == "sandbox-exec", args.count > 3 {
                 args = args.suffix(from: 3).map({$0})
             }
-            stream <<< args.map({ $0.spm_shellEscaped() }).joined(separator: " ")
+            stream.send(args.map({ $0.spm_shellEscaped() }).joined(separator: " "))
 
             // Include the output, if present.
             if let output = try? result.utf8Output() + result.utf8stderrOutput() {
                 // We indent the output to keep it visually separated from everything else.
                 let indentation = "    "
-                stream <<< " output:\n" <<< indentation <<< output.replacingOccurrences(of: "\n", with: "\n" + indentation)
+                stream.send(" output:\n").send(indentation).send(output.replacingOccurrences(of: "\n", with: "\n" + indentation))
                 if !output.hasSuffix("\n") {
-                    stream <<< "\n"
+                    stream.send("\n")
                 }
             }
 
@@ -1333,7 +1333,7 @@ extension FileHandle: WritableByteStream {
 extension Process {
     @available(*, deprecated)
     fileprivate static func logToStdout(_ message: String) {
-        stdoutStream <<< message <<< "\n"
+        stdoutStream.send(message).send("\n")
         stdoutStream.flush()
     }
 }

--- a/Sources/TSCBasic/TerminalController.swift
+++ b/Sources/TSCBasic/TerminalController.swift
@@ -166,13 +166,13 @@ public final class TerminalController {
 
     /// Clears the current line and moves the cursor to beginning of the line..
     public func clearLine() {
-        stream <<< clearLineString <<< "\r"
+        stream.send(clearLineString).send("\r")
         flush()
     }
 
     /// Moves the cursor y columns up.
     public func moveCursor(up: Int) {
-        stream <<< "\u{001B}[\(up)A"
+        stream.send("\u{001B}[\(up)A")
         flush()
     }
 
@@ -184,7 +184,7 @@ public final class TerminalController {
 
     /// Inserts a new line character into the stream.
     public func endLine() {
-        stream <<< "\n"
+        stream.send("\n")
         flush()
     }
 
@@ -198,9 +198,9 @@ public final class TerminalController {
     private func writeWrapped(_ string: String, inColor color: Color, bold: Bool = false, stream: WritableByteStream) {
         // Don't wrap if string is empty or color is no color.
         guard !string.isEmpty && color != .noColor else {
-            stream <<< string
+            stream.send(string)
             return
         }
-        stream <<< color.string <<< (bold ? boldString : "") <<< string <<< resetString
+        stream.send(color.string).send(bold ? boldString : "").send(string).send(resetString)
     }
 }

--- a/Sources/TSCUtility/ArgumentParser.swift
+++ b/Sources/TSCUtility/ArgumentParser.swift
@@ -955,34 +955,33 @@ public final class ArgumentParser {
         /// Prints an argument on a stream if it has usage.
         func print(formatted argument: String, usage: String, on stream: WritableByteStream) {
             // Start with a new line and add some padding.
-            stream <<< "\n" <<< Format.asRepeating(string: " ", count: padding)
+            stream.send("\n").send(Format.asRepeating(string: " ", count: padding))
             let count = argument.count
             // If the argument is longer than the max width, print the usage
             // on a new line. Otherwise, print the usage on the same line.
             if count >= maxWidth - padding {
-                stream <<< argument <<< "\n"
+                stream.send(argument).send("\n")
                 // Align full width because usage is to be printed on a new line.
-                stream <<< Format.asRepeating(string: " ", count: maxWidth + padding)
+                stream.send(Format.asRepeating(string: " ", count: maxWidth + padding))
             } else {
-                stream <<< argument
+                stream.send(argument)
                 // Align to the remaining empty space on the line.
-                stream <<< Format.asRepeating(string: " ", count: maxWidth - count)
+                stream.send(Format.asRepeating(string: " ", count: maxWidth - count))
             }
-            stream <<< usage
+            stream.send(usage)
         }
 
-        stream <<< "OVERVIEW: " <<< overview
+        stream.send("OVERVIEW: ").send(overview)
 
         if !usage.isEmpty {
-            stream <<< "\n\n"
+            stream.send("\n\n")
             // Get the binary name from command line arguments.
             let defaultCommandName = CommandLine.arguments[0].components(separatedBy: "/").last!
-            stream <<< "USAGE: " <<< (commandName ?? defaultCommandName) <<< " " <<< usage
+            stream.send("USAGE: ").send(commandName ?? defaultCommandName).send(" ").send(usage)
         }
 
         if optionArguments.count > 0 {
-            stream <<< "\n\n"
-            stream <<< "OPTIONS:"
+            stream.send("\n\nOPTIONS:")
             for argument in optionArguments.lazy.sorted(by: { $0.name < $1.name }) {
                 guard let usage = argument.usage else { continue }
                 // Create name with its shortname, if available.
@@ -997,8 +996,7 @@ public final class ArgumentParser {
         }
 
         if subparsers.keys.count > 0 {
-            stream <<< "\n\n"
-            stream <<< "SUBCOMMANDS:"
+            stream.send("\n\nSUBCOMMANDS:")
             for (command, parser) in subparsers.sorted(by: { $0.key < $1.key }) {
                 // Special case for hidden subcommands.
                 guard !parser.overview.isEmpty else { continue }
@@ -1007,8 +1005,7 @@ public final class ArgumentParser {
         }
 
         if positionalArguments.count > 0 {
-            stream <<< "\n\n"
-            stream <<< "POSITIONAL ARGUMENTS:"
+            stream.send("\n\nPOSITIONAL ARGUMENTS:")
             for argument in positionalArguments {
                 guard let usage = argument.usage else { continue }
                 print(formatted: argument.name, usage: usage, on: stream)
@@ -1016,11 +1013,11 @@ public final class ArgumentParser {
         }
         
         if let seeAlso = seeAlso {
-            stream <<< "\n\n"
-            stream <<< "SEE ALSO: \(seeAlso)"
+            stream.send("\n\n")
+            stream.send("SEE ALSO: \(seeAlso)")
         }
         
-        stream <<< "\n"
+        stream.send("\n")
         stream.flush()
     }
 }

--- a/Sources/TSCUtility/Diagnostics.swift
+++ b/Sources/TSCUtility/Diagnostics.swift
@@ -208,9 +208,9 @@ public enum PackageLocation {
         public var description: String {
             let stream = BufferedOutputByteStream()
             if let name = name {
-                stream <<< "'\(name)' "
+                stream.send("'\(name)' ")
             }
-            stream <<< packagePath
+            stream.send(packagePath)
             return stream.bytes.description
         }
     }

--- a/Sources/TSCUtility/ProgressAnimation.swift
+++ b/Sources/TSCUtility/ProgressAnimation.swift
@@ -42,8 +42,8 @@ public final class SingleLinePercentProgressAnimation: ProgressAnimationProtocol
 
     public func update(step: Int, total: Int, text: String) {
         if let header = header, !hasDisplayedHeader {
-            stream <<< header
-            stream <<< "\n"
+            stream.send(header)
+            stream.send("\n")
             stream.flush()
             hasDisplayedHeader = true
         }
@@ -51,7 +51,7 @@ public final class SingleLinePercentProgressAnimation: ProgressAnimationProtocol
         let percentage = step * 100 / total
         let roundedPercentage = Int(Double(percentage / 10).rounded(.down)) * 10
         if percentage != 100, !displayedPercentages.contains(roundedPercentage) {
-            stream <<< String(roundedPercentage) <<< ".. "
+            stream.send(String(roundedPercentage)).send(".. ")
             displayedPercentages.insert(roundedPercentage)
         }
 
@@ -60,7 +60,7 @@ public final class SingleLinePercentProgressAnimation: ProgressAnimationProtocol
 
     public func complete(success: Bool) {
         if success {
-            stream <<< "OK"
+            stream.send("OK")
             stream.flush()
         }
     }
@@ -89,8 +89,8 @@ public final class MultiLineNinjaProgressAnimation: ProgressAnimationProtocol {
 
         guard text != lastDisplayedText else { return }
 
-        stream <<< "[\(step)/\(total)] " <<< text
-        stream <<< "\n"
+        stream.send("[\(step)/\(total)] ").send(text)
+        stream.send("\n")
         stream.flush()
         lastDisplayedText = text
     }
@@ -171,15 +171,15 @@ public final class MultiLinePercentProgressAnimation: ProgressAnimationProtocol 
         assert(step <= total)
 
         if !hasDisplayedHeader, !header.isEmpty {
-            stream <<< header
-            stream <<< "\n"
+            stream.send(header)
+            stream.send("\n")
             stream.flush()
             hasDisplayedHeader = true
         }
 
         let percentage = step * 100 / total
-        stream <<< "\(percentage)%: " <<< text
-        stream <<< "\n"
+        stream.send("\(percentage)%: ").send(text)
+        stream.send("\n")
         stream.flush()
         lastDisplayedText = text
     }

--- a/Tests/TSCBasicPerformanceTests/SHA256PerfTests.swift
+++ b/Tests/TSCBasicPerformanceTests/SHA256PerfTests.swift
@@ -20,7 +20,7 @@ class SHA256PerfTests: XCTestCasePerf {
         let byte = "f"
         let stream = BufferedOutputByteStream()
         for _ in 0..<20000 {
-            stream <<< byte
+            stream.send(byte)
         }
         measure {
             for _ in 0..<1000 {

--- a/Tests/TSCBasicPerformanceTests/WritableByteStreamPerfTests.swift
+++ b/Tests/TSCBasicPerformanceTests/WritableByteStreamPerfTests.swift
@@ -51,7 +51,7 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
             for _ in 0..<10 {
                 let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 16) {
-                    stream <<< sequence
+                    stream.send(sequence)
                 }
                 XCTAssertEqual(stream.bytes.count, 1 << 20)
             }
@@ -66,7 +66,7 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
             for _ in 0..<10 {
                 let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 20) {
-                    stream <<< byte
+                    stream.send(byte)
                 }
                 XCTAssertEqual(stream.bytes.count, 1 << 20)
             }
@@ -80,7 +80,7 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
             for _ in 0..<1 {
                 let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 20) {
-                    stream <<< Character("X")
+                    stream.send(Character("X"))
                 }
                 XCTAssertEqual(stream.bytes.count, 1 << 20)
             }
@@ -97,7 +97,7 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
             for _ in 0..<100 {
                 let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 16) {
-                    stream <<< bytes16
+                    stream.send(bytes16)
                 }
                 XCTAssertEqual(stream.bytes.count, 1 << 20)
             }
@@ -116,7 +116,7 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
             for _ in 0..<100 {
                 let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 16) {
-                    stream <<< bytes16
+                    stream.send(bytes16)
                 }
                 XCTAssertEqual(stream.bytes.count, 1 << 20)
             }
@@ -133,7 +133,7 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
             for _ in 0..<1000 {
                 let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 10) {
-                    stream <<< bytes1k
+                    stream.send(bytes1k)
                 }
                 XCTAssertEqual(stream.bytes.count, 1 << 20)
             }
@@ -150,7 +150,7 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
             for _ in 0..<10 {
                 let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 16) {
-                    stream <<< string16
+                    stream.send(string16)
                 }
                 XCTAssertEqual(stream.bytes.count, 1 << 20)
             }
@@ -167,7 +167,7 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
             for _ in 0..<100 {
                 let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 10) {
-                    stream <<< bytes1k
+                    stream.send(bytes1k)
                 }
                 XCTAssertEqual(stream.bytes.count, 1 << 20)
             }
@@ -206,10 +206,10 @@ class OutputByteStreamPerfTests: XCTestCasePerf {
                 let stream = BufferedOutputByteStream()
                 for _ in 0..<(1 << 10) {
                     for string in listOfStrings {
-                        stream <<< Format.asJSON(string)
+                        stream.send(Format.asJSON(string))
                     }
-                    stream <<< Format.asJSON(listOfStrings)
-                    stream <<< Format.asJSON(listOfThings, transform: { $0.value })
+                    stream.send(Format.asJSON(listOfStrings))
+                    stream.send(Format.asJSON(listOfThings, transform: { $0.value }))
                 }
                 XCTAssertGreaterThan(stream.bytes.count, 1000)
             }

--- a/Tests/TSCBasicTests/ByteStringTests.swift
+++ b/Tests/TSCBasicTests/ByteStringTests.swift
@@ -64,7 +64,7 @@ class ByteStringTests: XCTestCase {
 
     func testByteStreamable() {
         let s = BufferedOutputByteStream()
-        s <<< ByteString([1, 2, 3])
+        s.send(ByteString([1, 2, 3]))
         XCTAssertEqual(s.bytes, [1, 2, 3])
     }
 

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -48,12 +48,12 @@ class FileSystemTests: XCTestCase {
                 let executableSym = tempDirPath.appending(component: "exec-sym")
                 try! fs.createSymbolicLink(executableSym, pointingAt: executable, relative: false)
                 let stream = BufferedOutputByteStream()
-                stream <<< """
+                stream.send("""
                     #!/bin/sh
                     set -e
                     exit
 
-                    """
+                    """)
                 try! fs.writeFileContents(executable, bytes: stream.bytes)
                 try! Process.checkNonZeroExit(args: "chmod", "+x", executable.pathString)
                 XCTAssertTrue(fs.isExecutableFile(executable))

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -50,7 +50,7 @@ class ProcessTests: XCTestCase {
         try withTemporaryFile { file in
             let count = 10_000
             let stream = BufferedOutputByteStream()
-            stream <<< Format.asRepeating(string: "a", count: count)
+            stream.send(Format.asRepeating(string: "a", count: count))
             try localFileSystem.writeFileContents(file.path, bytes: stream.bytes)
             #if os(Windows)
             let cat = "cat.exe"

--- a/Tests/TSCBasicTests/SHA256Tests.swift
+++ b/Tests/TSCBasicTests/SHA256Tests.swift
@@ -32,7 +32,7 @@ class SHA256Tests: XCTestCase {
         let byte = "f"
         let stream = BufferedOutputByteStream()
         for _ in 0..<20000 {
-            stream <<< byte
+            stream.send(byte)
         }
         XCTAssertEqual(sha256.hash(stream.bytes).hexadecimalRepresentation, "23d00697ba26b4140869bab958431251e7e41982794d41b605b6a1d5dee56abf")
     }

--- a/Tests/TSCBasicTests/TemporaryFileTests.swift
+++ b/Tests/TSCBasicTests/TemporaryFileTests.swift
@@ -26,9 +26,9 @@ class TemporaryFileTests: XCTestCase {
 
             // Try writing some data to the file.
             let stream = BufferedOutputByteStream()
-            stream <<< "foo"
-            stream <<< "bar"
-            stream <<< "baz"
+            stream.send("foo")
+            stream.send("bar")
+            stream.send("baz")
             try localFileSystem.writeFileContents(file.path, bytes: stream.bytes)
 
             // Go to the beginning of the file.
@@ -50,9 +50,9 @@ class TemporaryFileTests: XCTestCase {
             
             // Try writing some data to the file.
             let stream = BufferedOutputByteStream()
-            stream <<< "foo"
-            stream <<< "bar"
-            stream <<< "baz"
+            stream.send("foo")
+            stream.send("bar")
+            stream.send("baz")
             try localFileSystem.writeFileContents(file.path, bytes: stream.bytes)
             
             // Go to the beginning of the file.

--- a/Tests/TSCUtilityTests/PkgConfigParserTests.swift
+++ b/Tests/TSCUtilityTests/PkgConfigParserTests.swift
@@ -127,10 +127,10 @@ final class PkgConfigParserTests: XCTestCase {
             try localFileSystem.createDirectory(fakePkgConfig.parentDirectory)
 
             let stream = BufferedOutputByteStream()
-            stream <<< """
+            stream.send("""
             #!/bin/sh
             echo "/Volumes/BestDrive/pkgconfig"
-            """
+            """)
             try localFileSystem.writeFileContents(fakePkgConfig, bytes: stream.bytes)
             // `FileSystem` does not support `chmod` on Linux, so we shell out instead.
             _ = try Process.popen(args: "chmod", "+x", fakePkgConfig.pathString)

--- a/Tests/TSCUtilityTests/SimplePersistenceTests.swift
+++ b/Tests/TSCUtilityTests/SimplePersistenceTests.swift
@@ -183,7 +183,7 @@ class SimplePersistenceTests: XCTestCase {
         let fs = InMemoryFileSystem()
         let stateFile = AbsolutePath.root.appending(components: "subdir", "state.json")
         try fs.writeFileContents(stateFile) {
-            $0 <<< """
+            $0.send("""
                 {
                     "version": 0,
                     "object": {
@@ -191,7 +191,7 @@ class SimplePersistenceTests: XCTestCase {
                         "old_int": 4
                     }
                 }
-                """
+                """)
         }
 
         let foo = Foo(int: 1, path: "/hello", fileSystem: fs)


### PR DESCRIPTION
Since TSCBasic has become a kitchen sink for multiple types and functions, it's important to be able to selectively import those. It is done with `import struct`, `import func`, and similar statements. Unfortunately, this doesn't work for operators, which means you have to import the whole module when you need access just to a single operator. This inadvertently pollutes the environment of available symbols, which is undesirable.

By deprecating the operator and adding a `send(_:)` function on `WritableByteStream` we allow selectively importing this functionality without importing the whole module.

This also brings the API closer to Swift conventions, which in my understanding don't favor use of operators for stream I/O. Looks like `<<<` was initially brought over to TSC as a C++ idiom.