### PR TITLE
Fix use of `errno` in `SystemError`

### DIFF
--- a/Sources/TSCBasic/Process/Process.swift
+++ b/Sources/TSCBasic/Process/Process.swift
@@ -1362,7 +1362,7 @@ private func close(fd: Int32) throws {
     func innerClose(_ fd: inout Int32) throws {
         let rv = TSCLibc.close(fd)
         guard rv == 0 else {
-            throw SystemError.close(rv)
+            throw SystemError.close(errno)
         }
     }
     var innerFd = fd

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -347,14 +347,8 @@ extension SystemError: CustomStringConvertible {
         switch self {
         case .chdir(let errno, let path):
             return "chdir error: \(strerror(errno)): \(path)"
-        case .close(let err):
-            let errorMessage: String
-            if err == -1 { // if the return code is -1, we need to consult the global `errno`
-                errorMessage = strerror(errno)
-            } else {
-                errorMessage = strerror(err)
-            }
-            return "close error: \(errorMessage)"
+        case .close(let errno):
+            return "close error: \(strerror(errno))"
         case .exec(let errno, let path, let args):
             let joinedArgs = args.joined(separator: " ")
             return "exec error: \(strerror(errno)): \(path) \(joinedArgs)"

--- a/Sources/TSCUtility/InterruptHandler.swift
+++ b/Sources/TSCUtility/InterruptHandler.swift
@@ -88,7 +88,7 @@ public final class InterruptHandler {
         // Create pipe.
         let rv = TSCLibc.pipe(&Self.signalWatchingPipe)
         guard rv == 0 else {
-            throw SystemError.pipe(rv)
+            throw SystemError.pipe(errno)
         }
       #endif
 


### PR DESCRIPTION
Calling `errno` inside `SystemError.description()` is far too late and will almost certainly return the wrong error number. Instead, pass the `errno` at the throw site, which is consistent with how most of the other `SystemError` throws work.