### PR TITLE
Small cleanup to non-block based `FileLock` API

### DIFF
--- a/Sources/TSCBasic/Lock.swift
+++ b/Sources/TSCBasic/Lock.swift
@@ -77,7 +77,7 @@ public final class FileLock {
     /// Create an instance of FileLock at the path specified
     ///
     /// Note: The parent directory path should be a valid directory.
-    public init(at lockFile: AbsolutePath) {
+    internal init(at lockFile: AbsolutePath) {
         self.lockFile = lockFile
     }
 
@@ -191,7 +191,7 @@ public final class FileLock {
         return try await body()
     }
 
-    private static func prepareLock(
+    public static func prepareLock(
         fileToLock: AbsolutePath,
         at lockFilesDirectory: AbsolutePath? = nil
     ) throws -> FileLock {

--- a/Tests/TSCBasicTests/LockTests.swift
+++ b/Tests/TSCBasicTests/LockTests.swift
@@ -10,7 +10,7 @@
 
 import XCTest
 
-import TSCBasic
+@testable import TSCBasic
 import TSCTestSupport
 
 class LockTests: XCTestCase {


### PR DESCRIPTION
It doesn't seem like we should be giving access to the arbitrary initializer and instead vend `prepareLock` publicly.