### PR TITLE
TSCBasic: normalise the drive letter spelling on Windows

### DIFF
--- a/Sources/TSCBasic/Path.swift
+++ b/Sources/TSCBasic/Path.swift
@@ -501,7 +501,13 @@ private struct WindowsPath: Path, Sendable {
     }
 
     init(string: String) {
-        self.string = string
+        if string.first?.isASCII ?? false, string.first?.isLetter ?? false, string.first?.isLowercase ?? false,
+           string.count > 1, string[string.index(string.startIndex, offsetBy: 1)] == ":"
+        {
+            self.string = "\(string.first!.uppercased())\(string.dropFirst(1))"
+        } else {
+            self.string = string
+        }
     }
 
     private static func repr(_ path: String) -> String {

--- a/Tests/TSCBasicTests/PathTests.swift
+++ b/Tests/TSCBasicTests/PathTests.swift
@@ -404,4 +404,19 @@ class PathTests: XCTestCase {
     // FIXME: We also need tests for dirname, basename, suffix, etc.
 
     // FIXME: We also need test for stat() operations.
+
+    #if os(Windows)
+    func testNormalization() {
+        XCTAssertEqual(
+            AbsolutePath(#"C:\Users\compnerd\AppData\Local\Programs\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe"#)
+                .pathString,
+            #"C:\Users\compnerd\AppData\Local\Programs\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe"#
+        )
+        XCTAssertEqual(
+            AbsolutePath(#"c:\Users\compnerd\AppData\Local\Programs\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe"#)
+                .pathString,
+            #"C:\Users\compnerd\AppData\Local\Programs\Swift\Toolchains\0.0.0+Asserts\usr\bin\swiftc.exe"#
+        )
+    }
+    #endif
 }


### PR DESCRIPTION
Windows normalises the drive letter to an uppercase letter.  However, some environments (e.g. nodejs) use the lower case spelling.  This results in a path spelling difference which triggers a rebuild in the case that the LSP is running within VSCode.

Normalise the spelling to the upper case always when building an `AbsolutePath`.

Based on a patch by Ami Fischman!