### PR TITLE
Put cursor at the end of last line for lit progress animation

### DIFF
--- a/Sources/TSCUtility/ProgressAnimation.swift
+++ b/Sources/TSCUtility/ProgressAnimation.swift
@@ -217,6 +217,8 @@ public final class RedrawingLitProgressAnimation: ProgressAnimationProtocol {
             terminal.write(header, inColor: .cyan, bold: true)
             terminal.endLine()
             hasDisplayedHeader = true
+        } else {
+            terminal.moveCursor(up: 1)
         }
 
         terminal.clearLine()
@@ -240,8 +242,6 @@ public final class RedrawingLitProgressAnimation: ProgressAnimationProtocol {
         } else {
             terminal.write(text)
         }
-
-        terminal.moveCursor(up: 1)
     }
 
     public func complete(success: Bool) {


### PR DESCRIPTION
The cursor was placed at the middle of the first progress line, and it makes the progress bar line too flickering (it's just my feeling). Also the last `Testing ` line was not printed when `Ctrl+C` signal is sent.

https://github.com/apple/swift-tools-support-core/assets/11702759/5c371ed4-1564-4a24-9ee4-59692fe99b30

