### PR TITLE
Patch `Expression implicitly coerced from 'String?' to 'Any'` in FileSystem.swift

### DIFF
--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -92,7 +92,7 @@ public struct FileSystemError: Error, Sendable {
 
 extension FileSystemError: CustomNSError {
     public var errorUserInfo: [String : Any] {
-        return [NSLocalizedDescriptionKey: self.localizedMessage]
+        return [NSLocalizedDescriptionKey: self.localizedMessage ?? "Could not find '\(String(describing: self.path))'"]
     }
 }
 

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -92,7 +92,15 @@ public struct FileSystemError: Error, Sendable {
 
 extension FileSystemError: CustomNSError {
     public var errorUserInfo: [String : Any] {
-        return [NSLocalizedDescriptionKey: self.localizedMessage ?? "Could not find '\(String(describing: self.path))'"]
+        guard let localizedMessage = self.localizedMessage else {
+            guard let path = self.path?.pathString else {
+                return [NSLocalizedDescriptionKey: "File system error: \(self)"]
+            }
+
+            return [NSLocalizedDescriptionKey: "Could not find '\(path)'"]
+        }
+
+        return [NSLocalizedDescriptionKey: localizedMessage]
     }
 }
 

--- a/Sources/TSCBasic/FileSystem.swift
+++ b/Sources/TSCBasic/FileSystem.swift
@@ -92,15 +92,7 @@ public struct FileSystemError: Error, Sendable {
 
 extension FileSystemError: CustomNSError {
     public var errorUserInfo: [String : Any] {
-        guard let localizedMessage = self.localizedMessage else {
-            guard let path = self.path?.pathString else {
-                return [NSLocalizedDescriptionKey: "File system error: \(self)"]
-            }
-
-            return [NSLocalizedDescriptionKey: "Could not find '\(path)'"]
-        }
-
-        return [NSLocalizedDescriptionKey: localizedMessage]
+        return [NSLocalizedDescriptionKey: localizedMessage ?? "\(self)"]
     }
 }
 


### PR DESCRIPTION
If `self.localizedMessage` is missing, it could cause problems up the stack if a `String` is expected, and `nil` is returned.