### PR TITLE
Call chdir to change working directory in older versions of glibc

### DIFF
--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -726,12 +726,13 @@ public final class Process {
         }
         let argv = CStringArray(resolvedArgs)
         let env = CStringArray(environment.map({ "\($0.0)=\($0.1)" }))
-        let rv = switch spawnFunc {
+        let rv: Int32
+        switch spawnFunc {
         case .posix_spawn:
-            posix_spawnp(&processID, argv.cArray[0]!, &fileActions, &attributes, argv.cArray, env.cArray)
+            rv = posix_spawnp(&processID, argv.cArray[0]!, &fileActions, &attributes, argv.cArray, env.cArray)
         case .fork_exec(let workingDirectory):
           #if os(Linux)
-            SPM_fork_exec_chdir(&processID, workingDirectory, argv.cArray[0]!, argv.cArray, env.cArray, &stdinPipe, &outputPipe, &stderrPipe, outputRedirection.redirectsOutput, outputRedirection.redirectStderr)
+            rv = SPM_fork_exec_chdir(&processID, workingDirectory, argv.cArray[0]!, argv.cArray, env.cArray, &stdinPipe, &outputPipe, &stderrPipe, outputRedirection.redirectsOutput, outputRedirection.redirectStderr)
           #else
             throw Process.Error.workingDirectoryNotSupported
           #endif

--- a/Sources/TSCBasic/Process.swift
+++ b/Sources/TSCBasic/Process.swift
@@ -730,7 +730,11 @@ public final class Process {
         case .posix_spawn:
             posix_spawnp(&processID, argv.cArray[0]!, &fileActions, &attributes, argv.cArray, env.cArray)
         case .fork_exec(let workingDirectory):
+          #if os(Linux)
             SPM_fork_exec_chdir(&processID, workingDirectory, argv.cArray[0]!, argv.cArray, env.cArray, &stdinPipe, &outputPipe, &stderrPipe, outputRedirection.redirectsOutput, outputRedirection.redirectStderr)
+          #else
+            throw Process.Error.workingDirectoryNotSupported
+          #endif
         }
         
         guard rv == 0 else {

--- a/Sources/TSCclibc/include/process.h
+++ b/Sources/TSCclibc/include/process.h
@@ -9,4 +9,8 @@ int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restric
 // Runtime check for the availability of posix_spawn_file_actions_addchdir_np. Returns 0 if the method is available, -1 if not.
 bool SPM_posix_spawn_file_actions_addchdir_np_supported();
 
+// Alternative for posix_spawn_file_actions_addchdir_np on Linux that mimics its behavior using fork, exec*, and chdir.
+int SPM_fork_exec_chdir(pid_t *pid, const char *target_directory, const char *cmd, char *const argv[], char *const envp[],
+                        int in_pipe[], int out_pipe[], int err_pipe[], bool redirect_out, bool redirect_err);
+
 #endif

--- a/Sources/TSCclibc/process.c
+++ b/Sources/TSCclibc/process.c
@@ -5,7 +5,10 @@
 #endif
 
 #include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
+#include <sys/wait.h>
 
 #include "process.h"
 
@@ -14,8 +17,7 @@ int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restric
 #  if __GLIBC_PREREQ(2, 29)
     return posix_spawn_file_actions_addchdir_np(file_actions, path);
 #  else
-    // Change working directory which child process will inherit
-    return chdir(path);
+    return ENOSYS;
 #  endif
 #else
     return ENOSYS;
@@ -24,10 +26,71 @@ int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restric
 
 bool SPM_posix_spawn_file_actions_addchdir_np_supported() {
 #if defined(__GLIBC__)
+#  if __GLIBC_PREREQ(2, 29)
     return true;
+#  else
+    return false;
+#  endif
 #else
     return false;
 #endif
+}
+
+int SPM_fork_exec_chdir(pid_t *pid, const char *cwd,
+                        const char *cmd, char *const argv[], char *const envp[],
+                        int in_pipe[], int out_pipe[], int err_pipe[], bool redirect_out, bool redirect_err) {
+    *pid = fork();
+
+    if (*pid < 0) {
+        perror("fork() failed");
+        _exit(EXIT_FAILURE);
+    } else if (*pid > 0) { // Parent process
+        // Wait for child process to finish
+        int status;
+        waitpid(*pid, &status, 0);
+        return status;
+    } else { // Child process
+        // Change working directory then execute cmd
+        if (chdir(cwd)) {
+            _exit(EXIT_FAILURE);
+        }
+        
+        // Replicate pipe logic in TSCBasic.Process.launch()
+        
+        // Dupe the read portion of the remote to 0.
+        dup2(in_pipe[0], 0);
+        // Close the other side's pipe since it was duped to 0.
+        close(in_pipe[0]);
+        close(in_pipe[1]);
+        
+        if (redirect_out) {
+            // Open the write end of the pipe.
+            dup2(out_pipe[1], 1);
+            // Close the other ends of the pipe since they were duped to 1.
+            close(out_pipe[0]);
+            close(out_pipe[1]);
+            
+            if (redirect_err) {
+                // If merged was requested, send stderr to stdout.
+                dup2(1, 2);
+            } else {
+                // If no redirect was requested, open the pipe for stderr.
+                dup2(err_pipe[1], 2);
+                // Close the other ends of the pipe since they were dupped to 2.
+                close(err_pipe[0]);
+                close(err_pipe[1]);
+            }
+        } else {
+            dup2(1, 1);
+            dup2(2, 2);
+        }
+
+        execve(cmd, argv, envp);
+        
+        // If execve returns, it must have failed.
+        perror(cmd);
+        _exit(EXIT_FAILURE);
+    }
 }
 
 #endif

--- a/Sources/TSCclibc/process.c
+++ b/Sources/TSCclibc/process.c
@@ -5,6 +5,7 @@
 #endif
 
 #include <errno.h>
+#include <unistd.h>
 
 #include "process.h"
 
@@ -13,7 +14,8 @@ int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restric
 #  if __GLIBC_PREREQ(2, 29)
     return posix_spawn_file_actions_addchdir_np(file_actions, path);
 #  else
-    return ENOSYS;
+    // Change working directory which child process will inherit
+    return chdir(path);
 #  endif
 #else
     return ENOSYS;
@@ -22,11 +24,7 @@ int SPM_posix_spawn_file_actions_addchdir_np(posix_spawn_file_actions_t *restric
 
 bool SPM_posix_spawn_file_actions_addchdir_np_supported() {
 #if defined(__GLIBC__)
-#  if __GLIBC_PREREQ(2, 29)
     return true;
-#  else
-    return false;
-#  endif
 #else
     return false;
 #endif


### PR DESCRIPTION
Motivation:
`SPM_posix_spawn_file_actions_addchdir_np_supported` and `SPM_posix_spawn_file_actions_addchdir_np` simply return error for glibc versions < 2.29. This causes SwiftPM tools such as `swift package-registry publish` to be unusable on Amazon Linux 2, which has an older version of glibc installed.

Modifications:
For older versions of glibc, call `chdir` to change working directory as an alternative to `posix_spawn_file_actions_addchdir_np`. This way child process will inherit the working directory path.