### PR TITLE
TSCBasic: fix race condition causing close errors

### DIFF
--- a/Sources/TSCBasic/Process/Process.swift
+++ b/Sources/TSCBasic/Process/Process.swift
@@ -702,10 +702,6 @@ public final class Process {
         // Dupe the read portion of the remote to 0.
         posix_spawn_file_actions_adddup2(&fileActions, stdinPipe[0], 0)
 
-        // Close the other side's pipe since it was dupped to 0.
-        posix_spawn_file_actions_addclose(&fileActions, stdinPipe[0])
-        posix_spawn_file_actions_addclose(&fileActions, stdinPipe[1])
-
         var outputPipe: [Int32] = [-1, -1]
         var stderrPipe: [Int32] = [-1, -1]
         if outputRedirection.redirectsOutput {
@@ -715,10 +711,6 @@ public final class Process {
             // Open the write end of the pipe.
             posix_spawn_file_actions_adddup2(&fileActions, outputPipe[1], 1)
 
-            // Close the other ends of the pipe since they were dupped to 1.
-            posix_spawn_file_actions_addclose(&fileActions, outputPipe[0])
-            posix_spawn_file_actions_addclose(&fileActions, outputPipe[1])
-
             if outputRedirection.redirectStderr {
                 // If merged was requested, send stderr to stdout.
                 posix_spawn_file_actions_adddup2(&fileActions, 1, 2)
@@ -726,10 +718,6 @@ public final class Process {
                 // If no redirect was requested, open the pipe for stderr.
                 try open(pipe: &stderrPipe)
                 posix_spawn_file_actions_adddup2(&fileActions, stderrPipe[1], 2)
-
-                // Close the other ends of the pipe since they were dupped to 2.
-                posix_spawn_file_actions_addclose(&fileActions, stderrPipe[0])
-                posix_spawn_file_actions_addclose(&fileActions, stderrPipe[1])
             }
         } else {
             posix_spawn_file_actions_adddup2(&fileActions, 1, 1)
@@ -1351,9 +1339,20 @@ private func WTERMSIG(_ status: Int32) -> Int32 {
 
 /// Open the given pipe.
 private func open(pipe: inout [Int32]) throws {
-    let rv = TSCLibc.pipe(&pipe)
+    var rv = TSCLibc.pipe(&pipe)
     guard rv == 0 else {
-        throw SystemError.pipe(rv)
+        throw SystemError.pipe(errno)
+    }
+
+    rv = TSCLibc.fcntl(pipe[0], F_SETFD, FD_CLOEXEC)
+    if rv == 0 {
+       rv = TSCLibc.fcntl(pipe[1], F_SETFD, FD_CLOEXEC)
+    }
+    guard rv != -1 else {
+        let err = errno
+        TSCLibc.close(pipe[0])
+        TSCLibc.close(pipe[1])
+        throw SystemError.fcntl(errno)
     }
 }
 

--- a/Sources/TSCBasic/misc.swift
+++ b/Sources/TSCBasic/misc.swift
@@ -298,6 +298,7 @@ public enum SystemError: Error {
     case close(Int32)
     case exec(Int32, path: String, args: [String])
     case pipe(Int32)
+    case fcntl(Int32)
     case posix_spawn(Int32, [String])
     case read(Int32)
     case setenv(Int32, String)
@@ -360,6 +361,8 @@ extension SystemError: CustomStringConvertible {
             return "exec error: \(strerror(errno)): \(path) \(joinedArgs)"
         case .pipe(let errno):
             return "pipe error: \(strerror(errno))"
+        case .fcntl(let errno):
+            return "fcntl error: \(strerror(errno))"
         case .posix_spawn(let errno, let args):
             return "posix_spawn error: \(strerror(errno)), `\(args)`"
         case .read(let errno):


### PR DESCRIPTION
When compiling SwiftPM (via `swift-bootstrap`), I was very consistently getting a "close error" that would break the compile.

This appears to be a race condition as it only happens with overlapping `popen` calls, likely from the subprocess in the 2nd `popen` call inheriting all the pipe file descriptors from the previous `popen` call.

What seemed to fix it for me is instead of manually closing all pipes in the subprocess, we instead set `O_CLOEXEC` on the pipe - this will apply to all subprocesses so concurrent `popen` calls are no longer a concern.

It appears this issue may have popped up before but wasn't tracked down fully: #143 (indeed stdin seemed to be the one that would always error for me), #439 and friends.