### PR TITLE
[windows] fix trailing backslash string quoting

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
       windows_swift_versions: '["nightly-main"]'
       windows_build_command: 'Invoke-Program swift build'
       enable_android_sdk_build: true
-      android_sdk_build_command: "swift build --build-tests"
+      android_sdk_build_command: "swift build --build-tests --build-system native"
       android_ndk_versions: '["r27d", "r29"]'
       enable_ios_checks: true
       enable_macos_checks: true

--- a/Sources/TSCBasic/StringConversions.swift
+++ b/Sources/TSCBasic/StringConversions.swift
@@ -50,36 +50,53 @@ extension String {
     public func spm_shellEscaped() -> String {
 
         // If all the characters in the string are in the allow list then no need to escape.
-        guard let pos = utf8.firstIndex(where: { !inShellAllowlist($0) }) else {
+        guard utf8.contains(where: { !inShellAllowlist($0) }) else {
             return self
         }
 
-      #if os(Windows)
-        let quoteCharacter: Character = "\""
-        let escapedQuoteCharacter = "\"\""
-      #else
-        let quoteCharacter: Character = "'"
-        let escapedQuoteCharacter = "'\\''"
-      #endif
-        // If there are no quote characters then we can just wrap the string within the quotes.
-        guard let quotePos = utf8[pos...].firstIndex(of: quoteCharacter.asciiValue!) else {
-            return String(quoteCharacter) + self + String(quoteCharacter)
-        }
-
-        // Otherwise iterate and escape all the single quotes.
-        var newString = String(quoteCharacter) + String(self[..<quotePos])
-
-        for char in self[quotePos...] {
-            if char == quoteCharacter {
-                newString += escapedQuoteCharacter
-            } else {
-                newString += String(char)
+        #if os(Windows)
+            var quoted = "\""
+            var unquoted = self.unicodeScalars
+            while !unquoted.isEmpty {
+                guard let firstNonBackslash = unquoted.firstIndex(where: { $0 != "\\" }) else {
+                    let backslashCount = unquoted.count
+                    quoted.append(String(repeating: "\\", count: backslashCount * 2))
+                    break
+                }
+                let backslashCount = unquoted.distance(
+                    from: unquoted.startIndex, to: firstNonBackslash)
+                if unquoted[firstNonBackslash] == "\"" {
+                    quoted.append(String(repeating: "\\", count: backslashCount * 2 + 1))
+                } else {
+                    quoted.append(String(repeating: "\\", count: backslashCount))
+                }
+                quoted.append(String(unquoted[firstNonBackslash]))
+                unquoted.removeFirst(backslashCount + 1)
             }
-        }
+            quoted.append("\"")
+            return quoted
+        #else
+            let quoteCharacter: Character = "'"
+            let escapedQuoteCharacter = "'\\''"
+            // If there are no quote characters then we can just wrap the string within the quotes.
+            guard let quotePos = utf8.firstIndex(of: quoteCharacter.asciiValue!) else {
+                return String(quoteCharacter) + self + String(quoteCharacter)
+            }
 
-        newString += String(quoteCharacter)
+            // Otherwise iterate and escape all the single quotes.
+            var newString = String(quoteCharacter) + String(self[..<quotePos])
 
-        return newString
+            for char in self[quotePos...] {
+                if char == quoteCharacter {
+                    newString += escapedQuoteCharacter
+                } else {
+                    newString += String(char)
+                }
+            }
+
+            newString += String(quoteCharacter)
+            return newString
+        #endif
     }
 
     /// Shell escapes the current string. This method is mutating version of shellEscaped().

--- a/Tests/TSCBasicTests/StringConversionsTests.swift
+++ b/Tests/TSCBasicTests/StringConversionsTests.swift
@@ -36,6 +36,21 @@ class StringConversionTests: XCTestCase {
 
         str = "hello\nA\"B C>D*[$;()^><"
         XCTAssertEqual("'hello\nA\"B C>D*[$;()^><'", str.spm_shellEscaped())
+
+        #if os(Windows)
+        // Trailing backslash must be doubled so the closing quote is not escaped.
+        str = "hello world\\"
+        XCTAssertEqual("\"hello world\\\\\"", str.spm_shellEscaped())
+
+        // Embedded double-quote is escaped with a backslash.
+        str = "hello\"world"
+        XCTAssertEqual("\"hello\\\"world\"", str.spm_shellEscaped())
+
+        // Backslash immediately before an embedded double-quote: the backslash is doubled,
+        // then the quote is escaped with another backslash.
+        str = "hello\\\"world"
+        XCTAssertEqual("\"hello\\\\\\\"world\"", str.spm_shellEscaped())
+        #endif
     }
 
     func testLocalizedJoin() {


### PR DESCRIPTION
This patch fixes incorrectly quoting a string with a trailing slash on Windows. The fix is to double the amount of trailing slashes, which are then correctly converted back to the original number in argv.

From the [Microsoft documentation](https://learn.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments?view=msvc-170):
_If an odd number of backslashes is followed by a double quote mark, then one backslash (\) is placed in the argv array for every pair of backslashes (\\). The double quote mark is interpreted as an escape sequence by the remaining backslash, causing a literal double quote mark (") to be placed in argv._

This fixes https://github.com/swiftlang/swift/issues/88387.