### PR TITLE
Change `hasQuarantineAttribute(_:)` to `hasAttribute(_:_:)`

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -196,6 +196,9 @@ public protocol FileSystem: Sendable {
     /// Check whether the given path is accessible and writable.
     func isWritable(_ path: AbsolutePath) -> Bool
 
+    @available(*, deprecated, message: "use `hasAttribute(_:_:)` instead")
+    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool
+
     /// Returns `true` if a given path has an attribute with a given name applied when file system supports this
     /// attribute. Returns `false` if such attribute is not applied or it isn't supported.
     func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool
@@ -332,6 +335,8 @@ public extension FileSystem {
     func withLock<T>(on path: AbsolutePath, type: FileLock.LockType, _ body: () throws -> T) throws -> T {
         throw FileSystemError(.unsupported, path)
     }
+
+    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool { false }
 
     func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool { false }
 }

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -138,10 +138,30 @@ public enum FileMode: Sendable {
 }
 
 /// Extended file system attributes that can applied to a given file path. See also ``FileSystem/hasAttribute(_:_:)``.
-public enum FileSystemAttribute: String {
+public enum FileSystemAttribute: RawRepresentable {
     #if canImport(Darwin)
-    case quarantine = "com.apple.quarantine"
+    case quarantine
     #endif
+
+    public init?(rawValue: String) {
+        switch rawValue {
+        #if canImport(Darwin)
+        case "com.apple.quarantine":
+            self = .quarantine
+        #endif
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        #if canImport(Darwin)
+        case .quarantine:
+            return "com.apple.quarantine"
+        #endif
+        }
+    }
 }
 
 // FIXME: Design an asynchronous story?

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -137,6 +137,13 @@ public enum FileMode: Sendable {
     }
 }
 
+/// Extended file system attributes that can applied to a given file path. See also ``FileSystem/hasAttribute(_:_:)``.
+public enum FileSystemAttribute: String {
+    #if canImport(Darwin)
+    case quarantine = "com.apple.quarantine"
+    #endif
+}
+
 // FIXME: Design an asynchronous story?
 //
 /// Abstracted access to file system operations.
@@ -171,7 +178,7 @@ public protocol FileSystem: Sendable {
 
     /// Returns `true` if a given path has an attribute with a given name applied when file system supports this
     /// attribute. Returns `false` if such attribute is not applied or it isn't supported.
-    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool
+    func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool
 
     // FIXME: Actual file system interfaces will allow more efficient access to
     // more data than just the name here.
@@ -306,7 +313,7 @@ public extension FileSystem {
         throw FileSystemError(.unsupported, path)
     }
 
-    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool { false }
+    func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool { false }
 }
 
 /// Concrete FileSystem implementation which communicates with the local file system.
@@ -355,9 +362,9 @@ private struct LocalFileSystem: FileSystem {
         return FileInfo(attrs)
     }
 
-    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool {
+    func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool {
 #if canImport(Darwin)
-        let bufLength = getxattr(path.pathString, name, nil, 0, 0, 0)
+        let bufLength = getxattr(path.pathString, name.rawValue, nil, 0, 0, 0)
 
         return bufLength > 0
 #else

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -356,7 +356,7 @@ private struct LocalFileSystem: FileSystem {
     }
 
     func hasAttribute(name: String, _ path: AbsolutePath) -> Bool {
-#if canImport(Darwin) || canImport(Glibc)
+#if canImport(Darwin)
         let bufLength = getxattr(path.pathString, name, nil, 0, 0, 0)
 
         return bufLength > 0

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -169,9 +169,9 @@ public protocol FileSystem: Sendable {
     /// Check whether the given path is accessible and writable.
     func isWritable(_ path: AbsolutePath) -> Bool
 
-    /// Returns `true` if a given path has a quarantine attribute applied if when file system supports this attribute.
-    /// Returns `false` if such attribute is not applied or it isn't supported.
-    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool
+    /// Returns `true` if a given path has an attribute with a given name applied when file system supports this
+    /// attribute. Returns `false` if such attribute is not applied or it isn't supported.
+    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool
 
     // FIXME: Actual file system interfaces will allow more efficient access to
     // more data than just the name here.
@@ -306,7 +306,7 @@ public extension FileSystem {
         throw FileSystemError(.unsupported, path)
     }
 
-    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool { false }
+    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool { false }
 }
 
 /// Concrete FileSystem implementation which communicates with the local file system.
@@ -355,9 +355,9 @@ private struct LocalFileSystem: FileSystem {
         return FileInfo(attrs)
     }
 
-    func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool {
-#if canImport(Darwin)
-        let bufLength = getxattr(path.pathString, "com.apple.quarantine", nil, 0, 0, 0)
+    func hasAttribute(name: String, _ path: AbsolutePath) -> Bool {
+#if canImport(Darwin) || canImport(Glibc)
+        let bufLength = getxattr(path.pathString, name, nil, 0, 0, 0)
 
         return bufLength > 0
 #else

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -864,12 +864,11 @@ class FileSystemTests: XCTestCase {
     func testHasAttribute() throws {
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
             let filePath = tempDir.appending(component: "quarantined")
-            let attributeName = "com.apple.quarantine"
             try localFileSystem.writeFileContents(filePath, bytes: "")
-            try Process.checkNonZeroExit(args: "xattr", "-w", attributeName, "foo", filePath.pathString)
-            XCTAssertTrue(localFileSystem.hasAttribute(name: attributeName, filePath))
-            try Process.checkNonZeroExit(args: "xattr", "-d", attributeName, filePath.pathString)
-            XCTAssertFalse(localFileSystem.hasAttribute(name: attributeName, filePath))
+            try Process.checkNonZeroExit(args: "xattr", "-w", FileSystemAttribute.quarantine.rawValue, "foo", filePath.pathString)
+            XCTAssertTrue(localFileSystem.hasAttribute(.quarantine, filePath))
+            try Process.checkNonZeroExit(args: "xattr", "-d", FileSystemAttribute.quarantine.rawValue, filePath.pathString)
+            XCTAssertFalse(localFileSystem.hasAttribute(.quarantine, filePath))
         }
     }
 #endif

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -860,8 +860,8 @@ class FileSystemTests: XCTestCase {
         try _testFileSystemFileLock(fileSystem: fs, fileA: fileA, fileB: fileB, lockFile: lockFile)
     }
 
-#if canImport(Darwin) || canImport(Glibc)
-    func testQuarantineAttribute() throws {
+#if canImport(Darwin)
+    func testHasAttribute() throws {
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
             let filePath = tempDir.appending(component: "quarantined")
             let attributeName = "com.apple.quarantine"

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -860,15 +860,16 @@ class FileSystemTests: XCTestCase {
         try _testFileSystemFileLock(fileSystem: fs, fileA: fileA, fileB: fileB, lockFile: lockFile)
     }
 
-#if canImport(Darwin)
+#if canImport(Darwin) || canImport(Glibc)
     func testQuarantineAttribute() throws {
         try withTemporaryDirectory(removeTreeOnDeinit: true) { tempDir in
             let filePath = tempDir.appending(component: "quarantined")
+            let attributeName = "com.apple.quarantine"
             try localFileSystem.writeFileContents(filePath, bytes: "")
-            try Process.checkNonZeroExit(args: "xattr", "-w", "com.apple.quarantine", "foo", filePath.pathString)
-            XCTAssertTrue(localFileSystem.hasQuarantineAttribute(filePath))
-            try Process.checkNonZeroExit(args: "xattr", "-d", "com.apple.quarantine", filePath.pathString)
-            XCTAssertFalse(localFileSystem.hasQuarantineAttribute(filePath))
+            try Process.checkNonZeroExit(args: "xattr", "-w", attributeName, "foo", filePath.pathString)
+            XCTAssertTrue(localFileSystem.hasAttribute(name: attributeName, filePath))
+            try Process.checkNonZeroExit(args: "xattr", "-d", attributeName, filePath.pathString)
+            XCTAssertFalse(localFileSystem.hasAttribute(name: attributeName, filePath))
         }
     }
 #endif


### PR DESCRIPTION
Makes the attribute reading API more generic as discussed at https://github.com/apple/swift-tools-support-core/pull/412#discussion_r1173788109