### PR TITLE
Revert "Update `Git` type for `ProcessEnvironmentBlock`"

### DIFF
--- a/Sources/TSCUtility/Git.swift
+++ b/Sources/TSCUtility/Git.swift
@@ -11,7 +11,51 @@
 import class Foundation.ProcessInfo
 import TSCBasic
 
+extension Version {
+    // FIXME: deprecate 2/2021 (used below), remove once clients transitioned
+    @available(*, deprecated, message: "moved to SwiftPM")
+    init?(tag: String) {
+        if tag.first == "v" {
+            self.init(string: String(tag.dropFirst()))
+        } else {
+            self.init(string: tag)
+        }
+    }
+}
+
 public enum Git {
+    // FIXME: deprecate 2/2021, remove once clients transitioned
+    @available(*, deprecated, message: "moved to SwiftPM")
+    public static func convertTagsToVersionMap(_ tags: [String]) -> [Version: [String]] {
+        // First, check if we need to restrict the tag set to version-specific tags.
+        var knownVersions: [Version: [String]] = [:]
+        var versionSpecificKnownVersions: [Version: [String]] = [:]
+
+        for tag in tags {
+            for versionSpecificKey in Versioning.currentVersionSpecificKeys {
+                if tag.hasSuffix(versionSpecificKey) {
+                    let trimmedTag = String(tag.dropLast(versionSpecificKey.count))
+                    if let version = Version(tag: trimmedTag) {
+                        versionSpecificKnownVersions[version, default: []].append(tag)
+                    }
+                    break
+                }
+            }
+            
+            if let version = Version(tag: tag) {
+                knownVersions[version, default: []].append(tag)
+            }
+        }
+        // Check if any version specific tags were found.
+        // If true, then return the version specific tags,
+        // or else return the version independent tags.
+        if !versionSpecificKnownVersions.isEmpty {
+            return versionSpecificKnownVersions
+        } else {
+            return knownVersions
+        }
+    }
+
     /// A shell command to run for Git. Can be either a name or a path.
     ///  - Note: modification is not thread safe, designed for testing only
     public static var tool: String = "git\(executableFileSuffix)"
@@ -26,55 +70,20 @@ public enum Git {
         }
     }
 
-    private static var _gitEnvironment = ProcessEnv.block
-
-    @available(*,
-        deprecated,
-        renamed: "environmentBlock",
-        message: "Previous `[String: String]` representation did not account for case insensitivity on Windows."
-    )
-    public static var environment: [String: String] {
-        get {
-            var env = Self._gitEnvironment
-
-            // These variables are inserted into the environment when shelling out
-            // to git if not already present.
-            let underrideVariables: ProcessEnvironmentBlock =  [
-                // Disable terminal prompts in git. This will make git error out and return
-                // when it needs a user/pass etc instead of hanging the terminal (SR-3981).
-                "GIT_TERMINAL_PROMPT": "0",
-
-                // The above is env variable is not enough. However, ssh_config's batch
-                // mode is made for this purpose. see: https://linux.die.net/man/5/ssh_config
-                "GIT_SSH_COMMAND": "ssh -oBatchMode=yes",
-            ]
-
-            for (key, value) in underrideVariables {
-                // Skip this key is already present in the env.
-                if env.keys.contains(key) { continue }
-
-                env[key] = value
-            }
-
-            return Dictionary(env.map { ($0.value, $1) }, uniquingKeysWith: { $1 })
-        }
-        set {
-            Self._gitEnvironment = .init(newValue)
-        }
-    }
+    private static var _gitEnvironment = ProcessInfo.processInfo.environment
 
     /// Returns the environment variables for launching the git subprocess.
     ///
     /// This contains the current environment with custom overrides for using
     /// git from swift build.
     ///  - Note: modification is not thread safe, designed for testing only
-    public static var environmentBlock: ProcessEnvironmentBlock {
+    public static var environment: [String: String] {
         get {
             var env = Self._gitEnvironment
 
             // These variables are inserted into the environment when shelling out
             // to git if not already present.
-            let underrideVariables: ProcessEnvironmentBlock =  [
+            let underrideVariables =  [
                 // Disable terminal prompts in git. This will make git error out and return
                 // when it needs a user/pass etc instead of hanging the terminal (SR-3981).
                 "GIT_TERMINAL_PROMPT": "0",


### PR DESCRIPTION
Reverts apple/swift-tools-support-core#470

https://ci.swift.org/job/oss-swift-package-amazon-linux-2/2845/console started failing with the following error. 

```
multiprocessing.pool.MaybeEncodingError: Error sending result: '<lit.Test.Test object at 0x7fd526e8be10>'. Reason: 'OverflowError('cannot serialize a string larger than 4GiB')'
```

PRs since the last successful run were: 
- https://github.com/apple/swift/pull/71814
- https://github.com/apple/swift/pull/71846
- https://github.com/apple/swift/pull/71293
- https://github.com/apple/swift-tools-support-core/pull/470

Let’s see if reverting this one fixes the issue.