### PR TITLE
Add `ThrottledProgressAnimation` to avoid too frequent animation updates

### DIFF
--- a/Sources/TSCUtility/ProgressAnimation.swift
+++ b/Sources/TSCUtility/ProgressAnimation.swift
@@ -10,6 +10,8 @@
 
 import TSCBasic
 
+import _Concurrency
+
 /// A protocol to operate on terminal based progress animations.
 public protocol ProgressAnimationProtocol {
     /// Update the animation with a new step.
@@ -293,6 +295,59 @@ public class DynamicProgressAnimation: ProgressAnimationProtocol {
     }
 
     public func complete(success: Bool) {
+        animation.complete(success: success)
+    }
+
+    public func clear() {
+        animation.clear()
+    }
+}
+
+/// A progress animation wrapper that throttles updates to a given interval.
+@available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+public class ThrottledProgressAnimation: ProgressAnimationProtocol {
+    private let animation: ProgressAnimationProtocol
+    private let shouldUpdate: () -> Bool
+    private var pendingUpdate: (Int, Int, String)?
+
+    public convenience init(_ animation: ProgressAnimationProtocol, interval: ContinuousClock.Duration) {
+        self.init(animation, clock: ContinuousClock(), interval: interval)
+    }
+
+    public convenience init<C: Clock>(_ animation: ProgressAnimationProtocol, clock: C, interval: C.Duration) {
+        self.init(animation, now: { clock.now }, interval: interval, clock: C.self)
+    }
+
+    init<C: Clock>(
+      _ animation: ProgressAnimationProtocol,
+      now: @escaping () -> C.Instant, interval: C.Duration, clock: C.Type = C.self
+    ) {
+        self.animation = animation
+        var lastUpdate: C.Instant?
+        self.shouldUpdate = {
+            let now = now()
+            if let lastUpdate = lastUpdate, now < lastUpdate.advanced(by: interval) {
+                return false
+            }
+            // If we're over the interval or it's the first update, should update.
+            lastUpdate = now
+            return true
+        }
+    }
+
+    public func update(step: Int, total: Int, text: String) {
+        guard shouldUpdate() else {
+            pendingUpdate = (step, total, text)
+            return
+        }
+        pendingUpdate = nil
+        animation.update(step: step, total: total, text: text)
+    }
+
+    public func complete(success: Bool) {
+        if let (step, total, text) = pendingUpdate {
+            animation.update(step: step, total: total, text: text)
+        }
         animation.complete(success: success)
     }
 


### PR DESCRIPTION
Too frequent updates to the progress animation can cause flickering and can prevent kernel from reflecting the terminal size change on `ioctl`.

This PR introduces a new ProgressAnimation class `ThrottledProgressAnimation`, which throttles update frequency of underlying animation.

This will be used by https://github.com/apple/swift-package-manager/pull/7315 to throttle too frequent `URLSession`'s delegation calls.