### PR TITLE
build: allow building in Debug mode on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,21 @@
+
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 cmake_minimum_required(VERSION 3.19)
 
 project(SwiftTSC LANGUAGES C Swift)
 
 set(CMAKE_Swift_LANGUAGE_VERSION 5)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+# TODO: lift this restriction once we have a split Swift runtime build which can
+# be built with a debug C runtime.
+set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 
+# TODO: lift this restriction once we have a split Swift runtime build which can
+# be built with a debug C runtime.
+set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
With this tweak, we should be able to build the package in debug mode
even on Windows.  We always use the release mode DLL form of the C/C++
runtime on Windows and can build the Swift code in Debug or Release mode
optimizations.