### PR TITLE
Enable use of `Foundation.Process` on non-Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,6 +75,9 @@ let package = Package(
             cxxSettings: [
               .define("_CRT_SECURE_NO_WARNINGS", .when(platforms: [.windows])),
             ],
+            swiftSettings: [
+              .define("USE_FOUNDATION")
+            ],
             linkerSettings: [
               .linkedLibrary("Pathcch", .when(platforms: [.windows])),
             ]),


### PR DESCRIPTION
This gets us close to passing `ProcessTests` on macOS with two issues remaining:

- `testSignals(): XCTAssertEqual failed: ("signalled(signal: 15)") is not equal to ("signalled(signal: 9)")`
- semi-frequent hangs in the tests

Note: `USE_FOUNDATION` is enabled unconditionally via the package manifest right now, we probably need to change that.