### PR TITLE
[5.10] Android: add better nullability checks for nullability annotations added in NDK 26 (#444)

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -491,8 +491,7 @@ private struct LocalFileSystem: FileSystem {
 
     func readFileContents(_ path: AbsolutePath) throws -> ByteString {
         // Open the file.
-        let fp = fopen(path.pathString, "rb")
-        if fp == nil {
+        guard let fp = fopen(path.pathString, "rb") else {
             throw FileSystemError(errno: errno, path)
         }
         defer { fclose(fp) }
@@ -521,8 +520,7 @@ private struct LocalFileSystem: FileSystem {
 
     func writeFileContents(_ path: AbsolutePath, bytes: ByteString) throws {
         // Open the file.
-        let fp = fopen(path.pathString, "wb")
-        if fp == nil {
+        guard let fp = fopen(path.pathString, "wb") else {
             throw FileSystemError(errno: errno, path)
         }
         defer { fclose(fp) }

--- a/Sources/TSCBasic/WritableByteStream.swift
+++ b/Sources/TSCBasic/WritableByteStream.swift
@@ -790,7 +790,7 @@ public final class LocalFileOutputByteStream: FileOutputByteStream {
     override final func writeImpl(_ bytes: ArraySlice<UInt8>) {
         bytes.withUnsafeBytes { bytesPtr in
             while true {
-                let n = fwrite(bytesPtr.baseAddress, 1, bytesPtr.count, filePointer)
+                let n = fwrite(bytesPtr.baseAddress!, 1, bytesPtr.count, filePointer)
                 if n < 0 {
                     if errno == EINTR { continue }
                     errorDetected(code: errno)

--- a/Sources/TSCTestSupport/PseudoTerminal.swift
+++ b/Sources/TSCTestSupport/PseudoTerminal.swift
@@ -24,7 +24,7 @@ public final class PseudoTerminal {
         if openpty(&primary, &secondary, nil, nil, nil) != 0 {
             return nil
         }
-        guard let outStream = try? LocalFileOutputByteStream(filePointer: fdopen(secondary, "w"), closeOnDeinit: false) else {
+        guard let outStream = try? LocalFileOutputByteStream(filePointer: fdopen(secondary, "w")!, closeOnDeinit: false) else {
             return nil
         }
         self.outStream = outStream

--- a/Tests/TSCBasicTests/PathShimTests.swift
+++ b/Tests/TSCBasicTests/PathShimTests.swift
@@ -39,7 +39,7 @@ class WalkTests : XCTestCase {
         var expected: [AbsolutePath] = [
             "\(root)/usr",
             "\(root)/bin",
-            "\(root)/xbin"
+            "\(root)/etc"
         ]
       #else
         let root = ""


### PR DESCRIPTION
Cherrypick of #444

__Explanation:__ These null checks allow this repo to compile against the latest versions of Bionic and glibc, apple/swift#70647, plus this fixes one test for Android.

__Scope:__ small fixes to check or unwrap optionals

__Issue:__ apple/swift#70647

__Risk:__ low, usually safer

__Testing:__ Passed all CI on trunk

__Reviewer:__ @neonichu

I wasn't planning on submitting these Bionic fixes for 5.10, but once I saw that they help with the latest glibc too, I figured we should get it in.