### PR TITLE
Android: add better nullability checks for nullability annotations added in NDK 26

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -490,8 +490,7 @@ private struct LocalFileSystem: FileSystem {
 
     func readFileContents(_ path: AbsolutePath) throws -> ByteString {
         // Open the file.
-        let fp = fopen(path.pathString, "rb")
-        if fp == nil {
+        guard let fp = fopen(path.pathString, "rb") else {
             throw FileSystemError(errno: errno, path)
         }
         defer { fclose(fp) }
@@ -520,8 +519,7 @@ private struct LocalFileSystem: FileSystem {
 
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString) throws {
         // Open the file.
-        let fp = fopen(path.pathString, "wb")
-        if fp == nil {
+        guard let fp = fopen(path.pathString, "wb") else {
             throw FileSystemError(errno: errno, path)
         }
         defer { fclose(fp) }

--- a/Sources/TSCBasic/Process/Process.swift
+++ b/Sources/TSCBasic/Process/Process.swift
@@ -191,6 +191,9 @@ public final class Process {
 
         /// The current OS does not support the workingDirectory API.
         case workingDirectoryNotSupported
+
+        /// The stdin could not be opened.
+        case stdinUnavailable
     }
 
     public enum OutputRedirection {
@@ -697,7 +700,10 @@ public final class Process {
         var stdinPipe: [Int32] = [-1, -1]
         try open(pipe: &stdinPipe)
 
-        let stdinStream = try LocalFileOutputByteStream(filePointer: fdopen(stdinPipe[1], "wb"), closeOnDeinit: true)
+        guard let fp = fdopen(stdinPipe[1], "wb") else {
+            throw Process.Error.stdinUnavailable
+        }
+        let stdinStream = try LocalFileOutputByteStream(filePointer: fp, closeOnDeinit: true)
 
         // Dupe the read portion of the remote to 0.
         posix_spawn_file_actions_adddup2(&fileActions, stdinPipe[0], 0)
@@ -1376,6 +1382,8 @@ extension Process.Error: CustomStringConvertible {
             return "could not find executable for '\(program)'"
         case .workingDirectoryNotSupported:
             return "workingDirectory is not supported in this platform"
+        case .stdinUnavailable:
+            return "could not open stdin on this platform"
         }
     }
 }

--- a/Sources/TSCBasic/WritableByteStream.swift
+++ b/Sources/TSCBasic/WritableByteStream.swift
@@ -790,7 +790,7 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     override final func writeImpl(_ bytes: ArraySlice<UInt8>) {
         bytes.withUnsafeBytes { bytesPtr in
             while true {
-                let n = fwrite(bytesPtr.baseAddress, 1, bytesPtr.count, filePointer)
+                let n = fwrite(bytesPtr.baseAddress!, 1, bytesPtr.count, filePointer)
                 if n < 0 {
                     if errno == EINTR { continue }
                     errorDetected(code: errno)

--- a/Sources/TSCTestSupport/PseudoTerminal.swift
+++ b/Sources/TSCTestSupport/PseudoTerminal.swift
@@ -24,7 +24,7 @@ public final class PseudoTerminal {
         if openpty(&primary, &secondary, nil, nil, nil) != 0 {
             return nil
         }
-        guard let outStream = try? LocalFileOutputByteStream(filePointer: fdopen(secondary, "w"), closeOnDeinit: false) else {
+        guard let outStream = try? LocalFileOutputByteStream(filePointer: fdopen(secondary, "w")!, closeOnDeinit: false) else {
             return nil
         }
         self.outStream = outStream

--- a/Tests/TSCBasicTests/PathShimTests.swift
+++ b/Tests/TSCBasicTests/PathShimTests.swift
@@ -39,7 +39,7 @@ class WalkTests : XCTestCase {
         var expected: [AbsolutePath] = [
             "\(root)/usr",
             "\(root)/bin",
-            "\(root)/xbin"
+            "\(root)/etc"
         ]
       #else
         let root = ""


### PR DESCRIPTION
This is needed because [Bionic recently added a bunch of these annotations](https://android.googlesource.com/platform/bionic/+/00a3dbaab65a7d628312fd67099c662942b1d45f%5E%21/#F0). I made sure this pull doesn't break anything by testing it on linux x86_64 and with the previous NDK 25c also. I used this patch with others to build the Swift toolchain for my Android CI, finagolfin/swift-android-sdk#122, and [the Termux app for Android](https://github.com/termux/termux-packages/commit/d10fd452662d3c39c0f19a901433bce8711b4688#diff-b8f3b540c354923485cb06eba2d66237536f89e88fd51e170495ddd8f5d32622R208), which now uses NDK 26b.