### PR TITLE
TSCTestSupport: account for `:` in function names

### DIFF
--- a/Sources/TSCTestSupport/misc.swift
+++ b/Sources/TSCTestSupport/misc.swift
@@ -33,6 +33,7 @@ public func testWithTemporaryDirectory(
         .replacingOccurrences(of: "(", with: "")
         .replacingOccurrences(of: ")", with: "")
         .replacingOccurrences(of: ".", with: "")
+        .replacingOccurrences(of: ":", with: "_")
     try withTemporaryDirectory(prefix: "spm-tests-\(cleanedFunction)") { tmpDirPath in
         defer {
             // Unblock and remove the tmp dir on deinit.


### PR DESCRIPTION
Windows does not permit `:` in the file names.  Substitute `:` with `_` to permit tests to execute on Windows.