### PR TITLE
Implement `Codable` for `ProcessEnvironmentKey`

### DIFF
--- a/Sources/TSCBasic/Process/ProcessEnv.swift
+++ b/Sources/TSCBasic/Process/ProcessEnv.swift
@@ -18,6 +18,20 @@ public struct ProcessEnvironmentKey {
   }
 }
 
+extension ProcessEnvironmentKey: Encodable {
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.value)
+    }
+}
+
+extension ProcessEnvironmentKey: Decodable {
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.value = try container.decode(String.self)
+    }
+}
+
 extension ProcessEnvironmentKey: Equatable {
   public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
     #if os(Windows)

--- a/Tests/TSCBasicTests/ProcessEnvTests.swift
+++ b/Tests/TSCBasicTests/ProcessEnvTests.swift
@@ -8,13 +8,13 @@
  See http://swift.org/CONTRIBUTORS.txt for Swift project authors
  */
 
+import Foundation
 import XCTest
 
 import TSCBasic
 import TSCTestSupport
 
 class ProcessEnvTests: XCTestCase {
-
     func testEnvVars() throws {
         let key = "SWIFTPM_TEST_FOO"
         XCTAssertEqual(ProcessEnv.vars[key], nil)
@@ -63,5 +63,15 @@ class ProcessEnvTests: XCTestCase {
         #else
         XCTAssertNotEqual(ProcessEnvironmentKey("Key"), "KEY")
         #endif
+    }
+
+    func testEnvironmentKeysCodable() throws {
+        let encoder = JSONEncoder()
+        let json = try encoder.encode(ProcessEnvironmentKey("foo"))
+        XCTAssertEqual(String(decoding: json, as: UTF8.self), #""foo""#)
+
+        let decoder = JSONDecoder()
+        let result = try decoder.decode(ProcessEnvironmentKey.self, from: json)
+        XCTAssertEqual(result, ProcessEnvironmentKey("foo"))
     }
 }


### PR DESCRIPTION
The `Job` type in the `apple/swift-driver` repository conforms to `Codable` and also stores process environment in its properties. Lack of `Codable` conformance on `ProcessEnvironmentKey` prevents us from migrating `Job` to `ProcessEnvironmentBlock`.