### PR TITLE
TSCBasic: honour `workingDirectory` on Windows' `Process` management

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -529,6 +529,9 @@ public final class Process {
         let process = Foundation.Process()
         _process = process
         process.arguments = Array(arguments.dropFirst()) // Avoid including the executable URL twice.
+        if let workingDirectory {
+            process.currentDirectoryURL = workingDirectory.asURL
+        }
         process.executableURL = executablePath.asURL
         process.environment = environment
 


### PR DESCRIPTION
If `workingdirectory` is set, ensure that it is honoured when creating the process.  This repairs a previous test failure in SPM.