### PR TITLE
Add `ProcessEnvironment` type to replace `ProcessEnv`

### DIFF
--- a/Sources/TSCBasic/Process/ProcessEnvironment.swift
+++ b/Sources/TSCBasic/Process/ProcessEnvironment.swift
@@ -1,0 +1,51 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2023 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import class Foundation.ProcessInfo
+
+public struct ProcessEnvironment: Sendable {
+    private(set) var storage = [String: String]()
+
+    public private(set) subscript(_ key: String) -> String? {
+        get {
+            #if os(Windows)
+            storage[key.lowercased()]
+            #else
+            storage[key]
+            #endif
+        }
+        set {
+            #if os(Windows)
+            storage[key.lowercased()] = newValue
+            #else
+            storage[key] = newValue
+            #endif
+        }
+    }
+
+    /// `PATH` variable in the process's environment (`Path` under Windows).
+    public var path: String? {
+        self["PATH"]
+    }
+
+    public static var current: ProcessEnvironment {
+        .init(ProcessInfo.processInfo.environment)
+    }
+}
+
+extension ProcessEnvironment {
+    public init(_ storage: [String : String]) {
+        var result = ProcessEnvironment()
+        for (key, value) in storage {
+            result[key] = value
+        }
+        self = result
+    }
+}

--- a/Sources/TSCBasic/Process/ProcessSet.swift
+++ b/Sources/TSCBasic/Process/ProcessSet.swift
@@ -19,6 +19,7 @@ public enum ProcessSetError: Swift.Error {
 /// A process set is a small wrapper for collection of processes.
 /// 
 /// This class is thread safe.
+@available(*, deprecated, message: "Use `TaskGroup` with async `Process` APIs instead")
 public final class ProcessSet {
 
     /// Array to hold the processes.

--- a/Tests/TSCBasicTests/ProcessSetTests.swift
+++ b/Tests/TSCBasicTests/ProcessSetTests.swift
@@ -14,6 +14,7 @@ import TSCLibc
 import TSCUtility
 import TSCTestSupport
 
+@available(*, deprecated)
 class ProcessSetTests: XCTestCase {
   #if !os(Windows) // Signals are not supported in Windows
     func script(_ name: String) -> String {

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -183,6 +183,7 @@ class ProcessTests: XCTestCase {
     }
 
   #if !os(Windows) // Signals are not supported in Windows
+    @available(*, deprecated)
     func testSignals() throws {
         let processes  = ProcessSet()
         let group = DispatchGroup()


### PR DESCRIPTION
`ProcessEnvironment` through subscript access guarantees that its `storage` is always normalized to lowercase keys when needed on Windows.