### PR TITLE
Use `URL.resourceValues()` for symlink detection

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -370,8 +370,10 @@ private struct LocalFileSystem: FileSystem {
     }
 
     func isSymlink(_ path: AbsolutePath) -> Bool {
-        let attrs = try? FileManager.default.attributesOfItem(atPath: path.pathString)
-        return attrs?[.type] as? FileAttributeType == .typeSymbolicLink
+        let url = NSURL(fileURLWithPath: path.pathString)
+        // We are intentionally using `NSURL.resourceValues(forKeys:)` here since it improves performance on Darwin platforms.
+        let result = try? url.resourceValues(forKeys: [.isSymbolicLinkKey])
+        return (result?[.isSymbolicLinkKey] as? Bool) == true
     }
 
     func isReadable(_ path: AbsolutePath) -> Bool {


### PR DESCRIPTION
This should provide a significant performance improvement on macOS. See [this](https://github.com/apple/swift-tools-support-core/pull/400#issuecomment-1618933610) for more discussion on non-macOS platforms.