### PR TITLE
Add support for Musl libc

### DIFF
--- a/Sources/TSCBasic/WritableByteStream.swift
+++ b/Sources/TSCBasic/WritableByteStream.swift
@@ -66,7 +66,7 @@ public extension WritableByteStream {
 // Public alias to the old name to not introduce API compatibility.
 public typealias OutputByteStream = WritableByteStream
 
-#if os(Android)
+#if os(Android) || canImport(Musl)
 public typealias FILEPointer = OpaquePointer
 #else
 public typealias FILEPointer = UnsafeMutablePointer<FILE>

--- a/Sources/TSCLibc/libc.swift
+++ b/Sources/TSCLibc/libc.swift
@@ -10,6 +10,8 @@
 
 #if canImport(Glibc)
 @_exported import Glibc
+#elseif canImport(Musl)
+@_exported import Musl
 #elseif os(Windows)
 @_exported import CRT
 @_exported import WinSDK

--- a/Sources/TSCUtility/IndexStore.swift
+++ b/Sources/TSCUtility/IndexStore.swift
@@ -457,7 +457,7 @@ private struct _DLOpenFlags: RawRepresentable, OptionSet {
     public static let deepBind: _DLOpenFlags = _DLOpenFlags(rawValue: 0)
   #else
     public static let first: _DLOpenFlags = _DLOpenFlags(rawValue: 0)
-  #if os(Linux)
+  #if os(Linux) && canImport(Glibc)
     public static let deepBind: _DLOpenFlags = _DLOpenFlags(rawValue: RTLD_DEEPBIND)
   #else
     public static let deepBind: _DLOpenFlags = _DLOpenFlags(rawValue: 0)

--- a/Sources/TSCUtility/InterruptHandler.swift
+++ b/Sources/TSCUtility/InterruptHandler.swift
@@ -8,6 +8,8 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
+#if !canImport(Musl)
+
 import TSCLibc
 import TSCBasic
 
@@ -135,3 +137,5 @@ public final class InterruptHandler {
         thread.join()
     }
 }
+
+#endif

--- a/Sources/TSCUtility/dlopen.swift
+++ b/Sources/TSCUtility/dlopen.swift
@@ -66,7 +66,7 @@ public struct DLOpenFlags: RawRepresentable, OptionSet {
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)
   #else
     public static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
-  #if os(Linux)
+  #if os(Linux) && canImport(Glibc)
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: RTLD_DEEPBIND)
   #else
     public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires a different import, which now should be applied to files that have `import Glibc` in them.