### PR TITLE
Remove redundant Sendable conformance

### DIFF
--- a/Sources/TSCBasic/Process/ProcessEnv.swift
+++ b/Sources/TSCBasic/Process/ProcessEnv.swift
@@ -68,8 +68,6 @@ extension ProcessEnvironmentBlock {
   }
 }
 
-extension ProcessEnvironmentBlock: Sendable {}
-
 /// Provides functionality related a process's environment.
 public enum ProcessEnv {
 


### PR DESCRIPTION
ProcessEnvironmentBlock is a typealias to Dictionary, which is already Sendable when the key and value is Sendable.