### PR TITLE
Update requirements in `Package.swift` to match SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.7
 
 /*
  This source file is part of the Swift.org open source project
@@ -18,7 +18,7 @@ let macOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTTSC_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
-    macOSPlatform = .macOS(.v10_13)
+    macOSPlatform = .macOS("12.0")
 }
 
 let CMakeFiles = ["CMakeLists.txt"]
@@ -27,6 +27,7 @@ let package = Package(
     name: "swift-tools-support-core",
     platforms: [
         macOSPlatform,
+        .iOS("15.0")
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let macOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTTSC_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
-    macOSPlatform = .macOS("12.0")
+    macOSPlatform = .macOS(.v12)
 }
 
 let CMakeFiles = ["CMakeLists.txt"]
@@ -27,7 +27,7 @@ let package = Package(
     name: "swift-tools-support-core",
     platforms: [
         macOSPlatform,
-        .iOS("15.0")
+        .iOS(.v15)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let macOSPlatform: SupportedPlatform
 if let deploymentTarget = ProcessInfo.processInfo.environment["SWIFTTSC_MACOS_DEPLOYMENT_TARGET"] {
     macOSPlatform = .macOS(deploymentTarget)
 } else {
-    macOSPlatform = .macOS(.v12)
+    macOSPlatform = .macOS(.v10_15)
 }
 
 let CMakeFiles = ["CMakeLists.txt"]


### PR DESCRIPTION
We no longer support Swift 5.5 and older versions of macOS with SwiftPM, makes sense to bring TSC requirements in line with that.