### PR TITLE
[5.9] [FileSystem] Add API for obtaining item replacement directory

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -195,6 +195,10 @@ public protocol FileSystem: AnyObject {
     /// Check whether the given path is accessible and writable.
     func isWritable(_ path: AbsolutePath) -> Bool
 
+    /// Returns any known item replacement directories for a given path. These may be used by platform-specific
+    /// libraries to handle atomic file system operations, such as deletion.
+    func itemReplacementDirectories(for path: AbsolutePath) throws -> [AbsolutePath]
+
     @available(*, deprecated, message: "use `hasAttribute(_:_:)` instead")
     func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool
 
@@ -331,6 +335,8 @@ public extension FileSystem {
     func hasQuarantineAttribute(_ path: AbsolutePath) -> Bool { false }
 
     func hasAttribute(_ name: FileSystemAttribute, _ path: AbsolutePath) -> Bool { false }
+
+    func itemReplacementDirectories(for path: AbsolutePath) throws -> [AbsolutePath] { [] }
 }
 
 /// Concrete FileSystem implementation which communicates with the local file system.
@@ -593,6 +599,13 @@ private class LocalFileSystem: FileSystem {
 
     func withLock<T>(on path: AbsolutePath, type: FileLock.LockType = .exclusive, _ body: () throws -> T) throws -> T {
         try FileLock.withLock(fileToLock: path, type: type, body: body)
+    }
+
+    func itemReplacementDirectories(for path: AbsolutePath) throws -> [AbsolutePath] {
+        let result = try FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: path.asURL, create: false)
+        let path = try AbsolutePath(validating: result.path)
+        // Foundation returns a path that is unique every time, so we return both that path, as well as its parent.
+        return [path, path.parentDirectory]
     }
 }
 


### PR DESCRIPTION
This is used by many Foundation methods that take an `atomically` parameter and we need to expose this in order to allow sandboxes processes to write to it.

(cherry picked from commit 7963ebc2377a0d8cc42a40e020c3448ee0fb1a3c)