### PR TITLE
Fix close error message

### DIFF
--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -349,7 +349,7 @@ extension SystemError: CustomStringConvertible {
             return "chdir error: \(strerror(errno)): \(path)"
         case .close(let err):
             let errorMessage: String
-            if err == -1 { // if the return code is -1, we need to  consult the global `errno`
+            if err == -1 { // if the return code is -1, we need to consult the global `errno`
                 errorMessage = strerror(errno)
             } else {
                 errorMessage = strerror(err)

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -347,8 +347,14 @@ extension SystemError: CustomStringConvertible {
         switch self {
         case .chdir(let errno, let path):
             return "chdir error: \(strerror(errno)): \(path)"
-        case .close(let errno):
-            return "close error: \(strerror(errno))"
+        case .close(let err):
+            let errorMessage: String
+            if err == -1 { // if the return code is -1, we need to  consult the global `errno`
+                errorMessage = strerror(errno)
+            } else {
+                errorMessage = strerror(err)
+            }
+            return "close error: \(errorMessage)"
         case .exec(let errno, let path, let args):
             let joinedArgs = args.joined(separator: " ")
             return "exec error: \(strerror(errno)): \(path) \(joinedArgs)"


### PR DESCRIPTION
From the macOS manpage:

> Upon successful completion, a value of 0 is returned.  Otherwise, a value
> of -1 is returned and the global integer variable errno is set to
> indicate the error.

I'm not certain whether the existing code may be there for cross-platform support, so I changed it to check for -1 and only then consult the global `errno`. This should preserve existing behavior if there's a cross-platform angle here.

rdar://117861543