### PR TITLE
[5.10] Fix filesystem test on macOS

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -104,6 +104,8 @@ public extension FileSystemError {
             self.init(.noEntry, path)
         case TSCLibc.ENOTDIR:
             self.init(.notDirectory, path)
+        case TSCLibc.EEXIST:
+            self.init(.alreadyExistsAtDestination, path)
         default:
             self.init(.ioError(code: errno), path)
         }

--- a/Tests/TSCBasicTests/FileSystemTests.swift
+++ b/Tests/TSCBasicTests/FileSystemTests.swift
@@ -331,7 +331,13 @@ class FileSystemTests: XCTestCase {
                 _ = try fs.readFileContents(root)
 
             }
-            XCTAssertThrows(FileSystemError(.isDirectory, root)) {
+            #if os(macOS)
+            // Newer versions of macOS end up with `EEXISTS` instead of `EISDIR` here.
+            let expectedError = FileSystemError(.alreadyExistsAtDestination, root)
+            #else
+            let expectedError = FileSystemError(.isDirectory, root)
+            #endif
+            XCTAssertThrows(expectedError) {
                 try fs.writeFileContents(root, bytes: [])
             }
             XCTAssert(fs.exists(filePath))


### PR DESCRIPTION
* **Explanation**:  It looks like we end up with `EEXISTS` here on newer versions of macOS.
* **Scope**: Any test runs on macOS will fail because of this issue.
* **Risk**: Low, it doesn't impact existing file system error handling.
* **Testing**: This new file system error case is specifically handled in tests.
* **Reviewer**: @neonichu 
* **Main branch PR**: https://github.com/apple/swift-tools-support-core/pull/460