### PR TITLE
TSCBasic: deprecate `ProcessSet`

### DIFF
--- a/Sources/TSCBasic/Process/ProcessSet.swift
+++ b/Sources/TSCBasic/Process/ProcessSet.swift
@@ -19,6 +19,7 @@ public enum ProcessSetError: Swift.Error {
 /// A process set is a small wrapper for collection of processes.
 /// 
 /// This class is thread safe.
+@available(*, deprecated, message: "Use `TaskGroup` with async `Process` APIs instead")
 public final class ProcessSet {
 
     /// Array to hold the processes.

--- a/Tests/TSCBasicTests/ProcessSetTests.swift
+++ b/Tests/TSCBasicTests/ProcessSetTests.swift
@@ -14,6 +14,7 @@ import TSCLibc
 import TSCUtility
 import TSCTestSupport
 
+@available(*, deprecated)
 class ProcessSetTests: XCTestCase {
   #if !os(Windows) // Signals are not supported in Windows
     func script(_ name: String) -> String {

--- a/Tests/TSCBasicTests/ProcessTests.swift
+++ b/Tests/TSCBasicTests/ProcessTests.swift
@@ -183,6 +183,7 @@ class ProcessTests: XCTestCase {
     }
 
   #if !os(Windows) // Signals are not supported in Windows
+    @available(*, deprecated)
     func testSignals() throws {
         let processes  = ProcessSet()
         let group = DispatchGroup()


### PR DESCRIPTION
Redirect users to use `TaskGroup` instead of the `ProcessSet` API.